### PR TITLE
tpm2_ptool: use relative imports in tpm2_ptool.py

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -487,7 +487,7 @@ class ChangePinCommand(Command):
 
         is_so = args['user'] == 'so'
         oldpin = args['old']
-        newpin = args['new']
+        newpin = args['new'].encode()
 
         token = db.gettoken(label)
 
@@ -560,7 +560,7 @@ class InitPinCommand(Command):
         label = args['label']
 
         sopin = args['sopin']
-        newpin = args['userpin']
+        newpin = args['userpin'].encode()
 
         token = db.gettoken(label)
 

--- a/tools/tpm2_pkcs11/tpm2_ptool.py
+++ b/tools/tpm2_pkcs11/tpm2_ptool.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 
-from command import commandlet
+from .command import commandlet
 
 # These imports are required to add the commandlet even though they appear unused
 # Store level commands
-from commandlets_store import InitCommand  # pylint: disable=unused-import
-from commandlets_store import DestroyCommand  # pylint: disable=unused-import
+from .commandlets_store import InitCommand  # pylint: disable=unused-import
+from .commandlets_store import DestroyCommand  # pylint: disable=unused-import
 
 # Token Level Commands
-from commandlets_token import AddTokenCommand  # pylint: disable=unused-import
-from commandlets_token import AddEmptyTokenCommand  # pylint: disable=unused-import
-from commandlets_token import RmTokenCommand  # pylint: disable=unused-import
+from .commandlets_token import AddTokenCommand  # pylint: disable=unused-import
+from .commandlets_token import AddEmptyTokenCommand  # pylint: disable=unused-import
+from .commandlets_token import RmTokenCommand  # pylint: disable=unused-import
 
-from commandlets_token import VerifyCommand  # pylint: disable=unused-import
+from .commandlets_token import VerifyCommand  # pylint: disable=unused-import
 
-from commandlets_token import InitPinCommand  # pylint: disable=unused-import
-from commandlets_token import ChangePinCommand  # pylint: disable=unused-import
+from .commandlets_token import InitPinCommand  # pylint: disable=unused-import
+from .commandlets_token import ChangePinCommand  # pylint: disable=unused-import
 
-from commandlets_keys import AddKeyCommand  # pylint: disable=unused-import
-from commandlets_keys import ImportCommand  # pylint: disable=unused-import
+from .commandlets_keys import AddKeyCommand  # pylint: disable=unused-import
+from .commandlets_keys import ImportCommand  # pylint: disable=unused-import
 
 
 def main():


### PR DESCRIPTION
Due to [PEP 328](https://www.python.org/dev/peps/pep-0328/), it is necessary to use relative imports for local modules in Python 3. This is already done for the other modules, see e.g. [`commandlets_token.py`](https://github.com/tpm2-software/tpm2-pkcs11/blob/ad3c45208b0ea155d0426a737b53bb0c75b13a76/tools/tpm2_pkcs11/commandlets_token.py#L11), but not for `tpm2_ptool.py`. Also fix another small Python 3 incompatibility regarding binary strings that occurred while running `make check`.