### PR TITLE
Ensure Python 3 compatibility of tpm2_ptool

### DIFF
--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -333,7 +333,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(token))
         sql = 'INSERT INTO tokens ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, token.values())
+        c.execute(sql, list(token.values()))
 
         return c.lastrowid
 
@@ -360,7 +360,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(sealobjects))
         sql = 'INSERT INTO sealobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, sealobjects.values())
+        c.execute(sql, list(sealobjects.values()))
 
         return c.lastrowid
 
@@ -381,7 +381,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(pobject))
         sql = 'INSERT INTO pobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, pobject.values())
+        c.execute(sql, list(pobject.values()))
 
         return c.lastrowid
 
@@ -398,7 +398,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(sobject))
         sql = 'INSERT INTO sobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, sobject.values())
+        c.execute(sql, list(sobject.values()))
         return  c.lastrowid
 
     def addwrapping(self, tokid, priv, pub):
@@ -413,7 +413,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(wrapping))
         sql = 'INSERT INTO wrappingobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, wrapping.values())
+        c.execute(sql, list(wrapping.values()))
         return  c.lastrowid
 
     def addtertiary(self, sid, priv, pub, objauth, attrs, mech):
@@ -430,7 +430,7 @@ class Db(object):
         placeholders = ', '.join('?' * len(sobject))
         sql = 'INSERT INTO tobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, sobject.values())
+        c.execute(sql, list(sobject.values()))
         return  c.lastrowid
 
     def commit(self):

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -1161,7 +1161,7 @@ def main():
     commandlets = commandlet.get()
 
     # for each commandlet, instantiate and set up their options
-    for n, c in commandlets.iteritems():
+    for n, c in commandlets.items():
         p = subparser.add_parser(n, help=c.__doc__)
         p.set_defaults(which=n)
         # Instantiate

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import binascii
 import copy
@@ -624,7 +626,7 @@ class InitCommand(Command):
 
                     pid = db.addprimary(handle, pobjauth, pobjkey['salt'], pobjkey['iters'])
 
-                    print "Created a primary object of id: %d" % pid
+                    print("Created a primary object of id: %d" % pid)
 
                 except Exception as e:
                     if handle != None:
@@ -821,7 +823,7 @@ class AddTokenCommand(Command):
 
                 db.commit()
 
-        print "Created token: %s" % label
+        print("Created token: %s" % label)
 
 @commandlet("addkey")
 class AddKeyCommand(Command):
@@ -989,7 +991,7 @@ class AddKeyCommand(Command):
 
                 db.commit()
 
-                print "Added key: %d" % (tokid)
+                print("Added key: %d" % (tokid))
 
 @commandlet("rmtoken")
 class RmTokenCommand(Command):
@@ -1056,7 +1058,7 @@ class VerifyCommand(Command):
         userpin = args['userpin']
         path = args['path']
 
-        print 'Verifying label: "%s"' % label
+        print('Verifying label: "%s"' % label)
 
         pobj = db.getprimary(token['pid'])
         sealobj = db.getsealobject(token['id'])
@@ -1093,7 +1095,7 @@ class VerifyCommand(Command):
                 wrappingkeyauth = tpm2.unseal(sosealctx, sosealauth['hash'])
                 pobjauth = sopobjauth
 
-                print "SO pin valid!"
+                print("SO pin valid!")
 
             if userpin != None:
                 # load the seal object under the primary object using the AES/GCM software protected
@@ -1119,7 +1121,7 @@ class VerifyCommand(Command):
                 wrappingkeyauth = tpm2.unseal(usersealctx, usersealauth['hash'])
                 pobjauth = userpobjauth
 
-                print "USER pin valid!"
+                print("USER pin valid!")
 
 
             wrappingkeyctx = tpm2.load(pobj['handle'], pobjauth, wrappingkey['priv'], wrappingkey['pub'])
@@ -1131,7 +1133,7 @@ class VerifyCommand(Command):
             sobjauth = binascii.unhexlify(sobj['objauth'])
             sobjauth = tpm2.decrypt(wrappingkeyctx, wrappingkeyauth, sobjauth)
 
-            print "Secondary object verified(%d), auth: %s" % (sobj['id'], sobjauth)
+            print("Secondary object verified(%d), auth: %s" % (sobj['id'], sobjauth))
 
             tobjs = db.gettertiary(token['id'])
 
@@ -1139,7 +1141,7 @@ class VerifyCommand(Command):
                 tobjctx = tpm2.load(sobjctx, sobjauth, tobj['priv'], tobj['pub'])
                 tobjauth = binascii.unhexlify(tobj['objauth'])
                 tobjauth = tpm2._encryptdecrypt(wrappingkeyctx, wrappingkeyauth, tobjauth, decrypt=True)
-                print "Tertiary object verified(%d), auth: %s" % (tobj['id'], tobjauth)
+                print("Tertiary object verified(%d), auth: %s" % (tobj['id'], tobjauth))
 
     def __call__(self, args):
         if args['userpin'] == None and args['sopin'] == None:


### PR DESCRIPTION
This pull requests makes [tpm2_ptool](https://github.com/tpm2-software/tpm2-pkcs11/blob/master/tools/tpm2_ptool.py) compatible with Python 3, while retaining Python 2 compatibility. The necessary changes are in separate commits for easier review:

1. Use `print` as a function instead of as a statement, available as a [future statement](https://docs.python.org/2/library/__future__.html) in Python 2.
2. Use [`dict.items()`](https://docs.python.org/2/library/stdtypes.html#dict.items) instead of [`dict.iteritems()`](https://docs.python.org/2/library/stdtypes.html#dict.iteritems) because the latter has been removed from Python 3, while the former works in both versions.
3. Cast `dict.values()` to a list because Python 3 returns a [view](https://docs.python.org/3/library/stdtypes.html#dict.values) instead of a [list](https://docs.python.org/2/library/stdtypes.html#dict.values) like Python 2. This is redundant in Python 2, but works fine.
4. Distinguish between normal strings ([`str`](https://docs.python.org/3/library/stdtypes.html#str)) and byte strings ([`bytes`](https://docs.python.org/3/library/stdtypes.html#bytes)) and convert between them using [`str.encode()`](https://docs.python.org/3/library/stdtypes.html#str.encode) and [`bytes.decode()`](https://docs.python.org/3/library/stdtypes.html#bytes.decode). In Python 2, there is only `str` and encoding/decoding is therefore redundant (but works).