### PR TITLE
tpm2_ptool.py: implement changepin

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -73,6 +73,15 @@ tpm2_ptool.py changepin --label=label --user=so --old=myBADsopin --new=mysopin -
 # verify the token
 tpm2_ptool.py verify --label=label --sopin=mysopin --userpin=myuserpin --path=$TPM2_PKCS11_STORE
 
+# Use initpin to change the user pin
+tpm2_ptool.py initpin --label=label --sopin=mysopin --userpin=myverynewuserpin --path=$TPM2_PKCS11_STORE
+
+# verify the pin change
+tpm2_ptool.py verify --label=label --sopin=mysopin --userpin=myverynewuserpin --path=$TPM2_PKCS11_STORE
+
+# change it back
+tpm2_ptool.py initpin --label=label --sopin=mysopin --userpin=myuserpin --path=$TPM2_PKCS11_STORE
+
 # add 2 aes and 2 rsa keys under tokens 1 and 2
 for t in "label" "wrap-sw"; do
 	echo "Adding 2 AES 256 keys under token \"$t\""

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -62,9 +62,16 @@ handle=`tpm2_evictcontrol -a o -c $TPM2_PKCS11_STORE/primary.ctx | cut -d\: -f2-
 tpm2_ptool.py init --pobj-pin=anotherpobjpin --primary-handle=$handle --primary-auth=foopass --path=$TPM2_PKCS11_STORE
 
 # add 3 tokens
-tpm2_ptool.py addtoken --pid=1 --pobj-pin=mypobjpin --sopin=mysopin --userpin=myuserpin --label=label --path $TPM2_PKCS11_STORE
+tpm2_ptool.py addtoken --pid=1 --pobj-pin=mypobjpin --sopin=myBADsopin --userpin=myBADuserpin --label=label --path $TPM2_PKCS11_STORE
 tpm2_ptool.py addtoken --wrap=software --pid=1 --pobj-pin=mypobjpin --sopin=mysopin --userpin=myuserpin --label=wrap-sw --path $TPM2_PKCS11_STORE
 tpm2_ptool.py addtoken --pid=2 --pobj-pin=anotherpobjpin --sopin=anothersopin --userpin=anotheruserpin --label=import-keys --path $TPM2_PKCS11_STORE
+
+# Change the bad pins to something good (test tpm2_ptool.py changepin commandlet)
+tpm2_ptool.py changepin --label=label --user=user --old=myBADuserpin --new=myuserpin --path=$TPM2_PKCS11_STORE
+tpm2_ptool.py changepin --label=label --user=so --old=myBADsopin --new=mysopin --path=$TPM2_PKCS11_STORE
+
+# verify the token
+tpm2_ptool.py verify --label=label --sopin=mysopin --userpin=myuserpin --path=$TPM2_PKCS11_STORE
 
 # add 2 aes and 2 rsa keys under tokens 1 and 2
 for t in "label" "wrap-sw"; do


### PR DESCRIPTION
Implement the "changepin" functionality. This allows a user
or so to change their pin IF they know the old pin. It does
so by updating the Software Wrapping key for the primary
object auth value, as well as updating the auth value for
the coresponding users sealing object via tpm2_changeauth.

It re-populated the coresponding db fields with the new
information.

Signed-off-by: William Roberts <william.c.roberts@intel.com>