### PR TITLE
C_GetAttributeInfo: fix deadlock

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -367,7 +367,8 @@ CK_RV object_get_attributes(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, 
 
             /* buffer allocated, the size should be right */
             if (found->ulValueLen != t->ulValueLen) {
-                return CKR_BUFFER_TOO_SMALL;
+                rv = CKR_BUFFER_TOO_SMALL;
+                goto out;
             }
 
             memcpy(t->pValue, found->pValue, t->ulValueLen);


### PR DESCRIPTION
If a buffer is too small, it triggers an immediate return
without unlocking the session_ctx lock. Set the return
value in rv and goto out instead.

Signed-off-by: William Roberts <william.c.roberts@intel.com>