### PR TITLE
Apply correct padding

### DIFF
--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -71,6 +71,9 @@ CK_RV slot_get_list (unsigned char token_present, CK_SLOT_ID *slot_list, unsigne
 }
 
 CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
+    const unsigned char manufacturerID[] = "foo";
+    const unsigned char slotDescription[] = "bar";
+
 
     check_pointer(info);
     check_slot_id(slot_id);
@@ -84,8 +87,8 @@ CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
     info->hardwareVersion.major =
     info->hardwareVersion.minor = 42;
 
-    snprintf((char *)info->manufacturerID, sizeof(info->manufacturerID), " %s", "foo");
-    snprintf((char *)info->slotDescription, sizeof(info->slotDescription), " %s", "bar");
+    str_padded_copy(info->manufacturerID, manufacturerID, sizeof(info->manufacturerID));
+    str_padded_copy(info->slotDescription, slotDescription, sizeof(info->slotDescription));
 
     info->flags = CKF_TOKEN_PRESENT | CKF_HW_SLOT;
 

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -29,7 +29,7 @@ static inline int min(size_t a, size_t b) {
 }
 
 static inline void str_padded_copy(unsigned char * dst, const unsigned char * src, size_t dst_len) {
-    memset(dst, ' ', dst_len - 1);
+    memset(dst, ' ', dst_len);
     memcpy(dst, src, min(strlen((char *)(src)), dst_len));
 }
 


### PR DESCRIPTION
Most of the PKCS#11 strings MUST NOT be NULL terminated and MUST be padded with ' '.
This patchset fixes a few places 

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>