### PR TITLE
Symmetric crypto fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,7 +94,9 @@ AM_TESTS_ENVIRONMENT = \
     PATH=./src:$(PATH)
 INT_LOG_COMPILER = $(srcdir)/test/integration/scripts/int-test-setup.sh
 
-TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(AM_LDFLAGS)
+TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(AM_LDFLAGS) $(CMOCKA_LIBS)
+
+TETS_CFLAGS = $(CMOCKA_CFLAGS)
 
 # Intentionally empty so INTEGRATION and UNIT tests can append to it.
 check_PROGRAMS =
@@ -110,7 +112,8 @@ check_PROGRAMS += \
     test/integration/pkcs-login-logout.int \
     test/integration/pkcs-sign-verify.int \
     test/integration/pkcs-initialize-finalize.int \
-    test/integration/pkcs-misc.int
+    test/integration/pkcs-misc.int \
+    test/integration/pkcs-crypt.int
 
 XFAIL_TESTS=test/unit/test_pkcs11
 
@@ -148,6 +151,11 @@ test_integration_pkcs_initialize_finalize_int_SOURCES = test/integration/pkcs-in
 test_integration_pkcs_misc_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_misc_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
 test_integration_pkcs_misc_int_SOURCES = test/integration/pkcs-misc.int.c \
+    test/integration/main-test.c test/integration/test.h
+
+test_integration_pkcs_crypt_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_pkcs_crypt_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+test_integration_pkcs_crypt_int_SOURCES = test/integration/pkcs-crypt.int.c \
     test/integration/main-test.c test/integration/test.h
 
 endif

--- a/src/lib/encrypt.c
+++ b/src/lib/encrypt.c
@@ -238,3 +238,24 @@ CK_RV decrypt_final (CK_SESSION_HANDLE session, unsigned char *last_part, unsign
 
     return common_final(operation_decrypt, session, last_part, last_part_len);
 }
+
+CK_RV decrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
+
+    CK_RV rv = decrypt_update(session, encrypted_data, encrypted_data_len,
+            data, data_len);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    return decrypt_final(session, NULL, NULL);
+}
+
+CK_RV encrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
+
+    CK_RV rv = encrypt_update(session, data, data_len, encrypted_data, encrypted_data_len);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    return encrypt_final(session, NULL, NULL);
+}

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -20,4 +20,8 @@ CK_RV decrypt_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned l
 
 CK_RV decrypt_final (CK_SESSION_HANDLE session, unsigned char *last_part, unsigned long *last_part_len);
 
+CK_RV decrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+
+CK_RV encrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
+
 #endif /* SRC_LIB_ENCRYPT_H_ */

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -201,11 +201,11 @@ CK_RV session_ctx_token_logout(session_ctx *ctx) {
                 bool result = tpm_flushcontext(tpm, tobj->handle);
                 assert(result);
                 UNUSED(result);
-
-                twist_free(tobj->objauth);
-                tobj->objauth = NULL;
-
                 tobj->handle = 0;
+
+                /* Clear the unwrapped auth value for tertiary objects */
+                twist_free(tobj->unsealed_auth);
+                tobj->unsealed_auth = NULL;
             }
         }
     }
