### PR TITLE
Software Based hash when not supported

### DIFF
--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -6,15 +6,44 @@
 #ifndef SRC_LIB_DIGEST_H_
 #define SRC_LIB_DIGEST_H_
 
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <openssl/evp.h>
+
 #include "pkcs11.h"
+#include "object.h"
 
 typedef struct token token;
 
-CK_RV digest_init(token *tok, CK_MECHANISM *mechanism);
+typedef struct digest_op_data digest_op_data;
+struct digest_op_data {
+    bool use_sw_hash;
+    tobject *tobj;
+    CK_MECHANISM_TYPE mode;
+    union {
+        uint32_t sequence_handle;
+        EVP_MD_CTX *mdctx;
+    };
+};
 
-CK_RV digest_update(token *tok, unsigned char *part, unsigned long part_len);
+digest_op_data *digest_op_data_new(void);
+void digest_op_data_free(digest_op_data **opdata);
 
-CK_RV digest_final(token *tok, unsigned char *digest, unsigned long *digest_len);
+CK_RV digest_init_op(token *tok, digest_op_data *opdata, CK_MECHANISM *mechanism);
+static inline CK_RV digest_init(token *tok, CK_MECHANISM *mechanism) {
+    return digest_init_op(tok, NULL, mechanism);
+}
+
+CK_RV digest_update_op(token *tok, digest_op_data *opdata, unsigned char *part, unsigned long part_len);
+static inline CK_RV digest_update(token *tok, unsigned char *part, unsigned long part_len) {
+    return digest_update_op(tok, NULL, part, part_len);
+}
+
+CK_RV digest_final_op(token *tok, digest_op_data *opdata, unsigned char *digest, unsigned long *digest_len);
+static inline CK_RV digest_final(token *tok, unsigned char *digest, unsigned long *digest_len) {
+    return digest_final_op(tok, NULL, digest, digest_len);
+}
 
 CK_RV digest_oneshot(token *tok, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len);
 

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -203,3 +203,31 @@ size_t utils_get_halg_size(CK_MECHANISM_TYPE mttype) {
 
     return 0;
 }
