### PR TITLE
build: remove Gnulib dependency

### DIFF
--- a/.ci/coverity.run
+++ b/.ci/coverity.run
@@ -21,7 +21,7 @@ fi
 
 echo "Performing build with Coverity Scan"
 rm -fr $TRAVIS_BUILD_DIR/cov-int
-./bootstrap -I /usr/share/gnulib/m4 && ./configure && make clean
+./bootstrap && ./configure && make clean
 cov-build --dir $TRAVIS_BUILD_DIR/cov-int make -j $(nproc)
 
 echo "Collecting Coverity data for submission"

--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -71,7 +71,7 @@ else #GCC
 fi
 
 # Bootstrap the project
-./bootstrap -I /usr/share/gnulib/m4
+./bootstrap
 
 # clang has asan enabled with options exported that fail
 # make distcheck, so only do this with gcc.

--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -5,13 +5,6 @@
 # All rights reserved.
 #
 
-function install_m4_deps() {
-	# all of our projects need auto-conf archive up-to-date and
-	# distros tend to be outdated.
-	mkdir -p m4
-	cp /usr/share/gnulib/m4/ld-version-script.m4 m4/
-}
-
 function get_deps() {
 
 	# The list order is important and thus we can't use the keys of the dictionary as order is not preserved.
@@ -32,8 +25,6 @@ function get_deps() {
 		git clone "https://github.com/tpm2-software/$p.git"
 
 		pushd "$p"
-
-		install_m4_deps
 
 		./bootstrap
 		./configure $configure_flags

--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ test-suite.log
 
 nbproject/
 build/
-m4/
+m4/*
+!m4/ld-version-script.m4

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -20,11 +20,6 @@ The project depends on:
      Others may not work, some distros package versions too old. Either install or just copy the contents of the
      autoconf-archive's m4 directory to the m4 subdirectory of the tpm2-pkcs11 project. If the m4 folder is not
      present, simply create it with mkdir.
-10. [gnulib](https://www.gnu.org/software/gnulib/): For ld-version-script.m4.
-    On Ubuntu, the ld-version-script.m4 file does not resolve in it's default location under /usr/share/gnulib/m4.
-    During bootstrap one can pass arguments to autoreconf and specify additional search paths via `-I`.
-    For example:
-      ```./bootstrap -I /usr/share/gnulib/m4```
 
 ### Notes:
 The tpm2-tss and tpm2-tools projects must be obtained via source. Packaged versions existing
@@ -41,7 +36,7 @@ in known package managers are likely too old.
 Run the `bootstrap` command.
 
 ```sh
-$ ./bootstrap -I /usr/share/gnulib/m4
+$ ./bootstrap
 ```
 
 ## Step 3 - Configuring

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2019 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])


### PR DESCRIPTION
In https://github.com/tpm2-software/tpm2-tss/pull/1254, the dependency on Gnulib was removed by adding back `ld-version-script.m4`:

> Gnulib takes a different approach. Its components are intended to be shared at the source level, rather than being a library that gets built, installed, and linked against. Thus, there is no distribution tarball; the idea is to copy files from Gnulib into your own source tree.

To be consistent across projects, this should probably done here as well.