### PR TITLE
C_GenerateKeyPair: return CKR_FUNCTION_NOT_SUPPORTED

### DIFF
--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -59,7 +59,7 @@ CK_RV key_gen (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism,
     *public_key = 42;
     *private_key= 43;
 
-    rv = CKR_OK;
+    rv = CKR_FUNCTION_NOT_SUPPORTED;
 
 //unlock:
     session_ctx_unlock(ctx);


### PR DESCRIPTION
It's not implemented, just stubbed in and un-tested. Just
return CKR_FUNCTION_NOT_SUPPORTED for now so applications
don't get confused.

Fixes: #85

Signed-off-by: William Roberts <william.c.roberts@intel.com>