### PR TITLE
db: initialise BIGNUM pointers to NULL

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -175,7 +175,7 @@ static bool parse_attrs(const char *key, const char *value, size_t index, void *
     /* base10 encoded big integers */
     case CKA_PUBLIC_EXPONENT: {
 
-        BIGNUM *bn;
+        BIGNUM *bn = NULL;
         rc = BN_dec2bn(&bn, value);
         if (!rc) {
             LOGE("Could not convert key \"%s\" value \"%s\" to big integer",
@@ -188,7 +188,7 @@ static bool parse_attrs(const char *key, const char *value, size_t index, void *
     /* base16 encoded big integers */
     case CKA_MODULUS: {
 
-        BIGNUM *bn;
+        BIGNUM *bn = NULL;
         rc = BN_hex2bn(&bn, value);
         if (!rc) {
             LOGE("Could not convert key \"%s\" value \"%s\" to big integer",


### PR DESCRIPTION
Very interesting project! I will play around with it a bit once I find the time. For now, here is a pull request to enable a successful build on my system: the BIGNUM pointers in [src/lib/db.c](https://github.com/tpm2-software/tpm2-pkcs11/blob/master/src/lib/db.c) need to be initialised as null pointers, otherwise the integration tests (and possibly the library itself as well, I have not checked) just fail with a segfault. This seems to be in line with the [OpenSSL documentation](https://www.openssl.org/docs/man1.1.0/crypto/BN_bn2bin.html):

> int BN_hex2bn(BIGNUM **a, const char *str) [...] takes [...] characters [...] from the string str, [...] converts them to a BIGNUM and stores it in **a. If *a is NULL, a new BIGNUM is created.