### PR TITLE
fix null pointer dereference in session_table.c

### DIFF
--- a/src/lib/session_table.c
+++ b/src/lib/session_table.c
@@ -26,7 +26,7 @@ CK_RV session_table_new(session_table **t) {
         return CKR_HOST_MEMORY;
     }
 
-    CK_RV rv = mutex_create(x->lock);
+    CK_RV rv = mutex_create(&x->lock);
     if (rv != CKR_OK) {
         session_table_free(x);
         return rv;


### PR DESCRIPTION
x is calloced a few lines before, so the pointer to ->lock has the value
0 which equals NULL on most systems.
If mutex_create then wants to store the new calloced pthread_mutex_t in
*(x->lock) we get a NULL pointer dereference :/

--> pass the address of x->lock to mutex_create to get the desired
behavior

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>