### PR TITLE
rsa: support OAEP encryption

### DIFF
--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -6,24 +6,59 @@
 #ifndef SRC_LIB_ENCRYPT_H_
 #define SRC_LIB_ENCRYPT_H_
 
+#include <stdlib.h>
+
 #include "pkcs11.h"
+#include "tpm.h"
 
 typedef struct token token;
 
-CK_RV encrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+typedef struct encrypt_op_data encrypt_op_data;
+struct encrypt_op_data {
+    tpm_encrypt_data *tpm_enc_data;
+};
 
-CK_RV encrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+encrypt_op_data *encrypt_op_data_new(void);
+void encrypt_op_data_free(encrypt_op_data **opdata);
 
-CK_RV encrypt_final (token *tok, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
+CK_RV encrypt_init_op (token *tok, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+static inline CK_RV encrypt_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+    return encrypt_init_op(tok, NULL, mechanism, key);
+}
 
-CK_RV decrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+CK_RV encrypt_update_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+static inline CK_RV encrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+    return encrypt_update_op (tok, NULL, part, part_len, encrypted_part, encrypted_part_len);
+}
 
-CK_RV decrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+CK_RV encrypt_final_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
+static inline CK_RV encrypt_final (token *tok, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
+    return encrypt_final_op (tok, NULL, last_encrypted_part, last_encrypted_part_len);
+}
 
-CK_RV decrypt_final (token *tok, unsigned char *last_part, unsigned long *last_part_len);
+CK_RV decrypt_init_op (token *tok, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+static inline CK_RV decrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+    return decrypt_init_op (tok, NULL, mechanism, key);
+}
 
-CK_RV decrypt_oneshot (token *tok, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+CK_RV decrypt_update_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+static inline CK_RV decrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+        return decrypt_update_op (tok, NULL, part, part_len, encrypted_part, encrypted_part_len);
+}
 
-CK_RV encrypt_oneshot (token *tok, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
+CK_RV decrypt_final_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *last_part, unsigned long *last_part_len);
+static inline CK_RV decrypt_final (token *tok,  unsigned char *last_part, unsigned long *last_part_len) {
+    return decrypt_final_op (tok, NULL, last_part, last_part_len);
+}
+
+CK_RV decrypt_oneshot_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+static inline CK_RV decrypt_oneshot (token *tok, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
+    return decrypt_oneshot_op (tok, NULL, encrypted_data, encrypted_data_len, data, data_len);
+}
+
+CK_RV encrypt_oneshot_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
+static inline CK_RV encrypt_oneshot (token *tok, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
+    return encrypt_oneshot_op (tok, NULL, data, data_len, encrypted_data, encrypted_data_len);
+}
 
 #endif /* SRC_LIB_ENCRYPT_H_ */

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -111,4 +111,6 @@ CK_RV object_get_attributes(token *tok, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *t
  */
 CK_ATTRIBUTE_PTR object_get_attribute(tobject *tobj, CK_ATTRIBUTE_TYPE atype);
 
+CK_RV object_mech_is_supported(tobject *tobj, CK_MECHANISM_PTR mech);
+
 #endif /* SRC_PKCS11_OBJECT_H_ */

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -102,17 +102,13 @@ CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_han
 CK_RV tpm_hash_update(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG data_len);
 CK_RV tpm_hash_final(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG_PTR data_len);
 
-#define CKM_AES_NULL (CKM_VENDOR_DEFINED | 0x1)
+typedef struct tpm_encrypt_data tpm_encrypt_data;
+CK_RV tpm_encrypt_data_init(tpm_ctx *ctx, uint32_t handle, twist auth, CK_MECHANISM_PTR, tpm_encrypt_data **encdata);
+void tpm_encrypt_data_free(tpm_encrypt_data *encdata);
 
-CK_RV tpm_encrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mode, twist iv, twist plaintext, twist *ciphertext, twist *iv_out);
+CK_RV tpm_encrypt(tpm_encrypt_data *tpm_enc_data, CK_BYTE_PTR ptext, CK_ULONG ptextlen, CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen);
 
-CK_RV tpm_decrypt_handle(tpm_ctx *ctx, uint32_t handle, twist objauth, CK_MECHANISM_TYPE mode, twist iv, twist ciphertext, twist *plaintext, twist *iv_out);
-
-CK_RV tpm_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mode, twist iv, twist ciphertext, twist *plaintext, twist *iv_out);
-
-CK_RV tpm_rsa_decrypt(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech,
-        CK_BYTE_PTR ctext, CK_ULONG ctextlen,
-        CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen);
+CK_RV tpm_decrypt(tpm_encrypt_data *tpm_enc_data, CK_BYTE_PTR ctext, CK_ULONG ctextlen, CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen);
 
 bool tpm_register_handle(tpm_ctx *ctx, uint32_t *handle);
 


### PR DESCRIPTION
Refactor the internals to support RSA OAEP encryption via the
C_Encrypt/C_Decrypt interfaces. Currently, OAEP is limited to
what the TPM objects will support:
  1. hashalg *MUST* be the namealg of the RSA object.
  2. The mgf *MUST* be MGF1.

In the future, we could possibly synthesize it if not supported
directly via the TPM, just like PKCS Signing scheme.

Fixes #91

Signed-off-by: William Roberts <william.c.roberts@intel.com>