### PR TITLE
 test: fix race condition in create_pkcs_store.sh

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -57,11 +57,6 @@ that *are outside of normal autoconf/automake options*, which are documented [he
 
 ### Configure Options
 1. `--enable-unit` - Enables the unit tests when running `make check`
-
-   **Note:** When enabling unit tests, it will be necessary to rebuild `src/lib/twist.c` if it was already built, e.g. by using
-   ```
-   make --assume-new src/lib/twist.c check
-   ```
 2. `--enable-integration` - Enables the integration tests when running `make check`
   * Requires the following items to be found on PATH:
     * [tpm2-ptool](../tools/tpm2_ptool.py)

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -56,8 +56,8 @@ set -e
 tpm2_ptool.py init --pobj-pin=mypobjpin --path=$TPM2_PKCS11_STORE
 
 # Test the existing primary object init functionality
-tpm2_createprimary -p foopass -o primary.ctx -g sha256 -G rsa
-handle=`tpm2_evictcontrol -a o -c primary.ctx | cut -d\: -f2-2 | sed 's/^ *//g'`
+tpm2_createprimary -p foopass -o $TPM2_PKCS11_STORE/primary.ctx -g sha256 -G rsa
+handle=`tpm2_evictcontrol -a o -c $TPM2_PKCS11_STORE/primary.ctx | cut -d\: -f2-2 | sed 's/^ *//g'`
 
 tpm2_ptool.py init --pobj-pin=anotherpobjpin --primary-handle=$handle --primary-auth=foopass --path=$TPM2_PKCS11_STORE
 


### PR DESCRIPTION
Multiple integration tests can be run in parallel, but only one file `primary.ctx` is used for all of them in [`create_pkcs_store.sh`](https://github.com/tpm2-software/tpm2-pkcs11/blob/5be9faf7399b18e1f4f363af3d455e08eb17aba4/test/integration/scripts/create_pkcs_store.sh#L59). On my system, this leads to errors of the form
```
ERROR: Tss2_Sys_ContextLoad(0x1DF) - tpm:parameter(1):integrity check failed
ERROR: Could not load object, got: "primary.ctx"
ERROR: Unable to run tpm2_evictcontrol
```
when multiple tests try to write to that file at once. This is easily fixed by using separate files per test in the `$TPM2_PKCS11_STORE` directory.

In unrelated news, remove the instructions to rebuild `twist.c` because this is not necessary any more since #96 switched to using `config.h`.