### PR TITLE
configure: add CFLAG -Wstrict-overflow=5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,6 +258,7 @@ AS_IF([test x"$hardening" != x"no"], [
   add_hardened_c_flag([-Wformat-security])
   add_hardened_c_flag([-Wstack-protector])
   add_hardened_c_flag([-fstack-protector-all])
+  add_hardened_c_flag([-Wstrict-overflow=5])
 
   add_hardened_define_flag([-U_FORTIFY_SOURCE])
   add_hardened_define_flag([-D_FORTIFY_SOURCE=2])


### PR DESCRIPTION
Add -Wstrict-overflow=5 to hardened CFLAG's to force checking
of signed integer overflow issues.

Signed-off-by: William Roberts <william.c.roberts@intel.com>