### PR TITLE
test: remove unused variable and label

### DIFF
--- a/test/integration/pkcs-sign-verify.int.c
+++ b/test/integration/pkcs-sign-verify.int.c
@@ -668,7 +668,6 @@ static CK_ATTRIBUTE_PTR get_attr(CK_ATTRIBUTE_TYPE type, CK_ATTRIBUTE_PTR attrs,
 
 RSA *template_to_rsa_pub_key(CK_ATTRIBUTE_PTR attrs, CK_ULONG attr_len) {
 
-    bool ret = false;
     RSA *ssl_rsa_key = NULL;
     BIGNUM *e = NULL, *n = NULL;
 
@@ -700,7 +699,6 @@ RSA *template_to_rsa_pub_key(CK_ATTRIBUTE_PTR attrs, CK_ULONG attr_len) {
 
     return ssl_rsa_key;
 
-error:
     BN_free(n);
     BN_free(e);
     RSA_free(ssl_rsa_key);


### PR DESCRIPTION
Fix the following error when compiling with GCC 8.2.1:
```
test/integration/pkcs-sign-verify.int.c: In function ‘template_to_rsa_pub_key’:
test/integration/pkcs-sign-verify.int.c:703:1: error: label ‘error’ defined but not used [-Werror=unused-label]
 error:
 ^~~~~
test/integration/pkcs-sign-verify.int.c:671:10: error: unused variable ‘ret’ [-Werror=unused-variable]
     bool ret = false;
          ^~~
[...]
cc1: all warnings being treated as errors
```