### PR TITLE
Autoconf archive 2019.01.06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 # Automake
 Makefile.in
 aclocal.m4
+aminclude_static.am
 autom4te.cache
 compile
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,14 @@ AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(TSS2_ESYS_LIBS) \
                   $(SQLITE3_LIBS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) \
                   $(TCTI_DEVICE_LIBS) $(TCTI_SOCKET_LIBS) $(TCTI_MSSIM_LIBS)
 
+# ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+else
 @CODE_COVERAGE_RULES@
+endif
 
 # Add source code files from bootstrap
 include src_vars.mk

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@
 #;**********************************************************************;
 
 INCLUDE_DIRS    = -I$(srcdir)/src -I$(top_srcdir)/src/lib
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
                   $(TSS2_ESYS_CFLAGS) $(SQLITE3_CFLAGS) $(PTHREAD_CFLAGS) \
                   $(CRYPTO_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,11 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+AX_ADD_AM_MACRO_STATIC([])
+
 AC_CONFIG_FILES([Makefile])
 
 # enable autoheader config.h file


### PR DESCRIPTION
This PR applies the following recent changes to the build system from tpm2-tss:
- Support for Autoconf Archive 2019.01.06: https://github.com/tpm2-software/tpm2-tss/pull/1238, including the fix for older versions in https://github.com/tpm2-software/tpm2-tss/pull/1256
- Installation of the aclocal macros to the `m4/` subdirectory: https://github.com/tpm2-software/tpm2-tss/pull/1245