### PR TITLE
tpm2_ptool: fix bad kvp seperator in dict_from_kvp

### DIFF
--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -40,7 +40,7 @@ def list_dict_to_kvp(l):
     return x
 
 def dict_from_kvp(kvp):
-    return dict(x.split('=') for x in kvp.split(','))
+    return dict(x.split('=') for x in kvp.split('\n'))
 
 def rand_str(num):
     return binascii.hexlify(os.urandom(32))


### PR DESCRIPTION
Spliting the string on , is incorrect as the seperator is
a newline (\n). Update this in the split.

Signed-off-by: William Roberts <william.c.roberts@intel.com>