### PR TITLE
license: fix duplicate SPDX identifiers

### DIFF
--- a/test/integration/pkcs-find-objects.int.c
+++ b/test/integration/pkcs-find-objects.int.c
@@ -3,12 +3,7 @@
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  */
-/* SPDX-License-Identifier: BSD-2 */
-/***********************************************************************
- * Copyright (c) 2017-2018, Intel Corporation
- *
- * All rights reserved.
- ***********************************************************************/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -4,12 +4,7 @@
  * All rights reserved.
  */
 /* SPDX-License-Identifier: BSD-2 */
-/***********************************************************************
- * Copyright (c) 2017-2018, Intel Corporation
- *
- * All rights reserved.
- ***********************************************************************/
-#include <stdio.h>
+
 #include <stdlib.h>
 #include <string.h>
 #include <sqlite3.h>

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -3,12 +3,7 @@
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  */
-/* SPDX-License-Identifier: BSD-2 */
-/***********************************************************************
- * Copyright (c) 2017-2018, Intel Corporation
- *
- * All rights reserved.
- ***********************************************************************/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/integration/pkcs-open-close-session.int.c
+++ b/test/integration/pkcs-open-close-session.int.c
@@ -3,12 +3,7 @@
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  */
-/* SPDX-License-Identifier: BSD-2 */
-/***********************************************************************
- * Copyright (c) 2017-2018, Intel Corporation
- *
- * All rights reserved.
- ***********************************************************************/
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Corrects duplicate SPDX identifiers and incorect copyright dates.

Fixes: #42

Signed-off-by: William Roberts <william.c.roberts@intel.com>