### PR TITLE
Pass arguments as a list to cmd.extend

### DIFF
--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -152,7 +152,7 @@ class Tpm2(object):
         cmd = ['tpm2_evictcontrol', '-c', str(ctx) ]
 
         if ownerauth and len(ownerauth) > 0:
-            cmd.extend('-P', ownerauth)
+            cmd.extend(['-P', ownerauth])
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         stdout, stderr = p.communicate()


### PR DESCRIPTION
cmd.extend expects a list otherwise it will throw an exception.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>