### PR TITLE
add support for key labels and empty template find object calls

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -232,6 +232,16 @@ static bool parse_attrs(const char *key, const char *value, size_t index, void *
             return false;
         }
     } break;
+
+    case CKA_LABEL: {
+
+        a->ulValueLen = strlen(value);
+        a->pValue = strdup(value);
+        if (!a->pValue) {
+            LOGE("oom");
+            return false;
+        }
+    } break;
     default:
         LOGE("Unknown key, got: \"%s\"", key);
         return false;

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -74,6 +74,11 @@ void sealobject_free(sealobject *sealobj) {
 tobject *object_attr_filter(tobject *tobj, CK_ATTRIBUTE_PTR templ, unsigned long count) {
 
     unsigned long i;
+    // If ulCount is set to 0 all items match automatically.
+    if (count == 0) {
+	    return tobj;
+    }
+
     for (i=0; i < count; i++) {
         CK_ATTRIBUTE_PTR search = &templ[i];
 
@@ -136,10 +141,12 @@ void free_object_find_data(object_find_data *fd) {
 }
 
 CK_RV object_find_init(CK_SESSION_HANDLE session, CK_ATTRIBUTE_PTR templ, unsigned long count) {
-
     check_is_init();
-    check_pointer(templ);
-    check_num(count);
+
+    // if count is 0 template is not used and all objects are requested so templ can be NULL.
+    if (count > 0) {
+        check_pointer(templ);
+    }
 
     CK_RV rv = CKR_GENERAL_ERROR;
 

--- a/test/integration/pkcs-find-objects.int.c
+++ b/test/integration/pkcs-find-objects.int.c
@@ -187,6 +187,39 @@ static void test_find_objects_by_label(CK_SESSION_HANDLE hSession) {
     LOGV("\"%s\" Test Passed!", __func__);
 }
 
+static void test_find_objects_via_empty_template(CK_SESSION_HANDLE hSession) {
+
+    CK_RV rv = C_FindObjectsInit(hSession, NULL, 0);
+    if(rv != CKR_OK){
+        LOGE("C_FindObjectsInit failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    /*
+     * There are 4 keys in the test db with
+     */
+    unsigned long count;
+    CK_OBJECT_HANDLE objhandles[6];
+    rv = C_FindObjects(hSession, objhandles, ARRAY_LEN(objhandles), &count);
+    if(rv != CKR_OK){
+        LOGE("C_FindObjects failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    if(count != 4){
+        LOGE("C_FindObjects failed! Expected count=1, Actual count=%d", count);
+        exit(1);
+    }
+
+    rv = C_FindObjectsFinal(hSession);
+    if(rv != CKR_OK){
+        LOGE("C_FindObjectsFinal failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    LOGV("\"%s\" Test Passed!", __func__);
+}
+
 int test_invoke() {
 
     CK_RV rv = C_Initialize(NULL);
@@ -214,6 +247,7 @@ int test_invoke() {
     test_find_objects_aes_good(handle);
     test_sign_verify_CKM_RSA_PKCS(handle);
     test_find_objects_by_label(handle);
+    test_find_objects_via_empty_template(handle);
 
     rv = C_CloseSession(handle);
     if (rv == CKR_OK)

--- a/test/integration/pkcs-find-objects.int.c
+++ b/test/integration/pkcs-find-objects.int.c
@@ -149,6 +149,44 @@ static void test_find_objects_aes_good(CK_SESSION_HANDLE hSession) {
     LOGV("test_find_objects_aes_good Test Passed!");
 }
 
+static void test_find_objects_by_label(CK_SESSION_HANDLE hSession) {
+
+    char key_label[] = "mykeylabel";
+    CK_ATTRIBUTE tmpl[] = {
+      {CKA_LABEL, key_label, sizeof(key_label) - 1},
+    };
+
+    CK_RV rv = C_FindObjectsInit(hSession, tmpl, ARRAY_LEN(tmpl));
+    if(rv != CKR_OK){
+        LOGE("C_FindObjectsInit failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    /*
+     * There is only one key in the test db with the label "mykeylabel"
+     */
+    unsigned long count;
+    CK_OBJECT_HANDLE objhandles[1];
+    rv = C_FindObjects(hSession, objhandles, ARRAY_LEN(objhandles), &count);
+    if(rv != CKR_OK){
+        LOGE("C_FindObjects failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    if(count != 1){
+        LOGE("C_FindObjects failed! Expected count=1, Actual count=%d", count);
+        exit(1);
+    }
+
+    rv = C_FindObjectsFinal(hSession);
+    if(rv != CKR_OK){
+        LOGE("C_FindObjectsFinal failed! Response Code %x", rv);
+        exit(1);
+    }
+
+    LOGV("\"%s\" Test Passed!", __func__);
+}
+
 int test_invoke() {
 
     CK_RV rv = C_Initialize(NULL);
@@ -175,6 +213,7 @@ int test_invoke() {
 
     test_find_objects_aes_good(handle);
     test_sign_verify_CKM_RSA_PKCS(handle);
+    test_find_objects_by_label(handle);
 
     rv = C_CloseSession(handle);
     if (rv == CKR_OK)

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -69,9 +69,8 @@ tpm2_ptool.py addtoken --pid=2 --pobj-pin=anotherpobjpin --sopin=anothersopin --
 # add 2 aes and 2 rsa keys under tokens 1 and 2
 for t in "label" "wrap-sw"; do
 	echo "Adding 2 AES 256 keys under token \"$t\""
-	for i in `seq 0 1`; do
-	  tpm2_ptool.py addkey --algorithm=aes256 --label="$t" --userpin=myuserpin --path=$TPM2_PKCS11_STORE
-	done;
+	tpm2_ptool.py addkey --algorithm=aes256 --label="$t" --userpin=myuserpin --path=$TPM2_PKCS11_STORE
+	tpm2_ptool.py addkey --algorithm=aes256 --label="$t" --key-label=mykeylabel --userpin=myuserpin --path=$TPM2_PKCS11_STORE
 	echo "Added AES Keys"
 
 	echo "Adding 2 RSA 2048 keys under token \"$t\""

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -440,7 +440,7 @@ class Db(object):
         return  c.lastrowid
 
     def addtertiary(self, sid, priv, pub, objauth, attrs, mech):
-        sobject = {
+        tobject = {
             'sid'          : sid,
             'pub'          : pub,
             'priv'         : priv,
@@ -449,11 +449,11 @@ class Db(object):
             'mech'         : list_dict_to_kvp(mech),
         }
 
-        columns = ', '.join(sobject.keys())
-        placeholders = ', '.join('?' * len(sobject))
+        columns = ', '.join(tobject.keys())
+        placeholders = ', '.join('?' * len(tobject))
         sql = 'INSERT INTO tobjects ({}) VALUES ({})'.format(columns, placeholders)
         c = self._conn.cursor()
-        c.execute(sql, list(sobject.values()))
+        c.execute(sql, list(tobject.values()))
         return  c.lastrowid
 
     def commit(self):


### PR DESCRIPTION
Peter Huewe (1):
      C_FindObjectsInit: Return all objects if ulCount is 0

William Roberts (2):
      tpm2_ptool.py: fix addtertiary variable name
      db: add support for key labels
