### PR TITLE
docs: instructions to rebuild twist.c when enabling unit tests

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -57,6 +57,11 @@ that *are outside of normal autoconf/automake options*, which are documented [he
 
 ### Configure Options
 1. `--enable-unit` - Enables the unit tests when running `make check`
+
+   **Note:** When enabling unit tests, it will be necessary to rebuild `src/lib/twist.c` if it was already built, e.g. by using
+   ```
+   make --assume-new src/lib/twist.c check
+   ```
 2. `--enable-integration` - Enables the integration tests when running `make check`
   * Requires the following items to be found on PATH:
     * [tpm2-ptool](../tools/tpm2_ptool.py)


### PR DESCRIPTION
As suggested in https://github.com/tpm2-software/tpm2-pkcs11/issues/63#issuecomment-435952810, this PR documents the need to rebuild [`src/lib/twist.c`](https://github.com/tpm2-software/tpm2-pkcs11/blob/master/src/lib/twist.c) when enabling unit tests.