### PR TITLE
tpm2_ptool.py: add commandlet for emptytoken

### DIFF
--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -85,8 +85,11 @@ CK_RV token_get_info (CK_SLOT_ID slot_id, struct _CK_TOKEN_INFO *info) {
 
     // Support Flags
     info->flags = CKF_RNG
-        | CKF_LOGIN_REQUIRED
-        | CKF_TOKEN_INITIALIZED;
+        | CKF_LOGIN_REQUIRED;
+
+    if (t->config.is_initialized) {
+        info->flags |= CKF_TOKEN_INITIALIZED;
+    }
 
     // Identification
     str_padded_copy(info->label, t->label, sizeof(info->label));

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -38,6 +38,7 @@ struct token {
 
     struct {
         bool sym_support; /* use TPM for unwrapping if true else use software */
+        bool is_initialized; /* token initialization state */
     } config;
 
 };


### PR DESCRIPTION
The patch below is a partial step towards supporting the C_Initialize() call. However, we will be re-configuring the auth model soon to support a different way of authorizing objects and performing pin-change. So before we go write the supporting pkcs11 side of this, we want to update the db, as more updates will likely be ensuing right behind this patch.
----
Add a commandlet that allows the creation of an empty token. This token can
be initialized later via a call to C_InitToken().

Example:
p11tool --list-tokens

Token 5:
	URL: pkcs11:model=TPM2%20PKCS%2311;manufacturer=Intel;serial=0000000000000000;token=%28null%29
	Label: (null)
	Type: Hardware token
	Manufacturer: Intel
	Model: TPM2 PKCS#11
	Serial: 0000000000000000
	Module: libtpm2_pkcs11.so

Signed-off-by: William Roberts <william.c.roberts@intel.com>