### PR TITLE
db: store tpm pub/priv data in db

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -181,7 +181,7 @@ class NewKeyCommandBase(Command):
         with Db(path) as db:
 
             with TemporaryDirectory() as d:
-                tpm2 = Tpm2(d, path)
+                tpm2 = Tpm2(d)
 
                 label = args['label']
                 sopin = args['sopin']

--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -87,7 +87,7 @@ class InitCommand(Command):
             handle = None
             with TemporaryDirectory() as d:
                 try:
-                    tpm2 = Tpm2(d, path)
+                    tpm2 = Tpm2(d)
 
                     pobjkey = hash_pass(pobjpin.encode())
 

--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -98,7 +98,7 @@ class VerifyCommand(Command):
         wrappingkeyauth = None
 
         with TemporaryDirectory() as d:
-            tpm2 = Tpm2(d, path)
+            tpm2 = Tpm2(d)
 
             if sopin != None:
 
@@ -264,7 +264,7 @@ class AddTokenCommand(Command):
         pobjauthhash = AddTokenCommand.verify_pobjpin(pobject, pobjpin)
 
         with TemporaryDirectory() as d:
-            tpm2 = Tpm2(d, path)
+            tpm2 = Tpm2(d)
 
             #
             # Figure out if TPM supports encryptdecrypt
@@ -522,16 +522,13 @@ class ChangePinCommand(Command):
         db.updatepin(is_so, token, pobjkey, encpobjauth, newsealauth,
                      newsealpriv)
 
-        # Step 5 - unlink the old private tpm object file.
-        os.unlink(oldpriv)
-
     def __call__(self, args):
 
         path = args['path']
 
         with Db(path) as db:
             with TemporaryDirectory() as d:
-                tpm2 = Tpm2(d, path)
+                tpm2 = Tpm2(d)
                 ChangePinCommand.changepin(db, tpm2, args)
 
 
@@ -599,15 +596,11 @@ class InitPinCommand(Command):
         db.updatepin(False, token, pobjkey, encpobjauth, newsealauth,
                      newsealpriv, newsealpub)
 
-        # Step 5 - unlink the old private and public tpm object file.
-        os.unlink(oldsealpriv)
-        os.unlink(oldsealpub)
-
     def __call__(self, args):
 
         path = args['path']
 
         with Db(path) as db:
             with TemporaryDirectory() as d:
-                tpm2 = Tpm2(d, path)
+                tpm2 = Tpm2(d)
                 InitPinCommand.initpin(db, tpm2, args)

--- a/tools/tpm2_pkcs11/tpm2_ptool.py
+++ b/tools/tpm2_pkcs11/tpm2_ptool.py
@@ -20,7 +20,6 @@ from .commandlets_token import ChangePinCommand  # pylint: disable=unused-import
 from .commandlets_keys import AddKeyCommand  # pylint: disable=unused-import
 from .commandlets_keys import ImportCommand  # pylint: disable=unused-import
 
-
 def main():
     '''The main entry point.'''
 

--- a/tools/tpm2_pkcs11/utils.py
+++ b/tools/tpm2_pkcs11/utils.py
@@ -5,9 +5,10 @@ import argparse
 import sys
 import shutil
 import tempfile
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import (Cipher, algorithms, modes)
-
+from tempfile import NamedTemporaryFile
 
 # The delimiter changes based on nesting level to make parsing easier. We assume one key-value entry per line
 # where a key can have N KVPs as a CSV.
@@ -210,7 +211,6 @@ class TemporaryDirectory(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         shutil.rmtree(self.name)
-
 
 class TPMAuthUnwrapper(object):
 

--- a/tools/tpm2_ptool.py
+++ b/tools/tpm2_ptool.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from tpm2_pkcs11 import tpm2_ptool as tool
+
+tool.main()


### PR DESCRIPTION
** This will require a db delete and restore **

Having the public and private tpm data in files with paths in the DB itself
makes creating new objects that much more difficult as one needs to deal with
the myriad of filesystem issues. It would be much simpler to just store the
blob data in the DB, and should be faster:
  - https://www.sqlite.org/intern-v-extern-blob.html

Signed-off-by: William Roberts <william.c.roberts@intel.com>