### PR TITLE
Collection of small fixes for tpm2_ptool

### DIFF
--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -172,7 +172,7 @@ class Tpm2(object):
         stdout, stderr = p.communicate()
         rc = p.wait()
         if rc:
-            raise RuntimeError("Could not execute tpm2_load: %s", stderr)
+            raise RuntimeError("Could not execute tpm2_unseal: %s", stderr)
         return stdout
 
     def _encryptdecrypt(self, ctx, auth, data, decrypt=False):
@@ -186,7 +186,7 @@ class Tpm2(object):
         stdout, stderr = p.communicate(input=data)
         rc = p.wait()
         if rc:
-            raise RuntimeError("Could not execute tpm2_load: %s", stderr)
+            raise RuntimeError("Could not execute tpm2_encryptdecrypt: %s", stderr)
         return stdout
 
     def encrypt(self, ctx, auth, data):

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -198,7 +198,7 @@ class Tpm2(object):
     def _move(self, path):
         b = os.path.basename(path)
         n = os.path.join(self._final, b)
-        os.rename(path, n)
+        shutil.move(path, n)
         return n
 
     def create(self, phandle, pauth, objauth, objattrs=None, seal=None, alg=None):

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -786,7 +786,7 @@ class AddTokenCommand(Command):
                                                     sosealauth['hash'], seal=wrappingobjauth['hash'])
 
                 # Now we create the wrappingbject, with algorithm aes256
-                wrappingobjpriv, wrappingobjpub, wrappingobjpubdata = tpm2.create(pobject['handle'], pobjauthhash, wrappingobjauth['hash'], alg='aes256cfb')
+                wrappingobjpriv, wrappingobjpub, wrappingobjpubdata = tpm2.create(pobject['handle'], pobjauthhash, wrappingobjauth['hash'], alg='aes128cfb')
 
                 # Now we need to protect the primaryobject auth in a way where SO and USER can access the value.
                 # When a "pkcs11" admin generates a token, they give the auth value to SO and USER.
@@ -807,7 +807,7 @@ class AddTokenCommand(Command):
                 encsobjauth = binascii.hexlify(encsobjauth)
 
                 objattrs="restricted|decrypt|fixedtpm|fixedparent|sensitivedataorigin|userwithauth"
-                sobjpriv, sobjpub, sobjpubdata = tpm2.create(pobject['handle'], pobjauthhash, sobjauth, objattrs=objattrs, alg='aes256')
+                sobjpriv, sobjpub, sobjpubdata = tpm2.create(pobject['handle'], pobjauthhash, sobjauth, objattrs=objattrs, alg='aes128')
 
                 # If this succeeds, we update the token table
                 tokid = db.addtoken(pobject['id'], label, sopobjkey, sopobjauth, userpobjkey, userpobjauth)


### PR DESCRIPTION
This collection of commits contains some small fixes to correct two error messages, move files instead of renaming them (so it works when copying to another filesystem/mount) and defaulting to AES128 (see also https://github.com/tpm2-software/tpm2-tools/pull/1167 :wink:) as AES256 doesn't seem to be supported everywhere.