### PR TITLE
Fixes https://github.com/tpm2-software/tpm2-pkcs11/issues/5

### DIFF
--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -138,6 +138,13 @@ CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
     twist_free(tpin);
     session_ctx_unlock(ctx);
 
+    if (rv == CKR_OK) {
+        token *tok = session_ctx_get_token(ctx);
+        session_ctx_state state = session_ctx_state_get(ctx);
+
+        session_table_update_ctx_state(global.s_table, tok, state);
+    }
+
     return rv;
 }
 
@@ -153,6 +160,13 @@ CK_RV session_logout (CK_SESSION_HANDLE session) {
     CK_RV rv = session_ctx_logout(ctx);
 
     session_ctx_unlock(ctx);
+
+    if (rv == CKR_OK) {
+        token *tok = session_ctx_get_token(ctx);
+        session_ctx_state state = session_ctx_state_get(ctx);
+
+        session_table_update_ctx_state(global.s_table, tok, state);
+    }
 
     return rv;
 }

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -87,6 +87,10 @@ token *session_ctx_get_token(session_ctx *ctx) {
     return ctx->tok;
 }
 
+void session_ctx_state_set(session_ctx *ctx, session_ctx_state state) {
+    ctx->state = state;
+}
+
 session_ctx_state session_ctx_state_get(session_ctx *ctx) {
     return ctx->state;
 }

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -55,7 +55,9 @@ tpm_ctx *session_ctx_get_tpm_ctx(session_ctx *ctx);
 
 token *session_ctx_get_token(session_ctx *ctx);
 
+void session_ctx_state_set(session_ctx *ctx, session_ctx_state state);
 session_ctx_state session_ctx_state_get(session_ctx *ctx);
+
 
 static inline bool session_is_rw(session_ctx *ctx) {
 

--- a/src/lib/session_table.c
+++ b/src/lib/session_table.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  */
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "assert.h"
@@ -10,6 +11,7 @@
 #include "pkcs11.h"
 #include "session_ctx.h"
 #include "session_table.h"
+#include "token.h"
 #include "utils.h"
 
 struct session_table {
@@ -160,4 +162,20 @@ unlock:
     session_table_unlock(t);
 
     return ctx;
+}
+
+void session_table_update_ctx_state(session_table *t, token *tok, session_ctx_state state) {
+    session_table_lock(t);
+
+    unsigned i;
+    for (i=0; i < ARRAY_LEN(t->table); i++) {
+        CK_SESSION_HANDLE handle = i;
+        session_ctx *ctx = *session_table_lookup_unlocked(t, handle);
+
+        if (ctx && session_ctx_get_token(ctx) == tok) {
+            session_ctx_state_set(ctx, state);
+        }
+    }
+
+    session_table_unlock(t);
 }

--- a/src/lib/session_table.h
+++ b/src/lib/session_table.h
@@ -28,5 +28,6 @@ session_ctx *session_table_lookup(session_table *t, CK_SESSION_HANDLE handle);
 CK_RV session_table_free_ctx_unlocked(session_table *t, CK_SESSION_HANDLE handle);
 CK_RV session_table_free_ctx(session_table *t, CK_SESSION_HANDLE handle);
 void session_table_free_ctx_all(session_table *t);
+void session_table_update_ctx_state(session_table *t, token *tok, session_ctx_state state);
 
 #endif /* SRC_PKCS11_SESSION_TABLE_H_ */


### PR DESCRIPTION
Should fix the linked issue. I'm a little bit unsure about the locking semantics. I currently lock the session table to update all the session contexts, but it might be safer to lock the individual session contexts as well.