### PR TITLE
tpm2_ptool.py: Python 3 compatibility

### DIFF
--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -688,7 +688,7 @@ class InitCommand(Command):
                     else:
                         # get the primary object auth value and convert it to hex
                         pobjauth = args['primary_auth'] if args['primary_auth'] != None else ""
-                        pobjauth = binascii.hexlify(pobjauth)
+                        pobjauth = binascii.hexlify(pobjauth.encode())
 
                         handle = args['primary_handle']
                         if handle == None:
@@ -887,7 +887,7 @@ class AddTokenCommand(Command):
             #
             print("auto-detecting TPM encryptdecrypt interface for wrapping key usage")
             commands = tpm2.getcap('commands')
-            sym_support = 'encryptdecrypt' in commands
+            sym_support = 'encryptdecrypt'.encode() in commands
 
             if args['wrap'] != 'auto':
                 if args['wrap'] == 'software' and sym_support:


### PR DESCRIPTION
Two small fixes to ensure Python 3 compatibility of `tpm2_ptool.py`, which slipped through https://github.com/tpm2-software/tpm2-pkcs11/pull/45 and https://github.com/tpm2-software/tpm2-pkcs11/pull/54. With these modifications, the test suite passes using Python 3.