### PR TITLE
pkcs11.h: structure packing: dont do it on linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,14 @@ AC_ARG_ENABLE([dlclose],
   [AC_DEFINE([DISABLE_DLCLOSE], [1])]
  )
 
+AC_ARG_ENABLE([pack],
+            [AS_HELP_STRING([--enable-pack=]@<:@yes/no@:>@,
+                            [Pack the structures. (default is no, except on Windows, where it defaults to packing)])],
+            [enable_pack=$enableval],
+            [enable_pack=no])
+AS_IF([test "x$enable_pack" = "xyes"],
+      [AC_DEFINE([PKCS11_PACK], [1])])
+
 AC_DEFUN([unit_test_checks],[
 
     PKG_CHECK_MODULES([CMOCKA],[cmocka],

--- a/src/pkcs11.h
+++ b/src/pkcs11.h
@@ -181,7 +181,19 @@ extern "C" {
  * #endif
  */
 
+/*
+ * If the user specified packing, use their request
+ * or detect if windows is present
+ */
+#if defined PKCS11_PACK
+#define DO_PACK PKCS11_PACK
+# elif defined(_WIN32)
+#define DO_PACK 1
+#endif
+
+#if DO_PACK > 0
 #pragma pack(push, 1)
+#endif
 
 #define CK_PTR *
 
@@ -277,7 +289,9 @@ struct CK_FUNCTION_LIST {
 }
 #endif
 
+#if DO_PACK > 0
 #pragma pack(pop)
+#endif
 
 #endif /* _PKCS11_H_ */
 


### PR DESCRIPTION
Despite section 2.1 of:
  - http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959683

Stating:
  Cryptoki structures are packed to occupy as little space as is possible.
  Cryptoki structures SHALL be packed with 1-byte alignment.

Linux seems to not pack the structures. On a 64 bit machine, for instance
C_Initialize in libp11-kit's pkcs11 header file is at offset 8, versus offset
2. The only thing in-front of the C_Initialize function pointer is 2 char
inline version structure.

Stop packing on Linux, detect Windows and allow a FORCE_PACK option via
configure --enable-force-pack.

Signed-off-by: William Roberts <william.c.roberts@intel.com>