### PR TITLE
C_GetAttributeValue: fix attribute handling

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -365,13 +365,18 @@ CK_RV object_get_attributes(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, 
                 continue;
             }
 
-            /* buffer allocated, the size should be right */
-            if (found->ulValueLen != t->ulValueLen) {
+            /* The found attribute should fit inside the one to copy to */
+            if (found->ulValueLen > t->ulValueLen) {
                 rv = CKR_BUFFER_TOO_SMALL;
                 goto out;
             }
 
-            memcpy(t->pValue, found->pValue, t->ulValueLen);
+            t->ulValueLen = found->ulValueLen;
+            memcpy(t->pValue, found->pValue, found->ulValueLen);
+       } else {
+           /* If it's not found it defaults to empty. */
+           t->pValue = NULL;
+           t->ulValueLen = 0;
        }
     }
 


### PR DESCRIPTION
Fixes two cases when C_GetAttributeValue wasn't populating attributes
correctly.

The first case is when C_GetAttributeValue is called with a buffer bigger
than the actual attribute. The attributes length field needs to be set on
return so the caller knows the size. Previously the library assumed a caller
would always set the value pointer to NULL and populate all the size fields,
but this is NOT always the case.

The second case, is when C_GetAttributeValue fails to find data for an
attribute, that it shouldn't just skip it. It should set the size of
the attribute to 0 and the value pointer to NULL.

This patch also fixes the comparison for attribute buffer being too small.
It changes it from a not equal comparison to ensuring the found buffer is
less than or equal in size to the copy to attribute.

This issue was noticed when running:
  $ p11tool --list-all [url]

Signed-off-by: William Roberts <william.c.roberts@intel.com>