### PR TITLE
Token based tpm context, kill of cached session context and fix locking

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -23,6 +23,7 @@
 #include "object.h"
 #include "session_table.h"
 #include "token.h"
+#include "tpm.h"
 #include "twist.h"
 #include "utils.h"
 
@@ -866,6 +867,15 @@ CK_RV db_get_tokens(token **t, size_t *len) {
 
         int rc = init_pobject(t->pid, &t->pobject);
         if (rc != SQLITE_OK) {
+            goto error;
+        }
+
+        /*
+         * Intiialize the per-token tpm context
+         */
+        rv = tpm_ctx_new(&t->tctx);
+        if (rv != CKR_OK) {
+            LOGE("Could not initialize tpm ctx: 0x%x", rv);
             goto error;
         }
 

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -20,6 +20,7 @@
 
 #include "db.h"
 #include "log.h"
+#include "mutex.h"
 #include "object.h"
 #include "session_table.h"
 #include "token.h"
@@ -882,6 +883,12 @@ CK_RV db_get_tokens(token **t, size_t *len) {
         /* register the primary object handle with the TPM */
         bool res = tpm_register_handle(t->tctx, &t->pobject.handle);
         if (!res) {
+            goto error;
+        }
+
+        rv = mutex_create(&t->mutex);
+        if (rv != CKR_OK) {
+            LOGE("Could not initialize mutex: 0x%x", rv);
             goto error;
         }
 

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -879,6 +879,12 @@ CK_RV db_get_tokens(token **t, size_t *len) {
             goto error;
         }
 
+        /* register the primary object handle with the TPM */
+        bool res = tpm_register_handle(t->tctx, &t->pobject.handle);
+        if (!res) {
+            goto error;
+        }
+
         if (!t->config.is_initialized) {
             LOGV("skipping further initialization of token tid: %u", t->id);
             continue;

--- a/src/lib/digest.c
+++ b/src/lib/digest.c
@@ -9,6 +9,7 @@
 #include "digest.h"
 #include "session.h"
 #include "session_ctx.h"
+#include "token.h"
 #include "tpm.h"
 
 /*
@@ -49,7 +50,9 @@ CK_RV digest_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism) {
     /*
      * Start a hashing sequence with the TPM
      */
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
+
     uint32_t sequence_handle;
     rv = tpm_hash_init(tpm, mechanism->mechanism, &sequence_handle);
     if (rv != CKR_OK) {
@@ -100,7 +103,9 @@ CK_RV digest_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned lo
         goto out;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
+
     rv = tpm_hash_update(tpm, opdata->sequence_handle, part, part_len);
     if (rv != CKR_OK) {
         goto out;
@@ -139,7 +144,9 @@ CK_RV digest_final (CK_SESSION_HANDLE session, unsigned char *digest, unsigned l
         goto out;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
+
     rv = tpm_hash_final(tpm, opdata->sequence_handle, digest, digest_len);
     if (rv != CKR_OK) {
         goto out;

--- a/src/lib/digest.c
+++ b/src/lib/digest.c
@@ -23,30 +23,15 @@ struct digest_op_data {
     uint32_t sequence_handle;
 };
 
-CK_RV digest_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism) {
+CK_RV digest_init(token *tok, CK_MECHANISM *mechanism) {
 
-    check_is_init();
     check_pointer(mechanism);
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
-    token *tok = session_ctx_get_tok(ctx);
     bool is_active = token_opdata_is_active(tok);
     if (is_active) {
-        rv = CKR_OPERATION_ACTIVE;
-        goto out;
+        return CKR_OPERATION_ACTIVE;
     }
 
     /*
@@ -57,13 +42,12 @@ CK_RV digest_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism) {
     uint32_t sequence_handle;
     rv = tpm_hash_init(tpm, mechanism->mechanism, &sequence_handle);
     if (rv != CKR_OK) {
-        goto out;
+        return rv;
     }
 
     digest_op_data *opdata = calloc(1, sizeof(*opdata));
     if (!opdata) {
-        rv = CKR_HOST_MEMORY;
-        goto out;
+        return CKR_HOST_MEMORY;
     }
 
     opdata->mode = mechanism->mechanism;
@@ -72,105 +56,61 @@ CK_RV digest_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism) {
     /* Store everything for later */
     token_opdata_set(tok, operation_digest, opdata);
 
-    rv = CKR_OK;
-
-out:
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return CKR_OK;
 }
 
-CK_RV digest_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len) {
+CK_RV digest_update(token *tok, unsigned char *part, unsigned long part_len) {
 
-    check_is_init();
     check_pointer(part);
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
     digest_op_data *opdata = NULL;
-    token *tok = session_ctx_get_tok(ctx);
     rv = token_opdata_get(tok, operation_digest, &opdata);
     if (rv != CKR_OK) {
-        goto out;
+        return rv;
     }
 
     tpm_ctx *tpm = tok->tctx;
 
     rv = tpm_hash_update(tpm, opdata->sequence_handle, part, part_len);
     if (rv != CKR_OK) {
-        goto out;
+        return rv;
     }
 
-    rv = CKR_OK;
-
-out:
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return CKR_OK;
 }
 
-CK_RV digest_final (CK_SESSION_HANDLE session, unsigned char *digest, unsigned long *digest_len) {
+CK_RV digest_final(token *tok, unsigned char *digest, unsigned long *digest_len) {
 
-    check_is_init();
     check_pointer(digest);
     check_pointer(digest_len);
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
     digest_op_data *opdata = NULL;
-    token *tok = session_ctx_get_tok(ctx);
     rv = token_opdata_get(tok, operation_digest, &opdata);
     if (rv != CKR_OK) {
-        goto out;
+        return rv;
     }
 
     tpm_ctx *tpm = tok->tctx;
 
     rv = tpm_hash_final(tpm, opdata->sequence_handle, digest, digest_len);
-    if (rv != CKR_OK) {
-        goto out;
-    }
 
     token_opdata_clear(tok);
 
     free(opdata);
 
-out:
-    session_ctx_unlock(ctx);
-
     return rv;
 }
 
-CK_RV digest_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len) {
+CK_RV digest_oneshot(token *tok, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len) {
 
-    CK_RV rv = digest_update(session, data, data_len);
+    CK_RV rv = digest_update(tok, data, data_len);
     if (rv != CKR_OK) {
         return rv;
     }
 
-    return digest_final(session, digest, digest_len);
+    return digest_final(tok, digest, digest_len);
 }

--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -8,9 +8,14 @@
 
 #include "pkcs11.h"
 
-CK_RV digest_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism);
-CK_RV digest_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len);
-CK_RV digest_final (CK_SESSION_HANDLE session, unsigned char *digest, unsigned long *digest_len);
-CK_RV digest_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len);
+typedef struct token token;
+
+CK_RV digest_init(token *tok, CK_MECHANISM *mechanism);
+
+CK_RV digest_update(token *tok, unsigned char *part, unsigned long part_len);
+
+CK_RV digest_final(token *tok, unsigned char *digest, unsigned long *digest_len);
+
+CK_RV digest_oneshot(token *tok, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len);
 
 #endif /* SRC_LIB_DIGEST_H_ */

--- a/src/lib/encrypt.c
+++ b/src/lib/encrypt.c
@@ -7,6 +7,7 @@
 #include "encrypt.h"
 #include "session.h"
 #include "session_ctx.h"
+#include "token.h"
 #include "tpm.h"
 
 typedef struct encrypt_op_data encrypt_op_data;
@@ -141,7 +142,8 @@ static CK_RV common_update (operation op, CK_SESSION_HANDLE session, unsigned ch
         goto out;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
 
     rv = fop(tpm, opdata->object, opdata->mode, opdata->iv, input, &output, &iv_out);
     if (rv != CKR_OK) {

--- a/src/lib/encrypt.c
+++ b/src/lib/encrypt.c
@@ -7,6 +7,7 @@
 #include "encrypt.h"
 #include "session.h"
 #include "session_ctx.h"
+#include "token.h"
 #include "tpm.h"
 
 typedef struct encrypt_op_data encrypt_op_data;
@@ -18,9 +19,8 @@ struct encrypt_op_data {
 
 typedef CK_RV (*tpm_op)(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mode, twist iv, twist data_in, twist *data_out, twist *iv_out);
 
-static CK_RV common_init (operation op, CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+static CK_RV common_init (token *tok, operation op, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
 
-    check_is_init();
     check_pointer(mechanism);
 
     /*
@@ -42,36 +42,21 @@ static CK_RV common_init (operation op, CK_SESSION_HANDLE session, CK_MECHANISM 
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
+    bool is_active = token_opdata_is_active(tok);
+    if (is_active) {
+        rv = CKR_OPERATION_ACTIVE;
+        return rv;
+    }
+
+    tobject *tobj;
+    rv = token_load_object(tok, key, &tobj);
     if (rv != CKR_OK) {
         return rv;
     }
 
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
-    token *tok = session_ctx_get_tok(ctx);
-
-    bool is_active = token_opdata_is_active(tok);
-    if (is_active) {
-        rv = CKR_OPERATION_ACTIVE;
-        goto out;
-    }
-
-    tobject *tobj;
-    rv = session_ctx_load_object(ctx, key, &tobj);
-    if (rv != CKR_OK) {
-        goto out;
-    }
-
     encrypt_op_data *opdata = (encrypt_op_data *)calloc(1, sizeof(*opdata));
     if (!opdata) {
-        rv = CKR_HOST_MEMORY;
-        goto out;
+        return CKR_HOST_MEMORY;
     }
 
     opdata->object = tobj;
@@ -80,17 +65,13 @@ static CK_RV common_init (operation op, CK_SESSION_HANDLE session, CK_MECHANISM 
 
     token_opdata_set(tok, op, opdata);
 
-    rv = CKR_OK;
-
-out:
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return CKR_OK;
 }
 
-static CK_RV common_update (operation op, CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+static CK_RV common_update (token *tok, operation op,
+        unsigned char *part, unsigned long part_len,
+        unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
 
-    check_is_init();
     check_pointer(part);
     check_pointer(encrypted_part);
     check_pointer(encrypted_part_len);
@@ -127,20 +108,6 @@ static CK_RV common_update (operation op, CK_SESSION_HANDLE session, unsigned ch
     twist output = NULL;
     twist iv_out = NULL;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    token *tok = session_ctx_get_tok(ctx);
-
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
     encrypt_op_data *opdata = NULL;
     rv = token_opdata_get(tok, op, &opdata);
     if (rv != CKR_OK) {
@@ -165,17 +132,14 @@ static CK_RV common_update (operation op, CK_SESSION_HANDLE session, unsigned ch
     rv = CKR_OK;
 
 out:
-    session_ctx_unlock(ctx);
-
     twist_free(input);
     twist_free(output);
 
     return rv;
 }
 
-static CK_RV common_final (operation op, CK_SESSION_HANDLE session, unsigned char *last_part, unsigned long *last_part_len) {
-
-    check_is_init();
+static CK_RV common_final(token *tok, operation op,
+        unsigned char *last_part, unsigned long *last_part_len) {
 
     /*
      * We have no use for these.
@@ -185,24 +149,10 @@ static CK_RV common_final (operation op, CK_SESSION_HANDLE session, unsigned cha
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    bool session_state_ok = session_ctx_user_state_ok(ctx);
-    if (!session_state_ok) {
-        rv = CKR_USER_NOT_LOGGED_IN;
-        goto out;
-    }
-
-    token *tok = session_ctx_get_tok(ctx);
-
     encrypt_op_data *opdata = NULL;
     rv = token_opdata_get(tok, op, &opdata);
     if (rv != CKR_OK) {
-        goto out;
+        return rv;
     }
 
     twist_free(opdata->iv);
@@ -210,61 +160,56 @@ static CK_RV common_final (operation op, CK_SESSION_HANDLE session, unsigned cha
 
     token_opdata_clear(tok);
 
-    rv = CKR_OK;
-
-out:
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return CKR_OK;
 }
 
-CK_RV encrypt_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+CK_RV encrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
 
-    return common_init(operation_encrypt, session, mechanism, key);
+    return common_init(tok, operation_encrypt, mechanism, key);
 }
 
-CK_RV decrypt_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+CK_RV decrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
 
-    return common_init(operation_decrypt, session, mechanism, key);
+    return common_init(tok, operation_decrypt, mechanism, key);
 }
 
-CK_RV encrypt_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+CK_RV encrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
 
-    return common_update(operation_encrypt, session, part, part_len, encrypted_part, encrypted_part_len);
+    return common_update(tok, operation_encrypt, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV decrypt_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+CK_RV decrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
 
-    return common_update(operation_decrypt, session, part, part_len, encrypted_part, encrypted_part_len);
+    return common_update(tok, operation_decrypt, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV encrypt_final (CK_SESSION_HANDLE session, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
+CK_RV encrypt_final (token *tok, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
 
-    return common_final(operation_encrypt, session, last_encrypted_part, last_encrypted_part_len);
+    return common_final(tok, operation_encrypt, last_encrypted_part, last_encrypted_part_len);
 }
 
-CK_RV decrypt_final (CK_SESSION_HANDLE session, unsigned char *last_part, unsigned long *last_part_len) {
+CK_RV decrypt_final (token *tok, unsigned char *last_part, unsigned long *last_part_len) {
 
-    return common_final(operation_decrypt, session, last_part, last_part_len);
+    return common_final(tok, operation_decrypt, last_part, last_part_len);
 }
 
-CK_RV decrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
+CK_RV decrypt_oneshot (token *tok, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
 
-    CK_RV rv = decrypt_update(session, encrypted_data, encrypted_data_len,
+    CK_RV rv = decrypt_update(tok, encrypted_data, encrypted_data_len,
             data, data_len);
     if (rv != CKR_OK) {
         return rv;
     }
 
-    return decrypt_final(session, NULL, NULL);
+    return decrypt_final(tok, NULL, NULL);
 }
 
-CK_RV encrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
+CK_RV encrypt_oneshot (token *tok, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
 
-    CK_RV rv = encrypt_update(session, data, data_len, encrypted_data, encrypted_data_len);
+    CK_RV rv = encrypt_update(tok, data, data_len, encrypted_data, encrypted_data_len);
     if (rv != CKR_OK) {
         return rv;
     }
 
-    return encrypt_final(session, NULL, NULL);
+    return encrypt_final(tok, NULL, NULL);
 }

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -8,20 +8,22 @@
 
 #include "pkcs11.h"
 
-CK_RV encrypt_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+typedef struct token token;
 
-CK_RV encrypt_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+CK_RV encrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV encrypt_final (CK_SESSION_HANDLE session, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
+CK_RV encrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
 
-CK_RV decrypt_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+CK_RV encrypt_final (token *tok, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
 
-CK_RV decrypt_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+CK_RV decrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV decrypt_final (CK_SESSION_HANDLE session, unsigned char *last_part, unsigned long *last_part_len);
+CK_RV decrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
 
-CK_RV decrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+CK_RV decrypt_final (token *tok, unsigned char *last_part, unsigned long *last_part_len);
 
-CK_RV encrypt_oneshot (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
+CK_RV decrypt_oneshot (token *tok, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+
+CK_RV encrypt_oneshot (token *tok, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
 
 #endif /* SRC_LIB_ENCRYPT_H_ */

--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -201,11 +201,6 @@ CK_RV general_init(void *init_args) {
      *
      * THESE MUST GO AFTER MUTEX INIT above!!
      */
-    rv  = tpm_init();
-    if (rv != CKR_OK) {
-        goto err;
-    }
-
     rv = db_init();
     if (rv != CKR_OK) {
         goto err;
@@ -220,7 +215,6 @@ CK_RV general_init(void *init_args) {
 
     return CKR_OK;
 err:
-    tpm_destroy();
     return rv;
 }
 
@@ -233,7 +227,6 @@ CK_RV general_finalize(void *reserved) {
 
     _g_is_init = false;
 
-    tpm_destroy();
     db_destroy();
     slot_destroy();
 

--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -13,56 +13,22 @@
 #include "session_ctx.h"
 #include "utils.h"
 
-CK_RV key_gen (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism,
+CK_RV key_gen (token *tok, CK_MECHANISM *mechanism,
         CK_ATTRIBUTE *public_key_template, unsigned long public_key_attribute_count, CK_ATTRIBUTE *private_key_template,
         unsigned long private_key_attribute_count, CK_OBJECT_HANDLE *public_key, CK_OBJECT_HANDLE *private_key) {
 
-    check_is_init();
-
-    CK_RV rv = CKR_GENERAL_ERROR;
-
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
     // TODO use me
-    (void) mechanism;
-    (void) public_key_template;
-    (void) public_key_attribute_count;
-    (void) private_key_template;
-    (void) private_key_attribute_count;
+    UNUSED(tok);
 
-    //tpm_ctx *sys = session_ctx_get_tpm_ctx(ctx);
+    UNUSED(mechanism);
 
-//    util_buf *so_pin = session_ctx_get_so_pin_unlocked(ctx);
-//    assert(so_pin);
-//
-//    db_get_primary_key_auth();
-//
-//    bool res = tpm_genkeypair(sys, salt, NULL,
-//            public_key_template, public_key_attribute_count,
-//            private_key_template, private_key_attribute_count);
-//    if (!res) {
-//        goto unlock;
-//    }
+    UNUSED(public_key);
+    UNUSED(public_key_template);
+    UNUSED(public_key_attribute_count);
 
-//    rv = db_insert_keypair(public_key_template, public_key_attribute_count,
-//            private_key_template, private_key_attribute_count,
-//            public_key, private_key);
-//    if (!res) {
-//        goto unlock;
-//    }
+    UNUSED(private_key);
+    UNUSED(private_key_template);
+    UNUSED(private_key_attribute_count);
 
-    // TODO Real keygen here and set up objects.
-    *public_key = 42;
-    *private_key= 43;
-
-    rv = CKR_FUNCTION_NOT_SUPPORTED;
-
-//unlock:
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return CKR_FUNCTION_NOT_SUPPORTED;
 }

--- a/src/lib/key.h
+++ b/src/lib/key.h
@@ -8,6 +8,10 @@
 
 #include "pkcs11.h"
 
-CK_RV key_gen (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_ATTRIBUTE *public_key_template, unsigned long public_key_attribute_count, CK_ATTRIBUTE *private_key_template, unsigned long private_key_attribute_count, CK_OBJECT_HANDLE *public_key, CK_OBJECT_HANDLE *private_key);
+typedef struct token token;
+typedef struct session_ctx session_ctx;
+
+CK_RV key_gen (token *tok,
+        CK_MECHANISM *mechanism, CK_ATTRIBUTE *public_key_template, unsigned long public_key_attribute_count, CK_ATTRIBUTE *private_key_template, unsigned long private_key_attribute_count, CK_OBJECT_HANDLE *public_key, CK_OBJECT_HANDLE *private_key);
 
 #endif /* SRC_PKCS11_KEY_H_ */

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -14,6 +14,8 @@
 #include "twist.h"
 #include "utils.h"
 
+typedef struct token token;
+
 typedef struct pobject pobject;
 struct pobject {
     uint32_t handle;
@@ -90,13 +92,13 @@ void sobject_free(sobject *sobj);
 void wrappingobject_free(wrappingobject *wobj);
 void sealobject_free(sealobject *sealobj);
 
-CK_RV object_find_init(CK_SESSION_HANDLE session, CK_ATTRIBUTE_PTR templ, unsigned long count);
+CK_RV object_find_init(token *tok, CK_ATTRIBUTE_PTR templ, unsigned long count);
 
-CK_RV object_find(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE *object, unsigned long max_object_count, unsigned long *object_count);
+CK_RV object_find(token *tok, CK_OBJECT_HANDLE *object, unsigned long max_object_count, unsigned long *object_count);
 
-CK_RV object_find_final(CK_SESSION_HANDLE session);
+CK_RV object_find_final(token *tok);
 
-CK_RV object_get_attributes(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count);
+CK_RV object_get_attributes(token *tok, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count);
 
 /**
  * Given an attribute type, retrieves the attribute data if present.

--- a/src/lib/random.c
+++ b/src/lib/random.c
@@ -3,45 +3,30 @@
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  */
-#include <string.h>
-
-#include "general.h"
+#include "checks.h"
 #include "pkcs11.h"
 #include "random.h"
-#include "session.h"
+#include "session_ctx.h"
 #include "token.h"
 #include "tpm.h"
 
-CK_RV random_get(CK_SESSION_HANDLE session, unsigned char *random_data, unsigned long random_len) {
+CK_RV random_get(token *tok, unsigned char *random_data, unsigned long random_len) {
 
-    session_ctx *ctx = NULL;
-    CK_RV rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
+    check_pointer(random_data);
 
-    token *tok = session_ctx_get_tok(ctx);
     tpm_ctx *tpm = tok->tctx;
 
     bool res = tpm_getrandom(tpm, random_data, random_len);
-    session_ctx_unlock(ctx);
 
     return res ? CKR_OK: CKR_GENERAL_ERROR;
 }
 
-CK_RV seed_random (CK_SESSION_HANDLE session, unsigned char *seed, unsigned long seed_len) {
+CK_RV seed_random(token *tok, unsigned char *seed, unsigned long seed_len) {
 
-    session_ctx *ctx = NULL;
-    CK_RV rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
+    check_pointer(seed);
 
-    token *tok = session_ctx_get_tok(ctx);
     tpm_ctx *tpm = tok->tctx;
-
-    rv = tpm_stirrandom(tpm, seed, seed_len);
-    session_ctx_unlock(ctx);
+    CK_RV rv = tpm_stirrandom(tpm, seed, seed_len);
 
     return rv;
 }

--- a/src/lib/random.c
+++ b/src/lib/random.c
@@ -9,6 +9,7 @@
 #include "pkcs11.h"
 #include "random.h"
 #include "session.h"
+#include "token.h"
 #include "tpm.h"
 
 CK_RV random_get(CK_SESSION_HANDLE session, unsigned char *random_data, unsigned long random_len) {
@@ -19,9 +20,10 @@ CK_RV random_get(CK_SESSION_HANDLE session, unsigned char *random_data, unsigned
         return rv;
     }
 
-    tpm_ctx *sys = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
 
-    bool res = tpm_getrandom(sys, random_data, random_len);
+    bool res = tpm_getrandom(tpm, random_data, random_len);
     session_ctx_unlock(ctx);
 
     return res ? CKR_OK: CKR_GENERAL_ERROR;
@@ -35,7 +37,8 @@ CK_RV seed_random (CK_SESSION_HANDLE session, unsigned char *seed, unsigned long
         return rv;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
 
     rv = tpm_stirrandom(tpm, seed, seed_len);
     session_ctx_unlock(ctx);

--- a/src/lib/random.h
+++ b/src/lib/random.h
@@ -8,8 +8,11 @@
 
 #include "pkcs11.h"
 
-CK_RV random_get(CK_SESSION_HANDLE session, unsigned char *random_data, unsigned long random_len);
+typedef struct token token;
+typedef struct session_ctx session_ctx;
 
-CK_RV seed_random (CK_SESSION_HANDLE session, unsigned char *seed, unsigned long seed_len);
+CK_RV random_get(token *tok, unsigned char *random_data, unsigned long random_len);
+
+CK_RV seed_random(token *tok, unsigned char *seed, unsigned long seed_len);
 
 #endif /* SRC_PKCS11_RANDOM_H_ */

--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -14,6 +14,7 @@
 #include "pkcs11.h"
 #include "session.h"
 #include "session_table.h"
+#include "token.h"
 #include "tpm.h"
 #include "utils.h"
 
@@ -21,7 +22,7 @@ static CK_RV check_max_sessions(session_table *s_table) {
 
     unsigned long all;
 
-    session_table_get_cnt_unlocked(s_table, &all, NULL, NULL);
+    session_table_get_cnt(s_table, &all, NULL, NULL);
 
     return (all > MAX_NUM_OF_SESSIONS) ?
         CKR_SESSION_COUNT : CKR_OK;
@@ -79,10 +80,9 @@ CK_RV session_open(CK_SLOT_ID slot_id, CK_FLAGS flags, void *application,
 	    return CKR_SLOT_ID_INVALID;
 	}
 
-	session_table_lock(t->s_table);
 	rv = check_max_sessions(t->s_table);
 	if (rv != CKR_OK) {
-	    goto unlock;
+	    return rv;
 	}
 
 	/*
@@ -92,18 +92,14 @@ CK_RV session_open(CK_SLOT_ID slot_id, CK_FLAGS flags, void *application,
 	    return CKR_SESSION_READ_WRITE_SO_EXISTS;
 	}
 
-	rv = session_table_new_ctx_unlocked(t->s_table, session, t, flags);
+	rv = session_table_new_entry(t->s_table, session, t, flags);
     if (rv != CKR_OK) {
-        goto unlock;
+        return rv;
     }
 
 	add_tokid_to_session_handle(t->id, session);
 
-	rv = CKR_OK;
-
-unlock:
-	session_table_unlock(t->s_table);
-	return rv;
+	return CKR_OK;
 }
 
 CK_RV session_close(CK_SESSION_HANDLE session) {
@@ -129,7 +125,7 @@ CK_RV session_closeall(CK_SLOT_ID slot_id) {
     return CKR_OK;
 }
 
-CK_RV session_lookup(CK_SESSION_HANDLE session, session_ctx **ctx) {
+CK_RV session_lookup(CK_SESSION_HANDLE session, token **tok, session_ctx **ctx) {
 
     token *tmp = NULL;
     unsigned tokid = get_tokid_from_session_handle_and_cleanse(&session);
@@ -140,30 +136,24 @@ CK_RV session_lookup(CK_SESSION_HANDLE session, session_ctx **ctx) {
         return CKR_SESSION_HANDLE_INVALID;
     }
 
+    token_lock(tmp);
+
+    *tok = tmp;
+
     return CKR_OK;
 }
 
-CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
-        unsigned char *pin, unsigned long pin_len) {
 
-    check_is_init();
+CK_RV session_login(token *tok, CK_USER_TYPE user_type,
+        unsigned char *pin, unsigned long pin_len) {
 
     twist tpin = NULL;
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    session_ctx *ctx = NULL;
-    rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
     tpin = twistbin_new(pin, pin_len);
     if (!tpin) {
-        rv = CKR_HOST_MEMORY;
-        goto out;
+        return CKR_HOST_MEMORY;
     }
-
-    token *tok = session_ctx_get_tok(ctx);
 
     // TODO Handle CKU_CONTEXT_SPECIFIC
     // TODO Support CKA_ALWAYS_AUTHENTICATE
@@ -182,54 +172,26 @@ CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
 
     twist_free(tpin);
 
-out:
-    session_ctx_unlock(ctx);
-
     return rv;
 }
 
-CK_RV session_logout (CK_SESSION_HANDLE session) {
+CK_RV session_logout(token *tok) {
 
-    check_is_init();
-
-    session_ctx *ctx = NULL;
-    CK_RV rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    token *tok = session_ctx_get_tok(ctx);
-
-    rv = token_logout(tok);
-
-    session_ctx_unlock(ctx);
-
-    return rv;
+    return token_logout(tok);
 }
 
-CK_RV session_get_info (CK_SESSION_HANDLE session, CK_SESSION_INFO *info) {
+CK_RV session_get_info(token *tok, session_ctx *ctx, CK_SESSION_INFO *info) {
 
-    check_is_init();
     check_pointer(info);
-
-    session_ctx *ctx = NULL;
-    CK_RV rv = session_lookup(session, &ctx);
-    if (rv != CKR_OK) {
-        return rv;
-    }
 
     info->flags = session_ctx_flags_get(ctx);
 
-    token *t = session_ctx_get_tok(ctx);
-    info->slotID = t->id;
-
+    info->slotID = tok->id;
 
     info->state = session_ctx_state_get(ctx);
 
     // We'll need to set this state error at some point, perhaps TSS2_RC's
     info->ulDeviceError = 0;
-
-    session_ctx_unlock(ctx);
 
     return CKR_OK;
 }

--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -163,13 +163,15 @@ CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
         goto out;
     }
 
+    token *tok = session_ctx_get_tok(ctx);
+
     // TODO Handle CKU_CONTEXT_SPECIFIC
     // TODO Support CKA_ALWAYS_AUTHENTICATE
     switch(user_type) {
         case CKU_SO:
             /* falls-through */
         case CKU_USER:
-            rv = session_ctx_token_login(ctx, tpin, user_type);
+            rv = token_login(tok, tpin, user_type);
         break;
         case CKU_CONTEXT_SPECIFIC:
             rv = CKR_USER_TYPE_INVALID;

--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -196,7 +196,11 @@ CK_RV session_logout (CK_SESSION_HANDLE session) {
         return rv;
     }
 
-    rv = session_ctx_token_logout(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+
+    rv = token_logout(tok);
+
+    session_ctx_unlock(ctx);
 
     return rv;
 }

--- a/src/lib/session.h
+++ b/src/lib/session.h
@@ -9,8 +9,10 @@
 #include <stdbool.h>
 
 #include "pkcs11.h"
-#include "session_ctx.h"
 #include "tpm.h"
+
+typedef struct session_ctx session_ctx;
+typedef struct token token;
 
 /*
  * This max value CANNOT extend into the upper byte of a CK_SESSION_HANDLE,
@@ -25,13 +27,13 @@ CK_RV session_close(CK_SESSION_HANDLE session);
 
 CK_RV session_closeall(CK_SLOT_ID slot_id);
 
-CK_RV session_lookup(CK_SESSION_HANDLE session, session_ctx **ctx);
+CK_RV session_lookup(CK_SESSION_HANDLE session, token **tok, session_ctx **ctx);
 
-CK_RV session_login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
+CK_RV session_login(token *tok, CK_USER_TYPE user_type,
         unsigned char *pin, unsigned long pin_len);
 
-CK_RV session_logout (CK_SESSION_HANDLE session);
+CK_RV session_logout(token *tok );
 
-CK_RV session_get_info (CK_SESSION_HANDLE session, CK_SESSION_INFO *info);
+CK_RV session_get_info(token *tok, session_ctx *ctx, CK_SESSION_INFO *info);
 
 #endif /* SRC_PKCS11_SESSION_H_ */

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -11,10 +11,8 @@
 #include "pkcs11.h"
 #include "tpm.h"
 #include "utils.h"
-#include "token.h"
 
-typedef struct token token;
-
+typedef enum token_login_state token_login_state;
 typedef struct session_ctx session_ctx;
 
 /**
@@ -28,14 +26,14 @@ void session_ctx_free(session_ctx *ctx);
  * Creates a new session context within a given token.
  * @param ctx
  *  The new session context generated,
- * @param tok
- *  The token to associate with the session_context
+ * @param state
+ *  The token login state for setting the proper initial session state.
  * @param flags
  *  The session flags
  * @return
  *  CKR_OK on success.
  */
-CK_RV session_ctx_new(session_ctx **ctx, token *tok, CK_FLAGS flags);
+CK_RV session_ctx_new(session_ctx **ctx, token_login_state state, CK_FLAGS flags);
 
 /**
  * Internal locking routine, use the session_ctx_lock and session_ctx_unlock macros.
@@ -43,32 +41,6 @@ CK_RV session_ctx_new(session_ctx **ctx, token *tok, CK_FLAGS flags);
  *  The session to lock
  */
 void *_session_ctx_get_lock(session_ctx *ctx);
-
-/**
- * Lock session_ctx and abort on failure.
- * @param ctx
- *  The session to lock
- */
-#define session_ctx_lock(ctx) \
-    mutex_lock_fatal(_session_ctx_get_lock(ctx))
-
-/**
- * Unock session_ctx and abort on failure.
- * @param ctx
- *  The session to lock
- */
-#define session_ctx_unlock(ctx) \
-    mutex_unlock_fatal(_session_ctx_get_lock(ctx))
-
-/**
- * Given a session_context, retrieve the associated token.
- *
- * @param ctx
- *  The session_ctx to query for the token.
- * @return
- *  The token pointer.
- */
-token *session_ctx_get_tok(session_ctx *ctx);
 
 /**
  * Get the state of the session
@@ -88,7 +60,8 @@ CK_STATE session_ctx_state_get(session_ctx *ctx);
  */
 CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
 
-CK_RV session_ctx_load_object(session_ctx *ctx, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
+// XXX moveme
+CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 
 /**
  * Given a user, performs a login event, causing a transition to it's correct end state based
@@ -115,21 +88,5 @@ void session_ctx_login_event(session_ctx *ctx, CK_USER_TYPE user);
  *  The session context to transition.
  */
 void session_ctx_logout_event(session_ctx *ctx);
-
-/**
- * True if the session state is either:
- *  1. CKS_RO_USER_FUNCTIONS
- *  2. CKS_RW_USER_FUNCTIONS
- * @param ctx
- *  The session context to query state
- * @return
- *  true if the session state is CKS_RO_USER_FUNCTIONS or
- *  CKS_RW_USER_FUNCTIONS, false otherwise.
- */
-static inline bool session_ctx_user_state_ok(session_ctx *ctx) {
-
-    CK_STATE state = session_ctx_state_get(ctx);
-    return (state == CKS_RO_USER_FUNCTIONS) || (state == CKS_RW_USER_FUNCTIONS);
-}
 
 #endif /* SRC_PKCS11_SESSION_CTX_H_ */

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -41,8 +41,6 @@ void *_session_ctx_get_lock(session_ctx *ctx);
 void session_ctx_opdata_set(session_ctx *ctx, operation op, void *opdata);
 void *session_ctx_opdata_get(session_ctx *ctx, operation op);
 
-tpm_ctx *session_ctx_get_tpm_ctx(session_ctx *ctx);
-
 token *session_ctx_get_tok(session_ctx *ctx);
 
 CK_STATE session_ctx_state_get(session_ctx *ctx);

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -11,81 +11,82 @@
 #include "pkcs11.h"
 #include "tpm.h"
 #include "utils.h"
+#include "token.h"
 
 typedef struct token token;
 
-typedef enum operation operation;
-enum operation {
-    operation_find,
-    operation_sign,
-    operation_verify,
-    operation_encrypt,
-    operation_decrypt,
-    operation_digest,
-    operation_count
-};
-
 typedef struct session_ctx session_ctx;
 
+/**
+ * Frees a session context
+ * @param ctx
+ *  The session context to free
+ */
 void session_ctx_free(session_ctx *ctx);
+
+/**
+ * Creates a new session context within a given token.
+ * @param ctx
+ *  The new session context generated,
+ * @param tok
+ *  The token to associate with the session_context
+ * @param flags
+ *  The session flags
+ * @return
+ *  CKR_OK on success.
+ */
 CK_RV session_ctx_new(session_ctx **ctx, token *tok, CK_FLAGS flags);
 
+/**
+ * Internal locking routine, use the session_ctx_lock and session_ctx_unlock macros.
+ * @param ctx
+ *  The session to lock
+ */
 void *_session_ctx_get_lock(session_ctx *ctx);
 
+/**
+ * Lock session_ctx and abort on failure.
+ * @param ctx
+ *  The session to lock
+ */
 #define session_ctx_lock(ctx) \
     mutex_lock_fatal(_session_ctx_get_lock(ctx))
 
+/**
+ * Unock session_ctx and abort on failure.
+ * @param ctx
+ *  The session to lock
+ */
 #define session_ctx_unlock(ctx) \
     mutex_unlock_fatal(_session_ctx_get_lock(ctx))
 
-void session_ctx_opdata_set(session_ctx *ctx, operation op, void *opdata);
-void *session_ctx_opdata_get(session_ctx *ctx, operation op);
-
-token *session_ctx_get_tok(session_ctx *ctx);
-
-CK_STATE session_ctx_state_get(session_ctx *ctx);
-
-CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
-
-bool session_ctx_is_user_logged_in(session_ctx *ctx);
-
 /**
- * Causes a login event to be propagated through the token
- * associated with the session context. A login event is
- * Propagated by:
- *   1. setting the token level who is logged in state with whom is logged in.
- *   2. updating all open session states in the session table
- * @param ctx
- *  The session context to update
- * @param pin
- *  The pin
- * @param user
- *  The user
- * @return
- *  CKR_OK on success, anything else is a failure.
- * @note
- *  Locking:
- *    Callee expects caller to *TAKE* the session_ctx lock
- *    Callee expects caller to *RELEASE* session ctx_lock
- */
-CK_RV session_ctx_token_login(session_ctx *ctx, twist pin, CK_USER_TYPE user);
-
-/**
- * Generates a logout event to be propagated through the token associated
- * with the session context. A logout event is propagated by:
- *   1. setting the token level who is logged in state to no one is logged in.
- *   2. setting all existing sessions back to their original state.
+ * Given a session_context, retrieve the associated token.
  *
  * @param ctx
- *  The context triggering the login event
+ *  The session_ctx to query for the token.
  * @return
- *  CKR_OK on success, anything else is a failure.
- * @note
- *  Locking:
- *    Callee expects caller to take the session_ctx lock.
- *    Callee releases session_ctx_lock.
+ *  The token pointer.
  */
-CK_RV session_ctx_token_logout(session_ctx *ctx);
+token *session_ctx_get_tok(session_ctx *ctx);
+
+/**
+ * Get the state of the session
+ * @param ctx
+ *  Session context to query
+ * @return
+ *  The CK_STATE flags.
+ */
+CK_STATE session_ctx_state_get(session_ctx *ctx);
+
+/**
+ * Get the CK_Fstate of the session
+ * @param ctx
+ *  Session context to query
+ * @return
+ *  The CK_STATE flags.
+ */
+CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
 
 CK_RV session_ctx_load_object(session_ctx *ctx, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 
@@ -100,10 +101,8 @@ CK_RV session_ctx_load_object(session_ctx *ctx, CK_OBJECT_HANDLE key, tobject **
  *  The session context to transition.
  * @param user
  *  The user performing the login, ie state transition trigger.
- * @param take_lock
- *  true to lock the session context, false not to lock it (must already be locked).
  */
-void session_ctx_login_event(session_ctx *ctx, CK_USER_TYPE user, bool take_lock);
+void session_ctx_login_event(session_ctx *ctx, CK_USER_TYPE user);
 
 /**
  * Given a user, performs a logout event, causing a transition to it's correct
@@ -114,9 +113,23 @@ void session_ctx_login_event(session_ctx *ctx, CK_USER_TYPE user, bool take_lock
  *
  * @param ctx
  *  The session context to transition.
- * @param take_lock
- *  true to lock the session context, false not to lock it (must already be locked).
  */
-void session_ctx_logout_event(session_ctx *ctx, bool take_lock);
+void session_ctx_logout_event(session_ctx *ctx);
+
+/**
+ * True if the session state is either:
+ *  1. CKS_RO_USER_FUNCTIONS
+ *  2. CKS_RW_USER_FUNCTIONS
+ * @param ctx
+ *  The session context to query state
+ * @return
+ *  true if the session state is CKS_RO_USER_FUNCTIONS or
+ *  CKS_RW_USER_FUNCTIONS, false otherwise.
+ */
+static inline bool session_ctx_user_state_ok(session_ctx *ctx) {
+
+    CK_STATE state = session_ctx_state_get(ctx);
+    return (state == CKS_RO_USER_FUNCTIONS) || (state == CKS_RW_USER_FUNCTIONS);
+}
 
 #endif /* SRC_PKCS11_SESSION_CTX_H_ */

--- a/src/lib/session_table.c
+++ b/src/lib/session_table.c
@@ -18,7 +18,6 @@ struct session_table {
     unsigned long rw_cnt;
     CK_SESSION_HANDLE free_handle;
     session_ctx *table[MAX_NUM_OF_SESSIONS];
-    void *lock;
 };
 
 CK_RV session_table_new(session_table **t) {
@@ -26,12 +25,6 @@ CK_RV session_table_new(session_table **t) {
     session_table *x = calloc(1, sizeof(session_table));
     if (!x) {
         return CKR_HOST_MEMORY;
-    }
-
-    CK_RV rv = mutex_create(&x->lock);
-    if (rv != CKR_OK) {
-        session_table_free(x);
-        return rv;
     }
 
     *t = x;
@@ -45,21 +38,10 @@ void session_table_free(session_table *t) {
         return;
     }
 
-    if (t->lock) {
-        mutex_destroy(t->lock);
-    }
     free(t);
 }
 
-void session_table_lock(session_table *t) {
-    mutex_lock_fatal(t->lock);
-}
-
-void session_table_unlock(session_table *t) {
-    mutex_unlock_fatal(t->lock);
-}
-
-void session_table_get_cnt_unlocked(session_table *t, unsigned long *all, unsigned long *rw, unsigned long *ro) {
+void session_table_get_cnt(session_table *t, unsigned long *all, unsigned long *rw, unsigned long *ro) {
 
     /* All counts should always be greater than or equal to rw count */
     assert(t->cnt >= t->rw_cnt);
@@ -77,23 +59,17 @@ void session_table_get_cnt_unlocked(session_table *t, unsigned long *all, unsign
     }
 }
 
-void session_table_get_cnt(session_table *t, unsigned long *all, unsigned long *rw, unsigned long *ro) {
-    session_table_lock(t);
-    session_table_get_cnt_unlocked(t, all, rw, ro);
-    session_table_unlock(t);
-}
-
-session_ctx **session_table_lookup_unlocked(session_table *t, CK_SESSION_HANDLE handle) {
-    return &t->table[handle];
-}
-
-CK_RV session_table_new_ctx_unlocked(session_table *t, CK_SESSION_HANDLE *handle,
+CK_RV session_table_new_entry(session_table *t, CK_SESSION_HANDLE *handle,
         token *tok, CK_FLAGS flags) {
 
-    session_ctx **c = session_table_lookup_unlocked(t, t->free_handle);
-    assert(!*c);
+    /*
+     * TODO need to search for open slot here so we don't
+     * exhaust handles.
+     */
+    session_ctx **open_slot = &t->table[t->free_handle];
+    assert(!*open_slot);
 
-    CK_RV rv = session_ctx_new(c, tok, flags);
+    CK_RV rv = session_ctx_new(open_slot, tok->login_state, flags);
     if (rv != CKR_OK) {
         return rv;
     }
@@ -111,11 +87,6 @@ CK_RV session_table_new_ctx_unlocked(session_table *t, CK_SESSION_HANDLE *handle
 
 static void do_logout_if_needed(token *tok) {
 
-    /*
-     * Are we logged in, if so logout
-     * XXX Locking token, note the called routine manipulates
-     * token so we *MAY* need a locked/unlocked version
-     */
     if (tok->login_state != token_no_one_logged_in) {
         /*
          * This should never fail, if it does the state is so borked
@@ -126,7 +97,7 @@ static void do_logout_if_needed(token *tok) {
     }
 }
 
-static CK_RV session_table_free_ctx_unlocked_by_ctx(token *t, session_ctx **ctx) {
+static CK_RV session_table_free_ctx_by_ctx(token *t, session_ctx **ctx) {
 
     session_table *stable = t->s_table;
 
@@ -152,7 +123,7 @@ static CK_RV session_table_free_ctx_unlocked_by_ctx(token *t, session_ctx **ctx)
     return CKR_OK;
 }
 
-CK_RV session_table_free_ctx_unlocked_by_handle(token *t, CK_SESSION_HANDLE handle) {
+CK_RV session_table_free_ctx_by_handle(token *t, CK_SESSION_HANDLE handle) {
 
     session_table *stable = t->s_table;
 
@@ -161,12 +132,10 @@ CK_RV session_table_free_ctx_unlocked_by_handle(token *t, CK_SESSION_HANDLE hand
         return CKR_SESSION_HANDLE_INVALID;
     }
 
-    return session_table_free_ctx_unlocked_by_ctx(t, ctx);
+    return session_table_free_ctx_by_ctx(t, ctx);
 }
 
 void session_table_free_ctx_all(token *t) {
-
-    session_table_lock(t->s_table);
 
     unsigned i;
     for (i=0; i < ARRAY_LEN(t->s_table->table); i++) {
@@ -180,42 +149,22 @@ void session_table_free_ctx_all(token *t) {
             continue;
         }
 
-        session_table_free_ctx_unlocked_by_ctx(t, ctx);
+        session_table_free_ctx_by_ctx(t, ctx);
     }
-
-    session_table_unlock(t->s_table);
 }
 
 CK_RV session_table_free_ctx(token *t, CK_SESSION_HANDLE handle) {
 
-    session_table_lock(t->s_table);
-    CK_RV rv = session_table_free_ctx_unlocked_by_handle(t, handle);
-    session_table_unlock(t->s_table);
-
-    return rv;
+    return session_table_free_ctx_by_handle(t, handle);
 }
 
 session_ctx *session_table_lookup(session_table *t, CK_SESSION_HANDLE handle) {
-
-    session_ctx *ctx = NULL;
 
     if (handle > ARRAY_LEN(t->table)) {
         return NULL;
     }
 
-    session_table_lock(t);
-
-    ctx = *session_table_lookup_unlocked(t, handle);
-    if (!ctx) {
-        goto unlock;
-    }
-
-    session_ctx_lock(ctx);
-
-unlock:
-    session_table_unlock(t);
-
-    return ctx;
+    return t->table[handle];
 }
 
 void session_table_login_event(session_table *s_table, CK_USER_TYPE user) {

--- a/src/lib/session_table.h
+++ b/src/lib/session_table.h
@@ -17,18 +17,14 @@ typedef struct session_table session_table;
 CK_RV session_table_new(session_table **t);
 void session_table_free(session_table *t);
 
-void session_table_unlock(session_table *t);
-void session_table_lock(session_table *t);
-
 void session_table_get_cnt(session_table *t, unsigned long *all, unsigned long *rw, unsigned long *ro);
-void session_table_get_cnt_unlocked(session_table *t, unsigned long *all, unsigned long *rw, unsigned long *ro);
 
-CK_RV session_table_new_ctx_unlocked(session_table *t,
+CK_RV session_table_new_entry(session_table *t,
         CK_SESSION_HANDLE *handle, token *tok, CK_FLAGS flags);
 
 session_ctx *session_table_lookup(session_table *t, CK_SESSION_HANDLE handle);
 
-CK_RV session_table_free_ctx_unlocked_by_handle(token *t, CK_SESSION_HANDLE handle);
+CK_RV session_table_free_ctx_by_handle(token *t, CK_SESSION_HANDLE handle);
 CK_RV session_table_free_ctx(token *t, CK_SESSION_HANDLE handle);
 void session_table_free_ctx_all(token *t);
 

--- a/src/lib/session_table.h
+++ b/src/lib/session_table.h
@@ -39,10 +39,8 @@ void session_table_free_ctx_all(token *t);
  *  The session table
  * @param user
  *  The user triggering the login event.
- * @param called_session
- *  The session context that the login event occured on.
  */
-void session_table_login_event(session_table *s_table, CK_USER_TYPE user, session_ctx *called_session);
+void session_table_login_event(session_table *s_table, CK_USER_TYPE user);
 
 /**
  * performs a session_ctx_logout_event() call for each item in the table
@@ -52,7 +50,7 @@ void session_table_login_event(session_table *s_table, CK_USER_TYPE user, sessio
  * @param called_session
  *  The session context that the logout event occured on.
  */
-void session_table_logout_event(session_table *s_table, session_ctx *called_session);
+void token_logout_all_sessions(token *tok);
 
 
 #endif /* SRC_PKCS11_SESSION_TABLE_H_ */

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -68,7 +68,8 @@ static CK_RV common_init(operation op, CK_SESSION_HANDLE session, CK_MECHANISM_P
     uint32_t sequence_handle = 0;
     bool do_hash = is_hashing_needed(mechanism->mechanism);
     if (do_hash) {
-        tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+        token *tok = session_ctx_get_tok(ctx);
+        tpm_ctx *tpm = tok->tctx;
         rv = tpm_hash_init(tpm, mechanism->mechanism, &sequence_handle);
         if (rv != CKR_OK) {
             goto out;
@@ -134,7 +135,8 @@ static CK_RV common_update(operation op, CK_SESSION_HANDLE session, unsigned cha
     }
 
     if (opdata->do_hash) {
-        tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+        token *tok = session_ctx_get_tok(ctx);
+        tpm_ctx *tpm = tok->tctx;
         rv = tpm_hash_update(tpm, opdata->sequence_handle, part, part_len);
         if (rv != CKR_OK) {
             goto out;
@@ -195,7 +197,9 @@ CK_RV sign_final (CK_SESSION_HANDLE session, unsigned char *signature, unsigned 
         goto session_out;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
+
     /*
      * Double checking of opdata to silence scan-build
      */
@@ -324,7 +328,8 @@ CK_RV verify_final (CK_SESSION_HANDLE session, unsigned char *signature, unsigne
         goto out;
     }
 
-    tpm_ctx *tpm = session_ctx_get_tpm_ctx(ctx);
+    token *tok = session_ctx_get_tok(ctx);
+    tpm_ctx *tpm = tok->tctx;
 
     // TODO mode to buffer size
     CK_BYTE hash[1024];

--- a/src/lib/sign.h
+++ b/src/lib/sign.h
@@ -8,20 +8,22 @@
 
 #include "pkcs11.h"
 
-CK_RV sign_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+typedef struct token token;
 
-CK_RV sign_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len);
+CK_RV sign_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV sign_final (CK_SESSION_HANDLE session, unsigned char *signature, unsigned long *signature_len);
+CK_RV sign_update(token *tok, unsigned char *part, unsigned long part_len);
 
-CK_RV sign (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long *signature_len);
+CK_RV sign_final(token *tok, unsigned char *signature, unsigned long *signature_len);
 
-CK_RV verify_init (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+CK_RV sign(token *tok, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long *signature_len);
 
-CK_RV verify_update (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len);
+CK_RV verify_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV verify_final (CK_SESSION_HANDLE session, unsigned char *signature, unsigned long signature_len);
+CK_RV verify_update(token *tok, unsigned char *part, unsigned long part_len);
 
-CK_RV verify (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len);
+CK_RV verify_final(token *tok, unsigned char *signature, unsigned long signature_len);
+
+CK_RV verify(token *tok, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len);
 
 #endif

--- a/src/lib/slot.h
+++ b/src/lib/slot.h
@@ -9,7 +9,8 @@
 #include <stdbool.h>
 
 #include "pkcs11.h"
-#include "token.h"
+
+typedef struct token token;
 
 #define SLOT_ID 0x1234
 

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -121,3 +121,227 @@ CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info) {
 
     return CKR_OK;
 }
+
+bool token_is_any_user_logged_in(token *tok) {
+
+    return tok->login_state != token_no_one_logged_in;
+}
+
+CK_RV token_logout(token *tok) {
+
+    bool is_anyone_logged_in = token_is_any_user_logged_in(tok);
+    if (!is_anyone_logged_in) {
+        return CKR_USER_NOT_LOGGED_IN;
+    }
+
+    /*
+     * Ok now start evicting TPM objects from the right
+     * context
+     */
+    tpm_ctx *tpm = tok->tctx;
+
+    // Evict the keys
+    sobject *sobj = &tok->sobject;
+
+    if (tok->tobjects) {
+
+        list *cur = &tok->tobjects->l;
+        while(cur) {
+            tobject *tobj = list_entry(cur, tobject, l);
+            cur = cur->next;
+            if (tobj->handle) {
+                bool result = tpm_flushcontext(tpm, tobj->handle);
+                assert(result);
+                UNUSED(result);
+                tobj->handle = 0;
+
+                /* Clear the unwrapped auth value for tertiary objects */
+                twist_free(tobj->unsealed_auth);
+                tobj->unsealed_auth = NULL;
+            }
+        }
+    }
+
+    // Evict the wrapping object
+    wrappingobject *wobj = &tok->wrappingobject;
+    if (tok->config.sym_support) {
+        bool result = tpm_flushcontext(tpm, wobj->handle);
+        assert(result);
+        UNUSED(result);
+    }
+    twist_free(wobj->objauth);
+    wobj->objauth = NULL;
+    wobj->handle = 0;
+
+    // Evict the secondary object
+    bool result = tpm_flushcontext(tpm, sobj->handle);
+    assert(result);
+    UNUSED(result);
+    sobj->handle = 0;
+
+    // Kill primary object auth data
+    pobject *pobj = &tok->pobject;
+    twist_free(pobj->objauth);
+    pobj->objauth = NULL;
+
+    /*
+     * State transition all sessions in the table
+     */
+    token_logout_all_sessions(tok);
+
+    /*
+     * mark no one logged in
+     */
+    tok->login_state = token_no_one_logged_in;
+
+    return CKR_OK;
+}
+
+CK_RV token_login(token *tok, twist pin, CK_USER_TYPE user) {
+
+    twist sealobjauth = NULL;
+    twist dpobjauth = NULL;
+
+    CK_RV rv = CKR_GENERAL_ERROR;
+
+    bool is_anyone_logged_in = token_is_any_user_logged_in(tok);
+    if (is_anyone_logged_in) {
+        return CKR_USER_ALREADY_LOGGED_IN;
+    }
+
+    unsigned long ro;
+    session_table_get_cnt(tok->s_table, NULL, NULL, &ro);
+
+    if (user == CKU_SO && ro) {
+        return CKR_SESSION_READ_ONLY_EXISTS;
+    }
+
+
+    /*
+     * To login, we need to use PIN against the correct seal object.
+     * Load that seal object, and use tpm2_unseal to extract the
+     * wrapping key auth. Also, load the wrapping key and secondary object.
+     * Then on actual key operation, we can load the tertiary object.
+     */
+
+    /* derive the primary object auth for loading the sealed and wrapping key up */
+    unsigned pobjiters = user == CKU_USER ? tok->userpobjauthkeyiters : tok->sopobjauthkeyiters;
+    twist pobjsalt = user == CKU_USER ? tok->userpobjauthkeysalt : tok->sopobjauthkeysalt;
+    twist pobjauth = user == CKU_USER ? tok->userpobjauth : tok->sopobjauth;
+
+    dpobjauth = decrypt(pin, pobjsalt, pobjiters, pobjauth);
+    if (!dpobjauth) {
+        return CKR_PIN_INCORRECT;
+    }
+
+    tok->pobject.objauth = dpobjauth;
+
+    tpm_ctx *tpm = tok->tctx;
+
+    /* load seal object */
+    sealobject *sealobj = &tok->sealobject;
+    twist sealpub = user == CKU_USER ? sealobj->userpub : sealobj->sopub;
+    twist sealpriv = user == CKU_USER ? sealobj->userpriv : sealobj->sopriv;
+
+    uint32_t pobj_handle = tok->pobject.handle;
+
+    // TODO evict sealobjhandle
+    uint32_t sealobjhandle;
+    bool res = tpm_loadobj(tpm, pobj_handle, dpobjauth, sealpub, sealpriv, &sealobjhandle);
+    if (!res) {
+        goto error;
+    }
+
+    /* derive the sealed obj auth for use in tpm_unseal to get the wrapping key auth*/
+    unsigned sealiters = user == CKU_USER ? sealobj->userauthiters : sealobj->soauthiters;
+    twist sealsalt = user == CKU_USER ? sealobj->userauthsalt : sealobj->soauthsalt;
+    sealobjauth = utils_pdkdf2_hmac_sha256_raw(pin, sealsalt, sealiters);
+    if (!sealobjauth) {
+        rv = CKR_HOST_MEMORY;
+        goto error;
+    }
+
+    wrappingobject *wobj = &tok->wrappingobject;
+    twist wobjauth = tpm_unseal(tpm, sealobjhandle, sealobjauth);
+    if (!wobjauth) {
+        goto error;
+    }
+
+    /*
+     * If SW objauth unwrapping is enabled, we use the
+     * unsealed value as the key, else we use the TPM
+     * wrapping key directly.
+     *
+     * The SW version of unsealed auth shall remain in
+     * hex form where as the direct form shouldn't.
+     *
+     */
+    if (tok->config.sym_support) {
+        wobj->objauth = twistbin_unhexlify(wobjauth);
+        twist_free(wobjauth);
+        if (!wobj->objauth) {
+            LOGE("Could not unhexlify wrapping object auth");
+            goto error;
+        }
+
+        /* load the wrapping key */
+        res = tpm_loadobj(tpm, pobj_handle, dpobjauth, wobj->pub, wobj->priv, &wobj->handle);
+        if (!res) {
+            goto error;
+        }
+    } else {
+        wobj->objauth = wobjauth;
+    }
+
+    /* load the secondary object */
+    sobject *sobj = &tok->sobject;
+    res = tpm_loadobj(tpm, pobj_handle, dpobjauth, sobj->pub, sobj->priv, &sobj->handle);
+    if (!res) {
+        goto error;
+    }
+
+    /*
+     * Indicate that the token has been logged in
+     */
+    tok->login_state = user == CKU_USER ? token_user_logged_in : token_so_logged_in;
+
+    /*
+     * State transition all *EXISTING* sessions in the table
+     */
+    session_table_login_event(tok->s_table, user);
+
+    rv = CKR_OK;
+
+error:
+
+    twist_free(sealobjauth);
+
+    return rv;
+}
+
+bool token_opdata_is_active(token *tok) {
+
+    return tok->opdata.op != operation_none;
+}
+
+void token_opdata_set(token *tok, operation op, void *data) {
+
+    tok->opdata.op = op;
+    tok->opdata.data = data;
+}
+
+void token_opdata_clear(token *tok) {
+
+    token_opdata_set(tok, operation_none, NULL);
+}
+
+CK_RV _token_opdata_get(token *tok, operation op, void **data) {
+
+    if (op != tok->opdata.op) {
+        return CKR_OPERATION_NOT_INITIALIZED;
+    }
+
+    *data = tok->opdata.data;
+
+    return CKR_OK;
+}

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -53,14 +53,13 @@ void token_free(token *t) {
     }
 
     tpm_ctx_free(t->tctx);
+
+    mutex_destroy(t->mutex);
 }
 
-CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info) {
+CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {
 
     check_pointer(info);
-
-    token *t;
-    check_slot_id(slot_id, t,CKR_SLOT_ID_INVALID);
 
     const unsigned char token_sn[]   = TPM2_TOKEN_SERIAL_NUMBER;
     const unsigned char token_manuf[]  = TPM2_TOKEN_MANUFACTURER;
@@ -122,7 +121,7 @@ CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info) {
     return CKR_OK;
 }
 
-bool token_is_any_user_logged_in(token *tok) {
+static bool token_is_any_user_logged_in(token *tok) {
 
     return tok->login_state != token_no_one_logged_in;
 }
@@ -345,3 +344,12 @@ CK_RV _token_opdata_get(token *tok, operation op, void **data) {
 
     return CKR_OK;
 }
+
+void token_lock(token *t) {
+    mutex_lock_fatal(t->mutex);
+}
+
+void token_unlock(token *t) {
+    mutex_unlock_fatal(t->mutex);
+}
+

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -16,6 +16,7 @@
 #include "session.h"
 #include "session_table.h"
 #include "slot.h"
+#include "tpm.h"
 #include "token.h"
 #include "utils.h"
 
@@ -50,6 +51,8 @@ void token_free(token *t) {
             tobject_free(tobj);
         }
     }
+
+    tpm_ctx_free(t->tctx);
 }
 
 CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -6,8 +6,10 @@
 #ifndef SRC_TOKEN_H_
 #define SRC_TOKEN_H_
 
+#include "checks.h"
 #include "object.h"
 #include "pkcs11.h"
+#include "session_ctx.h"
 #include "tpm.h"
 #include "twist.h"
 #include "utils.h"
@@ -76,6 +78,8 @@ struct token {
     tpm_ctx *tctx;
 
     generic_opdata opdata;
+
+    void *mutex;
 };
 
 /**
@@ -94,7 +98,7 @@ void token_free(token *t);
  */
 void token_free_list(token *t, size_t len);
 
-CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info);
+CK_RV token_get_info(token *t, CK_TOKEN_INFO *info);
 
 /**
  * Causes a login event to be propagated through the token
@@ -125,15 +129,6 @@ CK_RV token_login(token *tok, twist pin, CK_USER_TYPE user);
  *  CKR_OK on success, anything else is a failure.
  */
 CK_RV token_logout(token *tok);
-
-/**
- * True if ANY user is logged into the card, including SO.
- * @param tok
- *  The token to check.
- * @return
- *  true if anyone is logged in.
- */
-bool token_is_any_user_logged_in(token *tok);
 
 /**
  * Determines if the opdata is in use
@@ -179,5 +174,8 @@ void token_opdata_clear(token *tok);
  */
 #define token_opdata_get(ctx, op, data) _token_opdata_get(ctx, op, (void **)data)
 CK_RV _token_opdata_get(token *tok, operation op, void **data);
+
+void token_lock(token *t);
+void token_unlock(token *t);
 
 #endif /* SRC_TOKEN_H_ */

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -15,11 +15,29 @@
 typedef struct session_table session_table;
 typedef struct session_ctx session_ctx;
 
+typedef enum operation operation;
+enum operation {
+    operation_none = 0,
+    operation_find,
+    operation_sign,
+    operation_verify,
+    operation_encrypt,
+    operation_decrypt,
+    operation_digest,
+    operation_count
+};
+
 typedef enum token_login_state token_login_state;
 enum token_login_state {
     token_no_one_logged_in = 0,
     token_user_logged_in   = 1 << 0,
     token_so_logged_in     = 1 << 1,
+};
+
+typedef struct generic_opdata generic_opdata;
+struct generic_opdata {
+    operation op;
+    void *data;
 };
 
 typedef struct token token;
@@ -55,15 +73,111 @@ struct token {
 
     token_login_state login_state;
 
-    session_ctx *login_session_ctx;
-
     tpm_ctx *tctx;
+
+    generic_opdata opdata;
 };
 
+/**
+ * Frees a token
+ * @param t
+ *  The token to free
+ */
 void token_free(token *t);
 
+/**
+ * Free's a list of tokens
+ * @param t
+ *  The token list to free
+ * @param len
+ *  The number of elements to free
+ */
 void token_free_list(token *t, size_t len);
 
 CK_RV token_get_info (CK_SLOT_ID slot_id, CK_TOKEN_INFO *info);
+
+/**
+ * Causes a login event to be propagated through the token
+ * associated with the session context. A login event is
+ * Propagated by:
+ *   1. setting the token level who is logged in state with whom is logged in.
+ *   2. updating all open session states in the session table
+ * @param ctx
+ *  The session context to update
+ * @param pin
+ *  The pin
+ * @param user
+ *  The user
+ * @return
+ *  CKR_OK on success, anything else is a failure.
+ */
+CK_RV token_login(token *tok, twist pin, CK_USER_TYPE user);
+
+/**
+ * Generates a logout event to be propagated through the token.
+ * A logout event is propagated by:
+ *   1. setting the token level "who is logged in state" to no one is logged in.
+ *   2. setting all existing sessions back to their original state.
+ *
+ * @param tok
+ *  The token to propagate the login event
+ * @return
+ *  CKR_OK on success, anything else is a failure.
+ */
+CK_RV token_logout(token *tok);
+
+/**
+ * True if ANY user is logged into the card, including SO.
+ * @param tok
+ *  The token to check.
+ * @return
+ *  true if anyone is logged in.
+ */
+bool token_is_any_user_logged_in(token *tok);
+
+/**
+ * Determines if the opdata is in use
+ * @param ctx
+ *  The token
+ * @return
+ */
+bool token_opdata_is_active(token *tok);
+
+/**
+ * Sets operational specific data. Callers should take care to ensure
+ * no other users are using it by calling token_opdata_is_active()
+ * before setting the data.
+ *
+ * @param tok
+ *  The token to set operational data on
+ * @param op
+ *  The operation setting the data
+ * @param data
+ *  The data to set
+ */
+void token_opdata_set(token *tok, operation op, void *data);
+
+/**
+ * Clears the token opdata state. NOTE that callers
+ * are required to perfrom memory managment on what
+ * is stored in the void pointer.
+ * @param tok
+ *  The token to clear operational data from.
+ */
+void token_opdata_clear(token *tok);
+
+/**
+ * Sets the operation specific state data
+ * @param tok
+ *  The token to set the operation state data
+ * @param op
+ *  The operation setting it
+ * @param data
+ *  The data to set
+ * @return
+ *  CKR_OK on success.
+ */
+#define token_opdata_get(ctx, op, data) _token_opdata_get(ctx, op, (void **)data)
+CK_RV _token_opdata_get(token *tok, operation op, void **data);
 
 #endif /* SRC_TOKEN_H_ */

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -56,6 +56,8 @@ struct token {
     token_login_state login_state;
 
     session_ctx *login_session_ctx;
+
+    tpm_ctx *tctx;
 };
 
 void token_free(token *t);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -456,8 +456,6 @@ bool tpm_loadobj(
         twist pub_path, twist priv_path,
         uint32_t *handle) {
 
-    bool rc = false;
-
     TPM2B_PRIVATE priv = { .size = 0 };
     bool res = files_load_private(priv_path, &priv);
     if (!res) {
@@ -700,8 +698,6 @@ bool tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_BYTE_PTR data, CK_ULONG datalen,
 
 CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_handle) {
 
-    CK_RV rv = CKR_GENERAL_ERROR;
-
     TPM2B_AUTH null_auth = TPM2B_EMPTY_INIT;
 
     TPMI_ALG_HASH halg = mech_to_hash_alg(mode);
@@ -867,8 +863,6 @@ CK_RV tpm_rsa_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech,
 
 static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_MECHANISM_TYPE mode, TPMI_YES_NO is_decrypt,
         twist iv_in, twist data_in, twist *data_out, twist *iv_out) {
-
-    CK_RV rc = CKR_GENERAL_ERROR;
 
     TPMI_ALG_SYM_MODE tpm_mode;
     switch(mode) {

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -19,6 +19,11 @@
 #include "tcti_ldr.h"
 #include "tpm.h"
 
+struct tpm_ctx {
+    TSS2_TCTI_CONTEXT *tcti_ctx;
+    ESYS_CONTEXT *esys_ctx;
+};
+
 #define TPM2B_INIT(xsize) { .size = xsize, }
 #define TPM2B_EMPTY_INIT TPM2B_INIT(0)
 
@@ -119,15 +124,6 @@ struct tpm2_hierarchy_pdata {
     }, \
 }
 
-static inline ESYS_CONTEXT *from_ctx(tpm_ctx *ctx) {
-    return (ESYS_CONTEXT *)ctx;
-}
-
-static inline tpm_ctx *to_ctx(ESYS_CONTEXT *sys) {
-    return (tpm_ctx *)sys;
-}
-
-
 #define SUPPORTED_ABI_VERSION \
 { \
     .tssCreator = 1, \
@@ -150,90 +146,46 @@ static ESYS_CONTEXT* esys_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
     return esys_ctx;
 }
 
-static void tcti_teardown (TSS2_TCTI_CONTEXT *tcti_context) {
-
-    Tss2_Tcti_Finalize(tcti_context);
-    free(tcti_context);
-}
-
-static void esys_teardown (ESYS_CONTEXT *esys_ctx) {
-
-    Esys_Finalize(&esys_ctx);
-}
-
-static struct {
-    unsigned long tcti_cnt;
-    void *tcti_mutex;
-    TSS2_TCTI_CONTEXT *tcti;
-    TPM2_HANDLE phandle;
-} global;
-
-static void lock_tcti(void) {
-    mutex_lock_fatal(global.tcti_mutex);
-}
-
-static void unlock_tcti(void) {
-    mutex_unlock_fatal(global.tcti_mutex);
-}
-
-CK_RV tpm_init(void) {
-
-    return mutex_create(&global.tcti_mutex);
-}
-
-void tpm_destroy(void) {
-
-    mutex_destroy(global.tcti_mutex);
-    global.tcti_mutex = NULL;
-}
-
-static void tpm_tcti_free_unlocked(void) {
-
-    assert(global.tcti_cnt);
-
-    global.tcti_cnt--;
-    if (!global.tcti_cnt) {
-        tcti_teardown (global.tcti);
-        global.tcti = NULL;
-    }
-}
-
-static bool tpm_ctx_new_unlocked(void) {
-
-    if (!global.tcti) {
-        global.tcti = tcti_ldr_load();
-    }
-
-    global.tcti_cnt++;
-
-    return global.tcti ? true : false;
-}
-
 void tpm_ctx_free(tpm_ctx *ctx) {
 
-    esys_teardown (from_ctx(ctx));
-    tpm_tcti_free_unlocked();
+    Esys_Finalize(&ctx->esys_ctx);
+    Tss2_Tcti_Finalize(ctx->tcti_ctx);
+    free(ctx->tcti_ctx);
+    free(ctx);
 }
 
-tpm_ctx *tpm_ctx_new(void) {
+CK_RV tpm_ctx_new(tpm_ctx **tctx) {
 
-    ESYS_CONTEXT *sys = NULL;
+    ESYS_CONTEXT *esys = NULL;
+    TSS2_TCTI_CONTEXT *tcti = NULL;
 
-    lock_tcti();
-    bool res = tpm_ctx_new_unlocked();
-    if (!res) {
-        goto unlock;
+    tpm_ctx *t = calloc(1, sizeof(*t));
+    if (!t) {
+        return CKR_HOST_MEMORY;
     }
 
-    sys = esys_ctx_init(global.tcti);
-    if (!sys) {
-        tpm_tcti_free_unlocked();
-        goto unlock;
+    tcti = tcti_ldr_load();
+    if (!tcti) {
+        goto error;
     }
 
-unlock:
-    unlock_tcti();
-    return to_ctx(sys);
+    esys = esys_ctx_init(tcti);
+    if (!esys) {
+        goto error;
+    }
+
+    /* populate */
+    t->esys_ctx = esys;
+    t->tcti_ctx = tcti;
+
+    /* assign back (return via pointer) */
+    *tctx = t;
+
+    return CKR_OK;
+
+error:
+    tpm_ctx_free(t);
+    return CKR_GENERAL_ERROR;
 }
 
 bool files_get_file_size(FILE *fp, unsigned long *file_size, const char *path) {
@@ -385,10 +337,6 @@ bool tpm_getrandom(tpm_ctx *ctx, BYTE *data, size_t size) {
 
     bool result = false;
 
-    lock_tcti();
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
     /*
      * This will get re-used once allocated by esys
      */
@@ -400,7 +348,7 @@ bool tpm_getrandom(tpm_ctx *ctx, BYTE *data, size_t size) {
                 sizeof(rand_bytes->buffer) : size;
 
         TSS2_RC rval = Esys_GetRandom(
-            esys_ctx,
+            ctx->esys_ctx,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
@@ -421,7 +369,6 @@ bool tpm_getrandom(tpm_ctx *ctx, BYTE *data, size_t size) {
 
 out:
     free(rand_bytes);
-    unlock_tcti();
 
     return result;
 }
@@ -429,10 +376,6 @@ out:
 CK_RV tpm_stirrandom(tpm_ctx *ctx, unsigned char *seed, unsigned long seed_len) {
 
     TSS2_RC rc = TSS2_TCTI_RC_GENERAL_FAILURE;;
-
-    lock_tcti();
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
 
     size_t offset = 0;
     while(offset < seed_len) {
@@ -445,33 +388,29 @@ CK_RV tpm_stirrandom(tpm_ctx *ctx, unsigned char *seed, unsigned long seed_len) 
         memcpy(stir.buffer, &seed[offset], chunk);
 
         rc = Esys_StirRandom(
-            esys_ctx,
+            ctx->esys_ctx,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             &stir);
         if (rc != TSS2_RC_SUCCESS) {
             LOGE("Esys_StirRandom: 0x%x:", rc);
-            goto out;
+            return CKR_GENERAL_ERROR;
         }
 
         offset += seed_len;
     }
 
-out:
-    unlock_tcti();
-    return rc == TSS2_RC_SUCCESS ? CKR_OK : CKR_GENERAL_ERROR;
+    return CKR_OK;
 }
 
 bool tpm_register_handle(tpm_ctx *ctx, uint32_t *handle) {
 
     ESYS_TR object;
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
     TSS2_RC rval =
         Esys_TR_FromTPMPublic(
-            esys_ctx,
+            ctx->esys_ctx,
             *handle,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
@@ -531,17 +470,13 @@ bool tpm_loadobj(
         return false;
     }
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
-    bool tmp_rc = set_esys_auth(esys_ctx, phandle, auth);
+    bool tmp_rc = set_esys_auth(ctx->esys_ctx, phandle, auth);
     if (!tmp_rc) {
         return false;
     }
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_Load(
-               esys_ctx,
+               ctx->esys_ctx,
                phandle,
                ESYS_TR_PASSWORD,
                ESYS_TR_NONE,
@@ -551,26 +486,17 @@ bool tpm_loadobj(
                handle);
     if (rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_Load: 0x%x:", rval);
-        goto out;
+        return false;
     }
 
-    rc = true;
-
-out:
-    unlock_tcti();
-    return rc;
+    return true;
 }
 
 bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle) {
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
-    lock_tcti();
-
     TSS2_RC rval = Esys_FlushContext(
-                esys_ctx,
+                ctx->esys_ctx,
                 handle);
-    unlock_tcti();
     if (rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_FlushContext: 0x%x", rval);
         return false;
@@ -637,19 +563,15 @@ twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth) {
 
     twist t = NULL;
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
-    bool result = set_esys_auth(esys_ctx, handle, objauth);
+    bool result = set_esys_auth(ctx->esys_ctx, handle, objauth);
     if (!result) {
         return false;
     }
 
     TPM2B_SENSITIVE_DATA *unsealed_data = NULL;
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_Unseal(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -657,12 +579,11 @@ twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth) {
             &unsealed_data);
     if (rval != TPM2_RC_SUCCESS) {
         LOGE("Tss2_Sys_Unseal: 0x%X", rval);
-        goto out;
+        return NULL;
     }
 
     t = twistbin_new(unsealed_data->buffer, unsealed_data->size);
-out:
-    unlock_tcti();
+
     free(unsealed_data);
 
     return t;
@@ -670,14 +591,10 @@ out:
 
 bool tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG_PTR siglen) {
 
-    bool rv = false;
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
     twist auth = tobj->unsealed_auth;
     TPMI_DH_OBJECT handle = tobj->handle;
 
-    bool result = set_esys_auth(esys_ctx, handle, auth);
+    bool result = set_esys_auth(ctx->esys_ctx, handle, auth);
     if (!result) {
         return false;
     }
@@ -704,7 +621,7 @@ bool tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR d
 
     TPMT_SIGNATURE *signature = NULL;
     TSS2_RC rval = Esys_Sign(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -719,7 +636,7 @@ bool tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR d
     }
 
     if (*siglen <  sizeof(signature->signature.rsassa.sig.size)) {
-        goto out;
+        return false;
     }
 
     assert(signature->sigAlg == TPM2_ALG_RSASSA);
@@ -727,25 +644,17 @@ bool tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR d
     *siglen = signature->signature.rsassa.sig.size;
     memcpy(sig, signature->signature.rsassa.sig.buffer, *siglen);
 
-    rv = true;
-
-out:
-    unlock_tcti();
     free(signature);
 
-    return rv;
+    return true;
 }
 
 bool tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG siglen) {
 
-    bool rc = false;
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
     twist auth = tobj->unsealed_auth;
     TPMI_DH_OBJECT handle = tobj->handle;
 
-    bool tmp_rc = set_esys_auth(esys_ctx, handle, auth);
+    bool tmp_rc = set_esys_auth(ctx->esys_ctx, handle, auth);
     if (tmp_rc) {
         return false;
     }
@@ -771,10 +680,8 @@ bool tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_BYTE_PTR data, CK_ULONG datalen,
 
     TPMT_TK_VERIFIED *validation = NULL;
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_VerifySignature(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -784,22 +691,16 @@ bool tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_BYTE_PTR data, CK_ULONG datalen,
             &validation);
     if (rval != TPM2_RC_SUCCESS) {
         LOGE("Esys_VerifySignature: 0x%x", rval);
-        goto out;
+        return false;
     }
 
-    rc = true;
-
-out:
-    unlock_tcti();
     free(validation);
-    return rc;
+    return true;
 }
 
 CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_handle) {
 
     CK_RV rv = CKR_GENERAL_ERROR;
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
 
     TPM2B_AUTH null_auth = TPM2B_EMPTY_INIT;
 
@@ -812,10 +713,8 @@ CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_han
         return CKR_OK;
     }
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_HashSequenceStart(
-            esys_ctx,
+            ctx->esys_ctx,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
@@ -824,23 +723,13 @@ CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_han
             sequence_handle);
     if (rval != TPM2_RC_SUCCESS) {
         LOGE("Esys_HashSequenceStart: 0x%x", rval);
-        goto out;
+        return CKR_GENERAL_ERROR;
     }
 
-    rv = CKR_OK;
-
-out:
-    unlock_tcti();
-    return rv;
+    return CKR_OK;
 }
 
 CK_RV tpm_hash_update(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG data_len) {
-
-    CK_RV rc = CKR_GENERAL_ERROR;
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
-    lock_tcti();
 
     size_t offset = 0;
     while(offset < data_len) {
@@ -853,7 +742,7 @@ CK_RV tpm_hash_update(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, 
         memcpy(buffer.buffer, &data[offset], send);
 
         TSS2_RC rval = Esys_SequenceUpdate(
-                    esys_ctx,
+                    ctx->esys_ctx,
                     sequence_handle,
                     ESYS_TR_PASSWORD,
                     ESYS_TR_NONE,
@@ -861,34 +750,24 @@ CK_RV tpm_hash_update(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, 
                     &buffer);
         if (rval != TPM2_RC_SUCCESS) {
             LOGE("Esys_SequenceUpdate: 0x%x", rval);
-            goto out;
+            return CKR_GENERAL_ERROR;
         }
 
         offset += send;
     }
 
-    rc = CKR_OK;
-
-out:
-    unlock_tcti();
-    return rc;
+    return CKR_OK;
 }
 
 CK_RV tpm_hash_final(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG_PTR data_len) {
-
-    CK_RV rc = CKR_GENERAL_ERROR;
-
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
 
     TPM2B_MAX_BUFFER no_data = { .size = 0 };
 
     TPMT_TK_HASHCHECK *validation = NULL;
     TPM2B_DIGEST *result = NULL;
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_SequenceComplete(
-            esys_ctx,
+            ctx->esys_ctx,
             sequence_handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -899,25 +778,20 @@ CK_RV tpm_hash_final(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, C
             &validation);
     if (rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_SequenceComplete: 0x%x", rval);
-        goto out;
+        return CKR_GENERAL_ERROR;
     }
 
     if (*data_len < result->size) {
-        rc = CKR_BUFFER_TOO_SMALL;
-        goto out;
+        return CKR_BUFFER_TOO_SMALL;
     }
 
     *data_len = result->size;
     memcpy(data, result->buffer, result->size);
 
-    rc = CKR_OK;
-
-out:
-    unlock_tcti();
     free(result);
     free(validation);
 
-    return rc;
+    return CKR_OK;
 }
 
 TPM2_ALG_ID mech_to_rsa_dec_alg(CK_MECHANISM_TYPE mech) {
@@ -936,8 +810,6 @@ CK_RV tpm_rsa_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech,
         CK_BYTE_PTR ctext, CK_ULONG ctextlen,
         CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen) {
 
-    CK_RV rc = CKR_GENERAL_ERROR;
-
     TPM2_ALG_ID alg = mech_to_rsa_dec_alg(mech);
     if (alg == TPM2_ALG_ERROR) {
         return CKR_ARGUMENTS_BAD;
@@ -954,25 +826,20 @@ CK_RV tpm_rsa_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech,
     }
     memcpy(tpm_ctext.buffer, ctext, ctextlen);
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-
     twist auth = tobj->unsealed_auth;
     ESYS_TR handle = tobj->handle;
-    bool result = set_esys_auth(esys_ctx, handle, auth);
+    bool result = set_esys_auth(ctx->esys_ctx, handle, auth);
     if (!result) {
         return CKR_GENERAL_ERROR;
     }
 
     TPMT_RSA_DECRYPT scheme  = { .scheme = alg };
 
-
     TPM2B_DATA label = TPM2B_EMPTY_INIT;
     TPM2B_PUBLIC_KEY_RSA *tpm_ptext;
 
-    lock_tcti();
-
     TSS2_RC rval = Esys_RSA_Decrypt(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -983,24 +850,19 @@ CK_RV tpm_rsa_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech,
             &tpm_ptext);
     if (rval != TPM2_RC_SUCCESS) {
         LOGE("Esys_RSA_Decrypt: 0x%x", rval);
-        goto out;
+        return CKR_GENERAL_ERROR;
     }
 
     if (*ptextlen < tpm_ctext.size) {
-        rc = CKR_BUFFER_TOO_SMALL;
-        goto out;
+        return CKR_BUFFER_TOO_SMALL;
     }
 
     *ptextlen = tpm_ptext->size;
     memcpy(ptext, tpm_ptext->buffer, tpm_ptext->size);
 
-    rc = CKR_OK;
-
-out:
-    unlock_tcti();
     free(tpm_ptext);
 
-    return rc;
+    return CKR_OK;
 }
 
 static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_MECHANISM_TYPE mode, TPMI_YES_NO is_decrypt,
@@ -1024,8 +886,7 @@ static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_ME
         return CKR_ARGUMENTS_BAD;
     }
 
-    ESYS_CONTEXT *esys_ctx = from_ctx(ctx);
-    bool result = set_esys_auth(esys_ctx, handle, objauth);
+    bool result = set_esys_auth(ctx->esys_ctx, handle, objauth);
     if (!result) {
         return CKR_GENERAL_ERROR;
     }
@@ -1060,13 +921,11 @@ static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_ME
     TPM2B_MAX_BUFFER *tpm_data_out = NULL;
     TPM2B_IV *tpm_iv_out = NULL;
 
-    lock_tcti();
-
     unsigned version = 2;
 
     TSS2_RC rval =
         Esys_EncryptDecrypt2(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -1081,7 +940,7 @@ static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_ME
     if (tpm2_error_get(rval) == TPM2_RC_COMMAND_CODE) {
         version = 1;
         rval = Esys_EncryptDecrypt(
-            esys_ctx,
+            ctx->esys_ctx,
             handle,
             ESYS_TR_PASSWORD,
             ESYS_TR_NONE,
@@ -1096,14 +955,14 @@ static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_ME
 
     if(rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_EncryptDecrypt%u: 0x%x", version, rval);
-        goto out;
+        return CKR_GENERAL_ERROR;
     }
 
     /* copy output data from tpm into twist types */
     if (iv_out) {
         *iv_out = twistbin_new(tpm_iv_out->buffer, tpm_iv_out->size);
         if (!*iv_out) {
-            goto out;
+            return CKR_HOST_MEMORY;
         }
     }
 
@@ -1112,17 +971,13 @@ static CK_RV encrypt_decrypt(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_ME
         if (iv_out) {
             twist_free(*iv_out);
         }
-        goto out;
+        return CKR_HOST_MEMORY;
     }
 
-    rc = CKR_OK;
-
-out:
-    unlock_tcti();
     free(tpm_data_out);
     free(tpm_iv_out);
 
-    return rc;
+    return CKR_OK;
 }
 
 /*

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -16,17 +16,6 @@
 typedef struct tpm_ctx tpm_ctx;
 
 /**
- * Initializes the tpm subsytem
- * @return
- */
-CK_RV tpm_init(void);
-
-/**
- * Frees the tpm subsystem
- */
-void tpm_destroy(void);
-
-/**
  * Destroys the system API context, and when the refcnt
  * hits 0 for the tcti context, destroys it as well.
  * @param ctx
@@ -36,13 +25,14 @@ void tpm_destroy(void);
 void tpm_ctx_free(tpm_ctx *ctx);
 
 /**
- * Initializes the system API context, and increments the refcnt
- * for the tcti context, destroys it as well.
- * @param sys
- *  The system API context
- * @note: NOT THREAD SAFE: Assumes session table lock held
+ * Creates a new tpm_ctx with it's own ESAPI
+ * and TCTI contexts internally.
+ * @param tctx
+ *  The tpm_ctx to create.
+ * @return
+ *  CJR_OK on success, anything else is a failure.
  */
-tpm_ctx *tpm_ctx_new(void);
+CK_RV tpm_ctx_new(tpm_ctx **tctx);
 
 /**
  * Generates random bytes from the TPM

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -35,6 +35,178 @@
         return _rc;\
     } while (0)
 
+/**
+ * Interface to calling into the internal interface from a cryptoki
+ * routine that takes slot id. Performs all locking on token.
+ *
+ * @note
+ *  - Requires a CK_RV rv to be declared.
+ *  - Performs **NO** auth checking. The slot routines implemented
+ *    do not need a particular state AFAIK.
+ *  - manages token locking
+ *
+ * @param userfun
+ *  The userfunction to call, ie the internal API.
+ * @param ...
+ *  The arguments to the internal API call from cryptoki.
+ * @return
+ *  The internal API's result as rv.
+ */
+#define TOKEN_WITH_LOCK_BY_SLOT(userfunc, slot, ...) \
+do { \
+    \
+    check_is_init(); \
+    \
+    token *t = slot_get_token(slot); \
+    if (!t) { \
+        return CKR_SLOT_ID_INVALID; \
+    } \
+    \
+    token_lock(t); \
+    rv = userfunc(t, ##__VA_ARGS__); \
+    token_unlock(t); \
+} while (0)
+
+/**
+ * Raw interface (DO NOT USE DIRECTLY) for calling into the internal interface from a cryptoki
+ * routine that takes a session handle. Performs all locking on token.
+ *
+ * @note
+ *  - Requires a CK_RV rv to be declared.
+ *  - do not use directly, use the ones with auth model.
+ *  - manages token locking
+ *
+ * @param userfun
+ *  The userfunction to call, ie the internal API.
+ * @param ...
+ *  The arguments to the internal API call from cryptoki.
+ * @return
+ *  The internal API's result as rv.
+ */
+#define __TOKEN_WITH_LOCK_BY_SESSION(authfn, userfunc, session, ...) \
+do { \
+    \
+    check_is_init(); \
+    \
+    token *t = NULL; \
+    session_ctx *ctx = NULL; \
+    rv = session_lookup(session, &t, &ctx); \
+    if (rv != CKR_OK) { \
+        return rv; \
+    } \
+    \
+    rv = authfn(ctx); \
+    if (rv != CKR_OK) { \
+        token_unlock(t); \
+        return rv; \
+    } \
+    rv = userfunc(t, ##__VA_ARGS__); \
+    token_unlock(t); \
+} while (0)
+
+/*
+ * Same as: __TOKEN_WITH_LOCK_BY_SESSION but hands the session_ctx to the internal routine.
+ */
+#define __TOKEN_WITH_LOCK_BY_SESSION_KEEP_CTX(authfn, userfunc, session, ...) \
+do { \
+    \
+    check_is_init(); \
+    \
+    token *t = NULL; \
+    session_ctx *ctx = NULL; \
+    rv = session_lookup(session, &t, &ctx); \
+    if (rv != CKR_OK) { \
+        return rv; \
+    } \
+    \
+    rv = authfn(ctx); \
+    if (rv != CKR_OK) { \
+        token_unlock(t); \
+        return rv; \
+    } \
+    rv = userfunc(t, ctx, ##__VA_ARGS__); \
+    token_unlock(t); \
+} while (0)
+
+/*
+ * Below you'll find the auth routines that validate session
+ * context. Becuase session context is required to be in a
+ * certain state for things, these auth plugins check a vary
+ * specific condition. Add more if you need different checks.
+ */
+static inline CK_RV auth_min_ro_pub(session_ctx *ctx) {
+
+    UNUSED(ctx);
+    return CKR_OK;
+}
+
+static inline CK_RV auth_min_ro_user(session_ctx *ctx) {
+
+    CK_STATE state = session_ctx_state_get(ctx);
+    switch(state) {
+    case CKS_RO_USER_FUNCTIONS:
+        /* falls-thru */
+    case CKS_RW_USER_FUNCTIONS:
+        return CKR_OK;
+        /* no default */
+    }
+
+    return CKR_USER_NOT_LOGGED_IN;
+}
+
+static inline CK_RV auth_any_logged_in(session_ctx *ctx) {
+    CK_STATE state = session_ctx_state_get(ctx);
+    switch(state) {
+    case CKS_RO_USER_FUNCTIONS:
+    case CKS_RW_USER_FUNCTIONS:
+    case CKS_RW_SO_FUNCTIONS:
+        return CKR_OK;
+        /* no default */
+    }
+
+    return CKR_USER_NOT_LOGGED_IN;
+}
+
+/*
+ * The macros below are used to call into the cryptoki API and perform a myriad of checking using certain
+ * auth models. Not using these is dangerous.
+ */
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RO Public Ie any session would work.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_min_ro_pub, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what TOKEN_WITH_LOCK_BY_SESSION_PUB_RO does, but passes the session_ctx to the internal api.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_PUB_RO_KEEP_CTX(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION_KEEP_CTX(auth_min_ro_pub, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RW Public. Ie no one logged in and R/W session.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_PUB_RW(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_min_rw_pub, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RO User. Ie user logged in and R/O or R/W session.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_USER_RO(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_min_ro_user, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RO User. Ie user logged in and R/W session.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_USER_RW(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_min_rw_user, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RO User. Ie so logged in and R/W session.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_SO_RW(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_min_rw_so, userfunc, session, ##__VA_ARGS__)
+
+/*
+ * Does what __TOKEN_WITH_LOCK_BY_SESSION does, and checks that the session is at least RO User. Ie user or so logged in and R/O or R/W session.
+ */
+#define TOKEN_WITH_LOCK_BY_SESSION_LOGGED_IN(userfunc, session, ...) __TOKEN_WITH_LOCK_BY_SESSION(auth_any_logged_in, userfunc, session, ##__VA_ARGS__)
+
 CK_RV C_Initialize (void *init_args) {
     TRACE_CALL;
     TRACE_RET(general_init(init_args));
@@ -67,7 +239,9 @@ CK_RV C_GetSlotInfo (CK_SLOT_ID slotID, CK_SLOT_INFO *info) {
 
 CK_RV C_GetTokenInfo (CK_SLOT_ID slotID, CK_TOKEN_INFO *info) {
     TRACE_CALL;
-    TRACE_RET(token_get_info (slotID, info));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SLOT(token_get_info, slotID, info);
+    TRACE_RET(rv);
 }
 
 CK_RV C_WaitForSlotEvent (CK_FLAGS flags, CK_SLOT_ID *slot, void *pReserved) {
@@ -117,7 +291,9 @@ CK_RV C_CloseAllSessions (CK_SLOT_ID slotID) {
 
 CK_RV C_GetSessionInfo (CK_SESSION_HANDLE session, CK_SESSION_INFO *info) {
     TRACE_CALL;
-    TRACE_RET(session_get_info(session, info));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO_KEEP_CTX(session_get_info, session, info);
+    TRACE_RET(rv);
 }
 
 CK_RV C_GetOperationState (CK_SESSION_HANDLE session, unsigned char *operation_state, unsigned long *operation_state_len) {
@@ -132,12 +308,16 @@ CK_RV C_SetOperationState (CK_SESSION_HANDLE session, unsigned char *operation_s
 
 CK_RV C_Login (CK_SESSION_HANDLE session, CK_USER_TYPE user_type, unsigned char *pin, unsigned long pin_len) {
     TRACE_CALL;
-    TRACE_RET(session_login(session, user_type, pin, pin_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(session_login, session, user_type, pin, pin_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Logout (CK_SESSION_HANDLE session) {
     TRACE_CALL;
-    TRACE_RET(session_logout(session));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_LOGGED_IN(session_logout, session);
+    TRACE_RET(rv);
 }
 
 CK_RV C_CreateObject (CK_SESSION_HANDLE session, CK_ATTRIBUTE *templ, unsigned long count, CK_OBJECT_HANDLE *object) {
@@ -162,7 +342,9 @@ CK_RV C_GetObjectSize (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, unsig
 
 CK_RV C_GetAttributeValue (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count) {
     TRACE_CALL;
-    TRACE_RET(object_get_attributes(session, object, templ, count));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(object_get_attributes, session, object, templ, count);
+    TRACE_RET(rv);
 }
 
 CK_RV C_SetAttributeValue (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count) {
@@ -172,72 +354,101 @@ CK_RV C_SetAttributeValue (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, C
 
 CK_RV C_FindObjectsInit (CK_SESSION_HANDLE session, CK_ATTRIBUTE *templ, unsigned long count) {
     TRACE_CALL;
-    TRACE_RET(object_find_init(session, templ, count));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(object_find_init, session, templ, count);
+    TRACE_RET(rv);
 }
 
 CK_RV C_FindObjects (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE *object, unsigned long max_object_count, unsigned long *object_count) {
     TRACE_CALL;
-    TRACE_RET(object_find(session, object, max_object_count, object_count));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(object_find, session, object, max_object_count, object_count);
+    TRACE_RET(rv);
 }
 
 CK_RV C_FindObjectsFinal (CK_SESSION_HANDLE session) {
     TRACE_CALL;
-    TRACE_RET(object_find_final(session));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(object_find_final, session);
+    TRACE_RET(rv);
 }
 
 CK_RV C_EncryptInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
     TRACE_CALL;
-    TRACE_RET(encrypt_init(session, mechanism, key));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(encrypt_init, session, mechanism, key);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Encrypt (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
     TRACE_CALL;
-    TRACE_RET(encrypt_oneshot(session, data, data_len, encrypted_data, encrypted_data_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(encrypt_oneshot, session, data, data_len, encrypted_data, encrypted_data_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_EncryptUpdate (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
     TRACE_CALL;
-    TRACE_RET(encrypt_update(session, part, part_len, encrypted_part, encrypted_part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(encrypt_update, session, part, part_len, encrypted_part, encrypted_part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_EncryptFinal (CK_SESSION_HANDLE session, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
+
     TRACE_CALL;
-    TRACE_RET(encrypt_final(session, last_encrypted_part, last_encrypted_part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(encrypt_final, session, last_encrypted_part, last_encrypted_part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DecryptInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
     TRACE_CALL;
-    TRACE_RET(decrypt_init(session, mechanism, key));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(decrypt_init, session, mechanism, key);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Decrypt (CK_SESSION_HANDLE session, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
     TRACE_CALL;
-    TRACE_RET(decrypt_oneshot(session, encrypted_data, encrypted_data_len, data, data_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(decrypt_oneshot, session, encrypted_data, encrypted_data_len, data, data_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DecryptUpdate (CK_SESSION_HANDLE session, unsigned char *encrypted_part, unsigned long encrypted_part_len, unsigned char *part, unsigned long *part_len) {
     TRACE_CALL;
-    TRACE_RET(decrypt_update(session, encrypted_part, encrypted_part_len, part, part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(decrypt_update, session, encrypted_part, encrypted_part_len, part, part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DecryptFinal (CK_SESSION_HANDLE session, unsigned char *last_part, unsigned long *last_part_len) {
     TRACE_CALL;
-    TRACE_RET(decrypt_final(session, last_part, last_part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(decrypt_final, session, last_part, last_part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DigestInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism) {
     TRACE_CALL;
-    TRACE_RET(digest_init(session, mechanism));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(digest_init, session, mechanism);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Digest (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len) {
     TRACE_CALL;
-    TRACE_RET(digest_oneshot(session, data, data_len, digest, digest_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(digest_oneshot, session, data, data_len, digest, digest_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DigestUpdate (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len) {
     TRACE_CALL;
-    TRACE_RET(digest_update(session, part, part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(digest_update, session, part, part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_DigestKey (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key) {
@@ -247,27 +458,37 @@ CK_RV C_DigestKey (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key) {
 
 CK_RV C_DigestFinal (CK_SESSION_HANDLE session, unsigned char *digest, unsigned long *digest_len) {
     TRACE_CALL;
-    TRACE_RET(digest_final(session, digest, digest_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(digest_final, session, digest, digest_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_SignInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
     TRACE_CALL;
-    TRACE_RET(sign_init(session, mechanism, key));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(sign_init, session, mechanism, key);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Sign (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long *signature_len) {
     TRACE_CALL;
-    TRACE_RET(sign(session, data, data_len, signature, signature_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(sign, session, data, data_len, signature, signature_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_SignUpdate (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len) {
     TRACE_CALL;
-    TRACE_RET(sign_update(session, part, part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(sign_update, session, part, part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_SignFinal (CK_SESSION_HANDLE session, unsigned char *signature, unsigned long *signature_len) {
     TRACE_CALL;
-    TRACE_RET(sign_final(session, signature, signature_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(sign_final, session, signature, signature_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_SignRecoverInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
@@ -282,22 +503,30 @@ CK_RV C_SignRecover (CK_SESSION_HANDLE session, unsigned char *data, unsigned lo
 
 CK_RV C_VerifyInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
     TRACE_CALL;
-    TRACE_RET(verify_init(session, mechanism, key));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify_init, session, mechanism, key);
+    TRACE_RET(rv);
 }
 
 CK_RV C_Verify (CK_SESSION_HANDLE session, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len) {
     TRACE_CALL;
-    TRACE_RET(verify(session, data, data_len, signature, signature_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify, session, data, data_len, signature, signature_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_VerifyUpdate (CK_SESSION_HANDLE session, unsigned char *part, unsigned long part_len) {
     TRACE_CALL;
-    TRACE_RET(verify_update(session, part, part_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify_update, session, part, part_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_VerifyFinal (CK_SESSION_HANDLE session, unsigned char *signature, unsigned long signature_len) {
     TRACE_CALL;
-    TRACE_RET(verify_final(session, signature, signature_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify_final, session, signature, signature_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_VerifyRecoverInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
@@ -337,7 +566,9 @@ CK_RV C_GenerateKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_ATTR
 
 CK_RV C_GenerateKeyPair (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_ATTRIBUTE *public_key_template, unsigned long public_key_attribute_count, CK_ATTRIBUTE *private_key_template, unsigned long private_key_attribute_count, CK_OBJECT_HANDLE *public_key, CK_OBJECT_HANDLE *private_key) {
     TRACE_CALL;
-    TRACE_RET(key_gen(session, mechanism, public_key_template, public_key_attribute_count, private_key_template, private_key_attribute_count, public_key, private_key));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(key_gen, session, mechanism, public_key_template, public_key_attribute_count, private_key_template, private_key_attribute_count, public_key, private_key);
+    TRACE_RET(rv);
 }
 
 CK_RV C_WrapKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE wrapping_key, CK_OBJECT_HANDLE key, unsigned char *wrapped_key, unsigned long *wrapped_key_len) {
@@ -357,12 +588,16 @@ CK_RV C_DeriveKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT
 
 CK_RV C_SeedRandom (CK_SESSION_HANDLE session, unsigned char *seed, unsigned long seed_len) {
     TRACE_CALL;
-    TRACE_RET(seed_random(session, seed, seed_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(seed_random, session, seed, seed_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_GenerateRandom (CK_SESSION_HANDLE session, unsigned char *random_data, unsigned long random_len) {
     TRACE_CALL;
-    TRACE_RET(random_get(session, random_data, random_len));
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(random_get, session, random_data, random_len);
+    TRACE_RET(rv);
 }
 
 CK_RV C_GetFunctionStatus (CK_SESSION_HANDLE session) {

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -107,6 +107,8 @@ static void test_random_good(void **state) {
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE handle = ti->handles[0];
 
+    user_login(ti->handles[0]);
+
     unsigned char buf[4];
 
     // Case 1: Good test
@@ -133,6 +135,8 @@ static void test_seed(void **state) {
 
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE handle = ti->handles[0];
+
+    user_login(ti->handles[0]);
 
     CK_RV rv = C_SeedRandom(handle, buf, sizeof(buf));
     assert_int_equal(rv, CKR_OK);


### PR DESCRIPTION
This makes progress on simplifying the internal design. We need to perhaps look at killing off the token * in session_ctx, as the token * is going to come down to R/O portions and session shared R/W data that needs to be locked. So clarifying this relationship and hiding data will help make the locking issues easier to solve.

Fixes: #6 
Fixes: #95 
Fixes: #75