### PR TITLE
Return the correct amount of mechanisms

### DIFF
--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -203,8 +203,8 @@ CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_
         return CKR_BUFFER_TOO_SMALL;
     }
 
-    *count = sizeof(mechs);
-    memcpy(mechanism_list, mechs, ARRAY_LEN(mechs));
+    *count = ARRAY_LEN(mechs);
+    memcpy(mechanism_list, mechs, sizeof(mechs));
 
     return CKR_OK;
 }


### PR DESCRIPTION
This patch corrects the values and amount of data returned by C_GetMechanismList.
It must return the number of entries (ARRAY_LEN(mechs)) in *count and copy the correct number of bytes to the caller (sizeof(mechs)).
This was mixed up and was causing a buffer overflow / leakage.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>