### PR TITLE
tpm2_ptool: add packages option to setup.py

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -17,6 +17,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
+    packages=['tpm2_pkcs11'],
 
     # Dependencies got here aka install_requires=['tensorflow']
     install_requires=[],


### PR DESCRIPTION
This is necessary to install the sources to the correct system directory with `python setup.py install`/`pip`/... so that they can be found by Python, see https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages.