### PR TITLE
env: copy TPM2_PKCS11_TCTI rather then modifying it

### DIFF
--- a/src/lib/tcti_ldr.c
+++ b/src/lib/tcti_ldr.c
@@ -174,6 +174,10 @@ tcti_conf tcti_get_config(void) {
         return conf;
     }
 
+    static char buf[1024];
+    snprintf(buf, sizeof(buf), "%s", optstr);
+    optstr = buf;
+
     char *split = strchr(optstr, ':');
     if (!split) {
         /* --tcti=device */


### PR DESCRIPTION
The env variable TPM2_PKCS11_TCTI was being modified in place
causing subsequent library loads within the same applications
to fail, as the env string is modified. Copy it into a static
buffer.

Fixes: #26

Signed-off-by: William Roberts <william.c.roberts@intel.com>