+
+bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech) {
+
+    switch(mech) {
+    case CKM_RSA_PKCS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool utils_mech_is_rsa_pkcs(CK_MECHANISM_TYPE mech) {
+
+    switch(mech) {
+    case CKM_RSA_PKCS:
+        /* falls-thru*/
+    case CKM_SHA1_RSA_PKCS:
+        /* falls-thru*/
+    case CKM_SHA256_RSA_PKCS:
+        /* falls-thru*/
+    case CKM_SHA384_RSA_PKCS:
+        /* falls-thru*/
+    case CKM_SHA512_RSA_PKCS:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -51,4 +51,25 @@ twist aes256_gcm_decrypt(const twist key, const twist objauth);
  */
 size_t utils_get_halg_size(CK_MECHANISM_TYPE mttype);
 
+/**
+ * True if a mechanism is a "raw" sign. A raw signing operation
+ * is defined as a signing structure constructed by the application,
+ * for instance mechanism type CKM_RSA_PKCS.
+ * @param mech
+ *  The mechanism to check.
+ * @return
+ *  True if it is a raw signature, else it isn't.
+ */
+bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech);
+
+/**
+ * True if the mechanism is an RSA PKCS v1.5 signing
+ * scheme.
+ * @param mech
+ *  The mechanism to check
+ * @return
+ *  True if it is, false otherwise.
+ */
+bool utils_mech_is_rsa_pkcs(CK_MECHANISM_TYPE mech);
+
 #endif /* SRC_PKCS11_UTILS_H_ */

--- a/test/integration/pkcs-sign-verify.int.c
+++ b/test/integration/pkcs-sign-verify.int.c
@@ -88,12 +88,23 @@ static const unsigned char _data[] = { 'F', 'O', 'O', ' ', 'B', 'A', 'R' };
 /*
  * The hash of the message to sign computed externally.
  */
-static const unsigned char _data_hash_sha256[] = { 0x8d, 0x35, 0xc9, 0x7b, 0xcd,
-        0x90, 0x2b, 0x96, 0xd1, 0xb5, 0x51, 0x74, 0x1b, 0xbe, 0x8a, 0x7f, 0x50,
-        0xbb, 0x5a, 0x69, 0x0b, 0x4d, 0x02, 0x25, 0x48, 0x2e, 0xaa, 0x63, 0xdb,
-        0xfb, 0x9d, 0xed };
+static const unsigned char _data_hash_sha256[] = {
+    0x8d, 0x35, 0xc9, 0x7b, 0xcd,
+    0x90, 0x2b, 0x96, 0xd1, 0xb5, 0x51, 0x74, 0x1b, 0xbe, 0x8a, 0x7f, 0x50,
+    0xbb, 0x5a, 0x69, 0x0b, 0x4d, 0x02, 0x25, 0x48, 0x2e, 0xaa, 0x63, 0xdb,
+    0xfb, 0x9d, 0xed
+};
 
-static void test_sign_verify_CKM_RSA_PKCS(void **state) {
+static const unsigned char _data_hash_sha512[] = {
+  0xcf, 0x4a, 0xca, 0x20, 0x77, 0xda, 0x02, 0xe6, 0x56, 0xc5, 0xe5, 0xed,
+  0x26, 0xd7, 0x81, 0x6b, 0xfc, 0x20, 0x2f, 0x7d, 0x40, 0xfe, 0x01, 0x27,
+  0x5f, 0x62, 0xd4, 0x91, 0x18, 0xa3, 0xbc, 0x5b, 0x20, 0xef, 0x94, 0x27,
+  0x24, 0xfc, 0x35, 0xb6, 0x67, 0x37, 0xbd, 0xec, 0x26, 0x28, 0x33, 0xc7,
+  0x49, 0xfd, 0xa9, 0x95, 0x54, 0x63, 0xc7, 0x55, 0xe9, 0x1a, 0x27, 0xc3,
+  0x8d, 0xda, 0x9e, 0xfb
+};
+
+static void test_sign_verify_CKM_RSA_PKCS_sha256(void **state) {
 
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE session = ti->handle;
@@ -169,10 +180,106 @@ static void test_sign_verify_CKM_RSA_PKCS(void **state) {
             ckm_sha256_rsa_pkcs_siglen);
 }
 
+/*
+ * Verify that using a non-tpm supported SHA algorithm works. The Simulator
+ * by default only goes to SHA384, so use SHA512.
+ *
+ * It uses CKM_RSA_PKCS and CKM_SHA512_RSA_PKCS to verify that
+ * they match.
+ *
+ * This uses CKM_RSA_PKCS which means that the host application
+ * builds out the RSA_PKCS v1.5 signing structure as defined in
+ * https://www.ietf.org/rfc/rfc3447.txt
+ */
+static void test_sign_verify_CKM_RSA_PKCS_sha512(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE session = ti->handle;
+
+    CK_OBJECT_CLASS key_class = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE key_type = CKK_RSA;
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS, &key_class, sizeof(key_class) },
+        { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
+    };
+
+    CK_RV rv = C_FindObjectsInit(session, tmpl, ARRAY_LEN(tmpl));
+    assert_int_equal(rv, CKR_OK);
+
+    /* Find an RSA key */
+    unsigned long count;
+    CK_OBJECT_HANDLE objhandles[1];
+    rv = C_FindObjects(session, objhandles, ARRAY_LEN(objhandles), &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjects(session, objhandles, ARRAY_LEN(objhandles), &count);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_FindObjectsFinal(session);
+    assert_int_equal(rv, CKR_OK);
+
+    user_login(session);
+
+    /*
+     * Now that we have a key for sign, build up what we need to sign,
+     * which is the ASN1 digest info for CKM_RSA_PKCS
+     */
+    CK_MECHANISM mech = { .mechanism = CKM_RSA_PKCS };
+    rv = C_SignInit(session, &mech, objhandles[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    /* 19 byte ASN1 header + sha512 64 byte size */
+    unsigned char digest_info[19 + sizeof(_data_hash_sha512)] = {
+        /* https://www.ietf.org/rfc/rfc3447.txt
+         * Page 42
+         * 19 byte ASN1 structure from the IETF rfc3447 for SHA512
+         */
+        0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+        0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40,
+
+        /* the hash bytes (64 of them), 0 them out */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 16 */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 32 */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 48 */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 64 */
+    };
+
+    memcpy(&digest_info[19], _data_hash_sha512, sizeof(_data_hash_sha512));
+
+    unsigned char ckm_rsa_pkcs_sig[4096];
+    unsigned long ckm_rsa_pkcs_siglen = sizeof(ckm_rsa_pkcs_sig);
+
+    rv = C_Sign(session, digest_info, sizeof(digest_info), ckm_rsa_pkcs_sig,
+            &ckm_rsa_pkcs_siglen);
+    assert_int_equal(rv, CKR_OK);
+
+    /*
+     * OK now internally hash/sign the data via CKM_SHA512_RSA_PKCS
+     */
+    mech.mechanism = CKM_SHA512_RSA_PKCS;
+    rv = C_SignInit(session, &mech, objhandles[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    unsigned char ckm_sha512_rsa_pkcs_sig[4096];
+    unsigned long ckm_sha512_rsa_pkcs_siglen = sizeof(ckm_rsa_pkcs_sig);
+
+    rv = C_Sign(session, (unsigned char *) _data, sizeof(_data),
+            ckm_sha512_rsa_pkcs_sig, &ckm_sha512_rsa_pkcs_siglen);
+    assert_int_equal(rv, CKR_OK);
+
+    assert_int_equal(ckm_sha512_rsa_pkcs_siglen, ckm_rsa_pkcs_siglen);
+
+    assert_memory_equal(ckm_sha512_rsa_pkcs_sig, ckm_rsa_pkcs_sig,
+            ckm_sha512_rsa_pkcs_siglen);
+}
+
 int main() {
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_sign_verify_CKM_RSA_PKCS,
+        cmocka_unit_test_setup_teardown(test_sign_verify_CKM_RSA_PKCS_sha256,
+                test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sign_verify_CKM_RSA_PKCS_sha512,
                 test_setup, test_teardown),
     };
 


### PR DESCRIPTION
When the TPM doesn't support the hashing algorithm requested
and subsequently the signing scheme selected using that hash,
synthesize it with software by:

1. Performing the digest in SW
2. Building the appropriate signing structure (PKCS v1.5 supported ONLY)
3. Apply the padding if needed (PKCS v1.5 supported ONLY)
4. Use raw RSA Decrypt (encrypt with private key)

Fixes: #4

Signed-off-by: William Roberts <william.c.roberts@intel.com>