@@ -225,9 +225,6 @@ CK_RV session_ctx_token_logout(session_ctx *ctx) {
     bool result = tpm_flushcontext(tpm, sobj->handle);
     assert(result);
     UNUSED(result);
-
-    twist_free(sobj->objauth);
-    sobj->objauth = NULL;
     sobj->handle = 0;
 
     // Kill primary object auth data

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -192,7 +192,7 @@ CK_RV C_EncryptInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJE
 
 CK_RV C_Encrypt (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
     TRACE_CALL;
-    TRACE_RET(CKR_FUNCTION_NOT_SUPPORTED);
+    TRACE_RET(encrypt_oneshot(session, data, data_len, encrypted_data, encrypted_data_len));
 }
 
 CK_RV C_EncryptUpdate (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
@@ -212,7 +212,7 @@ CK_RV C_DecryptInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJE
 
 CK_RV C_Decrypt (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
     TRACE_CALL;
-    TRACE_RET(CKR_FUNCTION_NOT_SUPPORTED);
+    TRACE_RET(decrypt_oneshot(session, encrypted_data, encrypted_data_len, data, data_len));
 }
 
 CK_RV C_DecryptUpdate (CK_SESSION_HANDLE session, unsigned char *encrypted_part, unsigned long encrypted_part_len, unsigned char *part, unsigned long *part_len) {

--- a/test/integration/pkcs-crypt.int.c
+++ b/test/integration/pkcs-crypt.int.c
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: BSD-2 */
+/***********************************************************************
+ * Copyright (c) 2018, Intel Corporation
+ *
+ * All rights reserved.
+ ***********************************************************************/
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <tss2/tss2_sys.h>
+
+#define LOGMODULE test
+#include "log.h"
+#include "pkcs11.h"
+#include "db.h"
+#include "test.h"
+
+typedef struct test_info test_info;
+struct test_info {
+    CK_SESSION_HANDLE handle;
+    CK_SLOT_ID slot;
+};
+
+static inline test_info *test_info_from_state(void **state) {
+    return (test_info *)*state;
+}
+
+static int test_setup(void **state) {
+
+    test_info *info = calloc(1, sizeof(*info));
+    assert_non_null(info);
+
+    /* Initialize the library */
+    CK_RV rv = C_Initialize(NULL);
+    assert_int_equal(rv, CKR_OK);
+
+    /* get the slots */
+    CK_SLOT_ID slots[6];
+    unsigned long count = ARRAY_LEN(slots);
+    rv = C_GetSlotList(true, slots, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 3);
+
+    /* open a session on slot 1 */
+    CK_SESSION_HANDLE handle;
+    rv = C_OpenSession(slots[1], CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+            NULL, &handle);
+    assert_int_equal(rv, CKR_OK);
+
+    /* assign to state */
+    info->handle = handle;
+    info->slot = slots[1];
+
+    *state = info;
+
+    /* success */
+    return 0;
+}
+
+static int test_teardown(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_RV rv = C_CloseSession(ti->handle);
+    assert_int_equal(rv, CKR_OK);
+
+    free(ti);
+
+    return 0;
+}
+
+static void test_aes_encrypt_decrypt_good(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    CK_SESSION_HANDLE session = ti->handle;
+
+    CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
+    CK_KEY_TYPE key_type = CKK_AES;
+    CK_ATTRIBUTE tmpl[] = {
+      {CKA_CLASS, &key_class, sizeof(key_class)},
+      {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
+    };
+
+    CK_RV rv = C_FindObjectsInit(session, tmpl, ARRAY_LEN(tmpl));
+    assert_int_equal(rv, CKR_OK);
+
+    /* get a AES key */
+    unsigned long count;
+    CK_OBJECT_HANDLE objhandles[1];
+    rv = C_FindObjects(session, objhandles, ARRAY_LEN(objhandles), &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(session);
+    assert_int_equal(rv, CKR_OK);
+
+    /* now that we have an object, login */
+    unsigned char upin[] = "myuserpin";
+    rv = C_Login(session, CKU_USER, upin, sizeof(upin) - 1);
+    assert_int_equal(rv, CKR_OK);
+
+    /* init encryption */
+    CK_BYTE iv[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+    };
+
+    CK_MECHANISM mechanism = {
+        CKM_AES_CBC_PAD, iv, sizeof(iv)
+    };
+
+    /*
+     * We're not dealing with padding schemes yet, but we do want to handle multi stage encrypt and decrypt.
+     */
+    CK_BYTE plaintext[] = {
+        'm', 'y', ' ', 's', 'e', 'c', 'r', 'e', 't', ' ', 'i', 's', 'c', 'o', 'o', 'l',
+        'm', 'y', ' ', 's', 'e', 'c', 'r', 'e', 't', ' ', 'i', 's', 'c', 'o', 'o', 'l',
+    };
+
+    CK_BYTE ciphertext[sizeof(plaintext)] = { 0 };
+
+    /* init */
+    rv = C_EncryptInit(session, &mechanism, objhandles[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    /* part 1 */
+    unsigned long ciphertext_len = 16;
+    rv = C_EncryptUpdate(session, plaintext, 16,
+            ciphertext, &ciphertext_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(ciphertext_len, 16);
+
+    /* part 2 */
+    ciphertext_len = 16;
+    rv = C_EncryptUpdate(session, plaintext, 16,
+            &ciphertext[16], &ciphertext_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(ciphertext_len, 16);
+
+    /* final, shouldn't have anything left over */
+    rv = C_EncryptFinal(session, NULL, NULL);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_DecryptInit (session, &mechanism, objhandles[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    unsigned char plaintext2[sizeof(plaintext)];
+    unsigned long plaintext2_len = ciphertext_len = 16;
+
+    rv = C_DecryptUpdate (session, ciphertext, ciphertext_len,
+            plaintext2, &plaintext2_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(plaintext2_len, 16);
+
+    rv = C_DecryptUpdate (session, &ciphertext[ciphertext_len], ciphertext_len,
+            &plaintext2[plaintext2_len], &plaintext2_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(plaintext2_len, 16);
+
+    rv = C_DecryptFinal (session, NULL, NULL);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(plaintext2_len, 16);
+
+    rv = C_Logout(session);
+    assert_int_equal(rv, CKR_OK);
+
+    assert_memory_equal(plaintext, plaintext2, sizeof(plaintext2));
+}
+
+int test_invoke(void) {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_aes_encrypt_decrypt_good,
+                test_setup, test_teardown),
+     };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/integration/pkcs-crypt.int.c
+++ b/test/integration/pkcs-crypt.int.c
@@ -27,10 +27,34 @@ typedef struct test_info test_info;
 struct test_info {
     CK_SESSION_HANDLE handle;
     CK_SLOT_ID slot;
+    bool is_logged_in;
+    struct {
+        CK_OBJECT_HANDLE aes;
+    } objects;
 };
 
 static inline test_info *test_info_from_state(void **state) {
     return (test_info *)*state;
+}
+
+static int group_setup(void **state) {
+    UNUSED(state);
+
+    /* Initialize the library */
+    CK_RV rv = C_Initialize(NULL);
+    assert_int_equal(rv, CKR_OK);
+
+    return 0;
+}
+
+static int group_teardown(void **state) {
+    UNUSED(state);
+
+    /* Finalize the library */
+    CK_RV rv = C_Finalize(NULL);
+    assert_int_equal(rv, CKR_OK);
+
+    return 0;
 }
 
 static int test_setup(void **state) {
@@ -38,14 +62,10 @@ static int test_setup(void **state) {
     test_info *info = calloc(1, sizeof(*info));
     assert_non_null(info);
 
-    /* Initialize the library */
-    CK_RV rv = C_Initialize(NULL);
-    assert_int_equal(rv, CKR_OK);
-
     /* get the slots */
     CK_SLOT_ID slots[6];
     unsigned long count = ARRAY_LEN(slots);
-    rv = C_GetSlotList(true, slots, &count);
+    CK_RV rv = C_GetSlotList(true, slots, &count);
     assert_int_equal(rv, CKR_OK);
     assert_int_equal(count, 3);
 
@@ -55,9 +75,29 @@ static int test_setup(void **state) {
             NULL, &handle);
     assert_int_equal(rv, CKR_OK);
 
+    CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
+    CK_KEY_TYPE key_type = CKK_AES;
+    CK_ATTRIBUTE tmpl[] = {
+      {CKA_CLASS, &key_class, sizeof(key_class)},
+      {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
+    };
+
+    rv = C_FindObjectsInit(handle, tmpl, ARRAY_LEN(tmpl));
+    assert_int_equal(rv, CKR_OK);
+
+    /* get a AES key */
+    CK_OBJECT_HANDLE objhandles[1];
+    rv = C_FindObjects(handle, objhandles, ARRAY_LEN(objhandles), &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(handle);
+    assert_int_equal(rv, CKR_OK);
+
     /* assign to state */
     info->handle = handle;
     info->slot = slots[1];
+    info->objects.aes = objhandles[0];
 
     *state = info;
 
@@ -68,6 +108,12 @@ static int test_setup(void **state) {
 static int test_teardown(void **state) {
 
     test_info *ti = test_info_from_state(state);
+
+    if (ti->is_logged_in) {
+        CK_RV rv = C_Logout(ti->handle);
+        assert_int_equal(rv, CKR_OK);
+    }
+
     CK_RV rv = C_CloseSession(ti->handle);
     assert_int_equal(rv, CKR_OK);
 
@@ -76,36 +122,23 @@ static int test_teardown(void **state) {
     return 0;
 }
 
+static void do_login(test_info *ti) {
+    /* now that we have an object, login */
+    unsigned char upin[] = "myuserpin";
+    CK_RV rv = C_Login(ti->handle, CKU_USER, upin, sizeof(upin) - 1);
+    assert_int_equal(rv, CKR_OK);
+
+    ti->is_logged_in = true;
+}
+
 static void test_aes_encrypt_decrypt_good(void **state) {
 
     test_info *ti = test_info_from_state(state);
 
     CK_SESSION_HANDLE session = ti->handle;
 
-    CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
-    CK_KEY_TYPE key_type = CKK_AES;
-    CK_ATTRIBUTE tmpl[] = {
-      {CKA_CLASS, &key_class, sizeof(key_class)},
-      {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
-    };
-
-    CK_RV rv = C_FindObjectsInit(session, tmpl, ARRAY_LEN(tmpl));
-    assert_int_equal(rv, CKR_OK);
-
-    /* get a AES key */
-    unsigned long count;
-    CK_OBJECT_HANDLE objhandles[1];
-    rv = C_FindObjects(session, objhandles, ARRAY_LEN(objhandles), &count);
-    assert_int_equal(rv, CKR_OK);
-    assert_int_equal(count, 1);
-
-    rv = C_FindObjectsFinal(session);
-    assert_int_equal(rv, CKR_OK);
-
     /* now that we have an object, login */
-    unsigned char upin[] = "myuserpin";
-    rv = C_Login(session, CKU_USER, upin, sizeof(upin) - 1);
-    assert_int_equal(rv, CKR_OK);
+    do_login(ti);
 
     /* init encryption */
     CK_BYTE iv[16] = {
@@ -130,7 +163,7 @@ static void test_aes_encrypt_decrypt_good(void **state) {
     CK_BYTE ciphertext[sizeof(plaintext)] = { 0 };
 
     /* init */
-    rv = C_EncryptInit(session, &mechanism, objhandles[0]);
+    CK_RV rv = C_EncryptInit(session, &mechanism, ti->objects.aes);
     assert_int_equal(rv, CKR_OK);
 
     /* part 1 */
@@ -151,7 +184,7 @@ static void test_aes_encrypt_decrypt_good(void **state) {
     rv = C_EncryptFinal(session, NULL, NULL);
     assert_int_equal(rv, CKR_OK);
 
-    rv = C_DecryptInit (session, &mechanism, objhandles[0]);
+    rv = C_DecryptInit (session, &mechanism, ti->objects.aes);
     assert_int_equal(rv, CKR_OK);
 
     unsigned char plaintext2[sizeof(plaintext)];
@@ -171,8 +204,60 @@ static void test_aes_encrypt_decrypt_good(void **state) {
     assert_int_equal(rv, CKR_OK);
     assert_int_equal(plaintext2_len, 16);
 
-    rv = C_Logout(session);
+    assert_memory_equal(plaintext, plaintext2, sizeof(plaintext2));
+}
+
+static void test_aes_encrypt_decrypt_oneshot_good(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    CK_SESSION_HANDLE session = ti->handle;
+
+    do_login(ti);
+
+    /* init encryption */
+    CK_BYTE iv[16] = {
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+        0xDE, 0xAD, 0xBE, 0xEF,
+    };
+
+    CK_MECHANISM mechanism = {
+        CKM_AES_CBC_PAD, iv, sizeof(iv)
+    };
+
+    /*
+     * We're not dealing with padding schemes yet, but we do want to handle multi stage encrypt and decrypt.
+     */
+    CK_BYTE plaintext[] = {
+        'm', 'y', ' ', 's', 'e', 'c', 'r', 'e', 't', ' ', 'i', 's', 'c', 'o', 'o', 'l',
+        'm', 'y', ' ', 's', 'e', 'c', 'r', 'e', 't', ' ', 'i', 's', 'c', 'o', 'o', 'l',
+    };
+
+    CK_BYTE ciphertext[sizeof(plaintext)] = { 0 };
+
+    /* init */
+    CK_RV rv = C_EncryptInit(session, &mechanism, ti->objects.aes);
     assert_int_equal(rv, CKR_OK);
+
+    /* part 1 */
+    unsigned long ciphertext_len = sizeof(plaintext);
+    rv = C_Encrypt(session, plaintext, ciphertext_len,
+            ciphertext, &ciphertext_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(ciphertext_len, sizeof(plaintext));
+
+    rv = C_DecryptInit (session, &mechanism, ti->objects.aes);
+    assert_int_equal(rv, CKR_OK);
+
+    unsigned char plaintext2[sizeof(plaintext)];
+    unsigned long plaintext2_len = sizeof(plaintext2);
+
+    rv = C_Decrypt (session, ciphertext, ciphertext_len,
+            plaintext2, &plaintext2_len);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(plaintext2_len, sizeof(plaintext2));
 
     assert_memory_equal(plaintext, plaintext2, sizeof(plaintext2));
 }
@@ -182,7 +267,9 @@ int test_invoke(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_aes_encrypt_decrypt_good,
                 test_setup, test_teardown),
-     };
+        cmocka_unit_test_setup_teardown(test_aes_encrypt_decrypt_oneshot_good,
+                test_setup, test_teardown),
+    };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
 }


### PR DESCRIPTION
* Restores the symmetric crypto test
* Fixes a session state bug when clearing db initialized data on secondary and tertiary objects
* Adds a test for C_Encrypt and C_Decrypt oneshot interfaces