### PR TITLE
session: track login/logout event at token scope

### DIFF
--- a/src/lib/mutex.c
+++ b/src/lib/mutex.c
@@ -101,6 +101,8 @@ static CK_RV default_mutex_destroy(void *mutex) {
         return CKR_MUTEX_BAD;
     }
 
+    free(p);
+
     return CKR_OK;
 }
 

--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -159,7 +159,8 @@ CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
 
     tpin = twistbin_new(pin, pin_len);
     if (!tpin) {
-        return CKR_HOST_MEMORY;
+        rv = CKR_HOST_MEMORY;
+        goto out;
     }
 
     // TODO Handle CKU_CONTEXT_SPECIFIC
@@ -178,6 +179,8 @@ CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
     }
 
     twist_free(tpin);
+
+out:
     session_ctx_unlock(ctx);
 
     return rv;

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -45,9 +45,9 @@ CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
 
 bool session_ctx_is_user_logged_in(session_ctx *ctx);
 
-CK_RV session_ctx_login(session_ctx *ctx, twist pin, CK_USER_TYPE user);
+CK_RV session_ctx_token_login(session_ctx *ctx, twist pin, CK_USER_TYPE user);
 
-CK_RV session_ctx_logout(session_ctx *ctx);
+CK_RV session_ctx_token_logout(session_ctx *ctx);
 
 CK_RV session_ctx_load_object(session_ctx *ctx, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -6,6 +6,7 @@
 #ifndef SRC_PKCS11_SESSION_CTX_H_
 #define SRC_PKCS11_SESSION_CTX_H_
 
+#include "mutex.h"
 #include "object.h"
 #include "pkcs11.h"
 #include "tpm.h"
@@ -29,8 +30,13 @@ typedef struct session_ctx session_ctx;
 void session_ctx_free(session_ctx *ctx);
 CK_RV session_ctx_new(session_ctx **ctx, token *tok, CK_FLAGS flags);
 
-void session_ctx_lock(session_ctx *ctx);
-void session_ctx_unlock(session_ctx *ctx);
+void *_session_ctx_get_lock(session_ctx *ctx);
+
+#define session_ctx_lock(ctx) \
+    mutex_lock_fatal(_session_ctx_get_lock(ctx))
+
+#define session_ctx_unlock(ctx) \
+    mutex_unlock_fatal(_session_ctx_get_lock(ctx))
 
 void session_ctx_opdata_set(session_ctx *ctx, operation op, void *opdata);
 void *session_ctx_opdata_get(session_ctx *ctx, operation op);
@@ -45,8 +51,42 @@ CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
 
 bool session_ctx_is_user_logged_in(session_ctx *ctx);
 
+/**
+ * Causes a login event to be propagated through the token
+ * associated with the session context. A login event is
+ * Propagated by:
+ *   1. setting the token level who is logged in state with whom is logged in.
+ *   2. updating all open session states in the session table
+ * @param ctx
+ *  The session context to update
+ * @param pin
+ *  The pin
+ * @param user
+ *  The user
+ * @return
+ *  CKR_OK on success, anything else is a failure.
+ * @note
+ *  Locking:
+ *    Callee expects caller to *TAKE* the session_ctx lock
+ *    Callee expects caller to *RELEASE* session ctx_lock
+ */
 CK_RV session_ctx_token_login(session_ctx *ctx, twist pin, CK_USER_TYPE user);
 
+/**
+ * Generates a logout event to be propagated through the token associated
+ * with the session context. A logout event is propagated by:
+ *   1. setting the token level who is logged in state to no one is logged in.
+ *   2. setting all existing sessions back to their original state.
+ *
+ * @param ctx
+ *  The context triggering the login event
+ * @return
+ *  CKR_OK on success, anything else is a failure.
+ * @note
+ *  Locking:
+ *    Callee expects caller to take the session_ctx lock.
+ *    Callee releases session_ctx_lock.
+ */
 CK_RV session_ctx_token_logout(session_ctx *ctx);
 
 CK_RV session_ctx_load_object(session_ctx *ctx, CK_OBJECT_HANDLE key, tobject **loaded_tobj);

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -16,6 +16,13 @@
 typedef struct session_table session_table;
 typedef struct session_ctx session_ctx;
 
+typedef enum token_login_state token_login_state;
+enum token_login_state {
+    token_no_one_logged_in = 0,
+    token_user_logged_in   = 1 << 0,
+    token_so_logged_in     = 1 << 1,
+};
+
 typedef struct token token;
 struct token {
 
@@ -46,6 +53,8 @@ struct token {
     } config;
 
     session_table *s_table;
+
+    token_login_state login_state;
 
     session_ctx *login_session_ctx;
 };

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -386,7 +386,18 @@ void test_user_login_logout_time_two(CK_SLOT_ID slotid) {
 
 int test_invoke() {
 
-    CK_RV rv = C_Initialize(NULL);
+    /*
+     * Run these tests with locking enabled
+     */
+    CK_C_INITIALIZE_ARGS args = {
+        .CreateMutex = NULL,
+        .DestroyMutex = NULL,
+        .LockMutex = NULL,
+        .UnlockMutex = NULL,
+        .flags = CKF_OS_LOCKING_OK
+    };
+
+    CK_RV rv = C_Initialize(&args);
     if (rv == CKR_OK)
 	LOGV("Initialize was successful");
     else


### PR DESCRIPTION
Login events need to be tracked at token scope in order
to set initial states of new sessions. Correct this
and add a test.

Fixes: #81

Signed-off-by: William Roberts <william.c.roberts@intel.com>