### PR TITLE
session_ctx: move opdata back from token scope

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,7 +123,8 @@ check_PROGRAMS += \
     test/integration/pkcs-initialize-finalize.int \
     test/integration/pkcs-misc.int \
     test/integration/pkcs-crypt.int \
-    test/integration/pkcs-keygen.int
+    test/integration/pkcs-keygen.int \
+    test/integration/pkcs-session-state.int
 
 XFAIL_TESTS=test/unit/test_pkcs11
 
@@ -160,6 +161,10 @@ test_integration_pkcs_crypt_int_SOURCES = test/integration/pkcs-crypt.int.c
 test_integration_pkcs_keygen_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_keygen_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
 test_integration_pkcs_keygen_int_SOURCES = test/integration/pkcs-keygen.int.c
+
+test_integration_pkcs_session_state_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_pkcs_session_state_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-state.c
 
 endif
 # END INTEGRATION

--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -11,10 +11,9 @@
 
 #include <openssl/evp.h>
 
-#include "pkcs11.h"
 #include "object.h"
-
-typedef struct token token;
+#include "pkcs11.h"
+#include "session_ctx.h"
 
 typedef struct digest_op_data digest_op_data;
 struct digest_op_data {
@@ -30,21 +29,21 @@ struct digest_op_data {
 digest_op_data *digest_op_data_new(void);
 void digest_op_data_free(digest_op_data **opdata);
 
-CK_RV digest_init_op(token *tok, digest_op_data *opdata, CK_MECHANISM_TYPE mechanism);
-static inline CK_RV digest_init(token *tok, CK_MECHANISM *mechanism) {
-    return digest_init_op(tok, NULL, mechanism->mechanism);
+CK_RV digest_init_op(session_ctx *ctx, digest_op_data *supplied_opdata, CK_MECHANISM_TYPE mechanism);
+static inline CK_RV digest_init(session_ctx *ctx, CK_MECHANISM *mechanism) {
+    return digest_init_op(ctx, NULL, mechanism->mechanism);
 }
 
-CK_RV digest_update_op(token *tok, digest_op_data *opdata, unsigned char *part, unsigned long part_len);
-static inline CK_RV digest_update(token *tok, unsigned char *part, unsigned long part_len) {
-    return digest_update_op(tok, NULL, part, part_len);
+CK_RV digest_update_op(session_ctx *ctx, digest_op_data *supplied_opdata, CK_BYTE_PTR part, CK_ULONG part_len);
+static inline CK_RV digest_update(session_ctx *ctx, unsigned char *part, unsigned long part_len) {
+    return digest_update_op(ctx, NULL, part, part_len);
 }
 
-CK_RV digest_final_op(token *tok, digest_op_data *opdata, unsigned char *digest, unsigned long *digest_len);
-static inline CK_RV digest_final(token *tok, unsigned char *digest, unsigned long *digest_len) {
-    return digest_final_op(tok, NULL, digest, digest_len);
+CK_RV digest_final_op(session_ctx *ctx, digest_op_data *supplied_opdata, CK_BYTE_PTR digest, CK_ULONG_PTR digest_len);
+static inline CK_RV digest_final(session_ctx *ctx, unsigned char *digest, unsigned long *digest_len) {
+    return digest_final_op(ctx, NULL, digest, digest_len);
 }
 
-CK_RV digest_oneshot(token *tok, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len);
+CK_RV digest_oneshot(session_ctx *ctx, unsigned char *data, unsigned long data_len, unsigned char *digest, unsigned long *digest_len);
 
 #endif /* SRC_LIB_DIGEST_H_ */

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -21,44 +21,44 @@ struct encrypt_op_data {
 encrypt_op_data *encrypt_op_data_new(void);
 void encrypt_op_data_free(encrypt_op_data **opdata);
 
-CK_RV encrypt_init_op (token *tok, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
-static inline CK_RV encrypt_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
-    return encrypt_init_op(tok, NULL, mechanism, key);
+CK_RV encrypt_init_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+static inline CK_RV encrypt_init(session_ctx *ctx, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+    return encrypt_init_op(ctx, NULL, mechanism, key);
 }
 
-CK_RV encrypt_update_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
-static inline CK_RV encrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
-    return encrypt_update_op (tok, NULL, part, part_len, encrypted_part, encrypted_part_len);
+CK_RV encrypt_update_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+static inline CK_RV encrypt_update (session_ctx *ctx, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+    return encrypt_update_op (ctx, NULL, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV encrypt_final_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
-static inline CK_RV encrypt_final (token *tok, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
-    return encrypt_final_op (tok, NULL, last_encrypted_part, last_encrypted_part_len);
+CK_RV encrypt_final_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
+static inline CK_RV encrypt_final (session_ctx *ctx, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
+    return encrypt_final_op (ctx, NULL, last_encrypted_part, last_encrypted_part_len);
 }
 
-CK_RV decrypt_init_op (token *tok, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
-static inline CK_RV decrypt_init (token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
-    return decrypt_init_op (tok, NULL, mechanism, key);
+CK_RV decrypt_init_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+static inline CK_RV decrypt_init (session_ctx *ctx, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
+    return decrypt_init_op (ctx, NULL, mechanism, key);
 }
 
-CK_RV decrypt_update_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
-static inline CK_RV decrypt_update (token *tok, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
-        return decrypt_update_op (tok, NULL, part, part_len, encrypted_part, encrypted_part_len);
+CK_RV decrypt_update_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len);
+static inline CK_RV decrypt_update (session_ctx *ctx, unsigned char *part, unsigned long part_len, unsigned char *encrypted_part, unsigned long *encrypted_part_len) {
+        return decrypt_update_op (ctx, NULL, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV decrypt_final_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *last_part, unsigned long *last_part_len);
-static inline CK_RV decrypt_final (token *tok,  unsigned char *last_part, unsigned long *last_part_len) {
-    return decrypt_final_op (tok, NULL, last_part, last_part_len);
+CK_RV decrypt_final_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_part, unsigned long *last_part_len);
+static inline CK_RV decrypt_final (session_ctx *ctx,  unsigned char *last_part, unsigned long *last_part_len) {
+    return decrypt_final_op (ctx, NULL, last_part, last_part_len);
 }
 
-CK_RV decrypt_oneshot_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
-static inline CK_RV decrypt_oneshot (token *tok, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
-    return decrypt_oneshot_op (tok, NULL, encrypted_data, encrypted_data_len, data, data_len);
+CK_RV decrypt_oneshot_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);
+static inline CK_RV decrypt_oneshot (session_ctx *ctx, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len) {
+    return decrypt_oneshot_op (ctx, NULL, encrypted_data, encrypted_data_len, data, data_len);
 }
 
-CK_RV encrypt_oneshot_op (token *tok, encrypt_op_data *supplied_opdata, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
-static inline CK_RV encrypt_oneshot (token *tok, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
-    return encrypt_oneshot_op (tok, NULL, data, data_len, encrypted_data, encrypted_data_len);
+CK_RV encrypt_oneshot_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len);
+static inline CK_RV encrypt_oneshot (session_ctx *ctx, unsigned char *data, unsigned long data_len, unsigned char *encrypted_data, unsigned long *encrypted_data_len) {
+    return encrypt_oneshot_op (ctx, NULL, data, data_len, encrypted_data, encrypted_data_len);
 }
 
 #endif /* SRC_LIB_ENCRYPT_H_ */

--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -297,7 +297,7 @@ CK_RV check_common_attrs(
 }
 
 CK_RV key_gen (
-        token *tok,
+        session_ctx *ctx,
 
         CK_MECHANISM_PTR mechanism,
 
@@ -319,6 +319,9 @@ CK_RV key_gen (
     tobject *new_tobj = NULL;
 
     tpm_object_data objdata = { 0 };
+
+    token *tok = session_ctx_get_token(ctx);
+    assert(tok);
 
     rv = check_common_attrs(
             private_key_template,

--- a/src/lib/key.h
+++ b/src/lib/key.h
@@ -12,7 +12,7 @@ typedef struct token token;
 typedef struct session_ctx session_ctx;
 
 CK_RV key_gen (
-        token *tok,
+        session_ctx *ctx,
 
         CK_MECHANISM_PTR mechanism,
 

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -15,6 +15,7 @@
 #include "utils.h"
 
 typedef struct token token;
+typedef struct session_ctx session_ctx;
 
 typedef struct pobject pobject;
 struct pobject {
@@ -104,13 +105,13 @@ void sobject_free(sobject *sobj);
 void wrappingobject_free(wrappingobject *wobj);
 void sealobject_free(sealobject *sealobj);
 
-CK_RV object_find_init(token *tok, CK_ATTRIBUTE_PTR templ, unsigned long count);
+CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, unsigned long count);
 
-CK_RV object_find(token *tok, CK_OBJECT_HANDLE *object, unsigned long max_object_count, unsigned long *object_count);
+CK_RV object_find(session_ctx *ctx, CK_OBJECT_HANDLE *object, unsigned long max_object_count, unsigned long *object_count);
 
-CK_RV object_find_final(token *tok);
+CK_RV object_find_final(session_ctx *ctx);
 
-CK_RV object_get_attributes(token *tok, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count);
+CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, unsigned long count);
 
 /**
  * Given an attribute type, retrieves the attribute data if present.

--- a/src/lib/random.c
+++ b/src/lib/random.c
@@ -10,9 +10,12 @@
 #include "token.h"
 #include "tpm.h"
 
-CK_RV random_get(token *tok, CK_BYTE_PTR random_data, CK_ULONG random_len) {
+CK_RV random_get(session_ctx *ctx, CK_BYTE_PTR random_data, CK_ULONG random_len) {
 
     check_pointer(random_data);
+
+    token *tok = session_ctx_get_token(ctx);
+    assert(tok);
 
     tpm_ctx *tpm = tok->tctx;
 
@@ -21,9 +24,12 @@ CK_RV random_get(token *tok, CK_BYTE_PTR random_data, CK_ULONG random_len) {
     return res ? CKR_OK: CKR_GENERAL_ERROR;
 }
 
-CK_RV seed_random(token *tok, CK_BYTE_PTR seed, CK_ULONG seed_len) {
+CK_RV seed_random(session_ctx *ctx, CK_BYTE_PTR seed, CK_ULONG seed_len) {
 
     check_pointer(seed);
+
+    token *tok = session_ctx_get_token(ctx);
+    assert(tok);
 
     tpm_ctx *tpm = tok->tctx;
     CK_RV rv = tpm_stirrandom(tpm, seed, seed_len);

--- a/src/lib/random.h
+++ b/src/lib/random.h
@@ -7,12 +7,13 @@
 #define SRC_PKCS11_RANDOM_H_
 
 #include "pkcs11.h"
+#include "session_ctx.h"
 
 typedef struct token token;
 typedef struct session_ctx session_ctx;
 
-CK_RV random_get(token *tok, unsigned char *random_data, unsigned long random_len);
+CK_RV random_get(session_ctx *ctx, unsigned char *random_data, unsigned long random_len);
 
-CK_RV seed_random(token *tok, unsigned char *seed, unsigned long seed_len);
+CK_RV seed_random(session_ctx *ctx, unsigned char *seed, unsigned long seed_len);
 
 #endif /* SRC_PKCS11_RANDOM_H_ */

--- a/src/lib/session.c
+++ b/src/lib/session.c
@@ -137,8 +137,11 @@ CK_RV session_lookup(CK_SESSION_HANDLE session, token **tok, session_ctx **ctx) 
 }
 
 
-CK_RV session_login(token *tok, CK_USER_TYPE user_type,
+CK_RV session_login(session_ctx *ctx, CK_USER_TYPE user_type,
         CK_BYTE_PTR pin, CK_ULONG pin_len) {
+
+    token *tok = session_ctx_get_token(ctx);
+    assert(tok);
 
     twist tpin = NULL;
     CK_RV rv = CKR_GENERAL_ERROR;

--- a/src/lib/session.h
+++ b/src/lib/session.h
@@ -29,7 +29,7 @@ CK_RV session_closeall(CK_SLOT_ID slot_id);
 
 CK_RV session_lookup(CK_SESSION_HANDLE session, token **tok, session_ctx **ctx);
 
-CK_RV session_login(token *tok, CK_USER_TYPE user_type,
+CK_RV session_login(session_ctx *ctx, CK_USER_TYPE user_type,
         unsigned char *pin, unsigned long pin_len);
 
 CK_RV session_logout(token *tok );

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -15,6 +15,24 @@
 typedef enum token_login_state token_login_state;
 typedef struct session_ctx session_ctx;
 
+typedef enum operation operation;
+enum operation {
+    operation_none = 0,
+    operation_find,
+    operation_sign,
+    operation_verify,
+    operation_encrypt,
+    operation_decrypt,
+    operation_digest,
+    operation_count
+};
+
+typedef struct generic_opdata generic_opdata;
+struct generic_opdata {
+    operation op;
+    void *data;
+};
+
 /**
  * Frees a session context
  * @param ctx
@@ -26,14 +44,14 @@ void session_ctx_free(session_ctx *ctx);
  * Creates a new session context within a given token.
  * @param ctx
  *  The new session context generated,
- * @param state
- *  The token login state for setting the proper initial session state.
+ * @param tok
+ *  The token the session is created on.
  * @param flags
  *  The session flags
  * @return
  *  CKR_OK on success.
  */
-CK_RV session_ctx_new(session_ctx **ctx, token_login_state state, CK_FLAGS flags);
+CK_RV session_ctx_new(session_ctx **ctx, token *tok, CK_FLAGS flags);
 
 /**
  * Internal locking routine, use the session_ctx_lock and session_ctx_unlock macros.
@@ -59,6 +77,8 @@ CK_STATE session_ctx_state_get(session_ctx *ctx);
  *  The CK_STATE flags.
  */
 CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
+
+token *session_ctx_get_token(session_ctx *ctx);
 
 // XXX moveme
 CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
@@ -88,5 +108,52 @@ void session_ctx_login_event(session_ctx *ctx, CK_USER_TYPE user);
  *  The session context to transition.
  */
 void session_ctx_logout_event(session_ctx *ctx);
+
+/**
+ * Determines if the opdata is in use
+ * @param ctx
+ *  The token
+ * @return
+ */
+bool session_ctx_opdata_is_active(session_ctx *ctx);
+
+typedef void (*opdata_free_fn)(void **opdata);
+
+/**
+ * Sets operational specific data. Callers should take care to ensure
+ * no other users are using it by calling session_ctx_opdata_is_active()
+ * before setting the data.
+ *
+ * @param tok
+ *  The session_ctx to set operational data on
+ * @param op
+ *  The operation setting the data
+ * @param data
+ *  The data to set
+ */
+void session_ctx_opdata_set(session_ctx *ctx, operation op, void *data, opdata_free_fn fn);
+
+/**
+ * Clears the session_ctx opdata state. NOTE that callers
+ * are required to perfrom memory managment on what
+ * is stored in the void pointer.
+ * @param tok
+ *  The session_ctx to clear operational data from.
+ */
+void session_ctx_opdata_clear(session_ctx *ctx);
+
+/**
+ * Sets the operation specific state data
+ * @param tok
+ *  The token to set the operation state data
+ * @param op
+ *  The operation setting it
+ * @param data
+ *  The data to set
+ * @return
+ *  CKR_OK on success.
+ */
+#define session_ctx_opdata_get(ctx, op, data) _session_ctx_opdata_get(ctx, op, (void **)data)
+CK_RV _session_ctx_opdata_get(session_ctx *ctx, operation op, void **data);
 
 #endif /* SRC_PKCS11_SESSION_CTX_H_ */

--- a/src/lib/session_table.c
+++ b/src/lib/session_table.c
@@ -70,7 +70,7 @@ CK_RV session_table_new_entry(session_table *t, CK_SESSION_HANDLE *handle,
     session_ctx **open_slot = &t->table[t->free_handle];
     assert(!*open_slot);
 
-    CK_RV rv = session_ctx_new(open_slot, tok->login_state, flags);
+    CK_RV rv = session_ctx_new(open_slot, tok, flags);
     if (rv != CKR_OK) {
         return rv;
     }

--- a/src/lib/sign.h
+++ b/src/lib/sign.h
@@ -7,27 +7,26 @@
 #define _SRC_LIB_SIGN_H_
 
 #include "pkcs11.h"
+#include "session_ctx.h"
 
-typedef struct token token;
+CK_RV sign_init(session_ctx *ctx, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV sign_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+CK_RV sign_update(session_ctx *ctx, unsigned char *part, unsigned long part_len);
 
-CK_RV sign_update(token *tok, unsigned char *part, unsigned long part_len);
+CK_RV sign_final_ex(session_ctx *ctx, unsigned char *signature, unsigned long *signature_len, bool is_oneshot);
 
-CK_RV sign_final_ex(token *tok, unsigned char *signature, unsigned long *signature_len, bool is_oneshot);
-
-static inline CK_RV sign_final(token *tok, unsigned char *signature, unsigned long *signature_len) {
-    return sign_final_ex(tok, signature, signature_len, false);
+static inline CK_RV sign_final(session_ctx *ctx, unsigned char *signature, unsigned long *signature_len) {
+    return sign_final_ex(ctx, signature, signature_len, false);
 }
 
-CK_RV sign(token *tok, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long *signature_len);
+CK_RV sign(session_ctx *ctx, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long *signature_len);
 
-CK_RV verify_init(token *tok, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+CK_RV verify_init(session_ctx *ctx, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
 
-CK_RV verify_update(token *tok, unsigned char *part, unsigned long part_len);
+CK_RV verify_update(session_ctx *ctx, unsigned char *part, unsigned long part_len);
 
-CK_RV verify_final(token *tok, unsigned char *signature, unsigned long signature_len);
+CK_RV verify_final(session_ctx *ctx, unsigned char *signature, unsigned long signature_len);
 
-CK_RV verify(token *tok, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len);
+CK_RV verify(session_ctx *ctx, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len);
 
 #endif

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -38,6 +38,8 @@ void token_free(token *t) {
 
     session_table_free(t->s_table);
 
+    twist_free(t->pobject.objauth);
+
     twist_free(t->sopobjauth);
     twist_free(t->sopobjauthkeysalt);
 
@@ -58,6 +60,11 @@ void token_free(token *t) {
     }
 
     tpm_ctx_free(t->tctx);
+
+    /*
+     * for each session remove them
+     */
+    session_table_free_ctx_all(t);
 
     mutex_destroy(t->mutex);
 }
@@ -352,33 +359,6 @@ error:
     twist_free(sealobjauth);
 
     return rv;
-}
-
-bool token_opdata_is_active(token *tok) {
-
-    return tok->opdata.op != operation_none;
-}
-
-void token_opdata_set(token *tok, operation op, void *data) {
-
-    tok->opdata.op = op;
-    tok->opdata.data = data;
-}
-
-void token_opdata_clear(token *tok) {
-
-    token_opdata_set(tok, operation_none, NULL);
-}
-
-CK_RV _token_opdata_get(token *tok, operation op, void **data) {
-
-    if (op != tok->opdata.op) {
-        return CKR_OPERATION_NOT_INITIALIZED;
-    }
-
-    *data = tok->opdata.data;
-
-    return CKR_OK;
 }
 
 void token_lock(token *t) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+ /* SPDX-License-Identifier: BSD-2 */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
@@ -17,29 +17,11 @@
 typedef struct session_table session_table;
 typedef struct session_ctx session_ctx;
 
-typedef enum operation operation;
-enum operation {
-    operation_none = 0,
-    operation_find,
-    operation_sign,
-    operation_verify,
-    operation_encrypt,
-    operation_decrypt,
-    operation_digest,
-    operation_count
-};
-
 typedef enum token_login_state token_login_state;
 enum token_login_state {
     token_no_one_logged_in = 0,
     token_user_logged_in   = 1 << 0,
     token_so_logged_in     = 1 << 1,
-};
-
-typedef struct generic_opdata generic_opdata;
-struct generic_opdata {
-    operation op;
-    void *data;
 };
 
 typedef struct token token;
@@ -76,8 +58,6 @@ struct token {
     token_login_state login_state;
 
     tpm_ctx *tctx;
-
-    generic_opdata opdata;
 
     void *mutex;
 };
@@ -129,51 +109,6 @@ CK_RV token_login(token *tok, twist pin, CK_USER_TYPE user);
  *  CKR_OK on success, anything else is a failure.
  */
 CK_RV token_logout(token *tok);
-
-/**
- * Determines if the opdata is in use
- * @param ctx
- *  The token
- * @return
- */
-bool token_opdata_is_active(token *tok);
-
-/**
- * Sets operational specific data. Callers should take care to ensure
- * no other users are using it by calling token_opdata_is_active()
- * before setting the data.
- *
- * @param tok
- *  The token to set operational data on
- * @param op
- *  The operation setting the data
- * @param data
- *  The data to set
- */
-void token_opdata_set(token *tok, operation op, void *data);
-
-/**
- * Clears the token opdata state. NOTE that callers
- * are required to perfrom memory managment on what
- * is stored in the void pointer.
- * @param tok
- *  The token to clear operational data from.
- */
-void token_opdata_clear(token *tok);
-
-/**
- * Sets the operation specific state data
- * @param tok
- *  The token to set the operation state data
- * @param op
- *  The operation setting it
- * @param data
- *  The data to set
- * @return
- *  CKR_OK on success.
- */
-#define token_opdata_get(ctx, op, data) _token_opdata_get(ctx, op, (void **)data)
-CK_RV _token_opdata_get(token *tok, operation op, void **data);
 
 /**
  * TODO

--- a/test/integration/pkcs-session-state.c
+++ b/test/integration/pkcs-session-state.c
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: BSD-2 */
+/***********************************************************************
+ * Copyright (c) 2019, Intel Corporation
+ *
+ * All rights reserved.
+ ***********************************************************************/
+
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/bn.h>
+#include <openssl/err.h>
+
+#include "test.h"
+
+struct test_info {
+    CK_SLOT_ID slot;
+    CK_OBJECT_HANDLE key;
+    CK_SESSION_HANDLE session[2];
+};
+
+static test_info *test_info_new(void) {
+
+    test_info *ti = calloc(1, sizeof(*ti));
+    assert_non_null(ti);
+
+    CK_SLOT_ID slots[6];
+    CK_ULONG count = ARRAY_LEN(slots);
+    CK_RV rv = C_GetSlotList(true, slots, &count);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_OpenSession(slots[0], CKF_SERIAL_SESSION | CKF_RW_SESSION,
+            NULL, NULL, &ti->session[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_OpenSession(slots[0], CKF_SERIAL_SESSION | CKF_RW_SESSION,
+            NULL, NULL, &ti->session[1]);
+    assert_int_equal(rv, CKR_OK);
+
+    ti->slot = slots[0];
+
+    user_login(ti->session[0]);
+
+    CK_OBJECT_CLASS key_class = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE key_type = CKK_RSA;
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS, &key_class, sizeof(key_class) },
+        { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
+    };
+
+    rv = C_FindObjectsInit(ti->session[0], tmpl, ARRAY_LEN(tmpl));
+    assert_int_equal(rv, CKR_OK);
+
+    count = 1;
+    rv = C_FindObjects(ti->session[0], &ti->key, count, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(ti->session[0]);
+    assert_int_equal(rv, CKR_OK);
+
+    return ti;
+}
+
+static int test_setup(void **state) {
+
+    /* get the slots */
+    test_info *ti = test_info_new();
+
+    *state = ti;
+
+    return 0;
+}
+
+static int test_teardown(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    CK_RV rv = C_CloseAllSessions(ti->slot);
+    assert_int_equal(rv, CKR_OK);
+
+    free(ti);
+
+    return 0;
+}
+
+static void test_session_operation_state(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    CK_MECHANISM dmech = {
+        .mechanism = CKM_SHA256,
+        .pParameter = NULL,
+        .ulParameterLen = 0
+    };
+
+    CK_MECHANISM smech = {
+        .mechanism = CKM_SHA256_RSA_PKCS,
+        .pParameter = NULL,
+        .ulParameterLen = 0
+    };
+
+    CK_BYTE iv[16] = {0};
+
+    CK_MECHANISM emech = {
+        .mechanism = CKM_AES_CBC,
+        .pParameter = &iv,
+        .ulParameterLen = sizeof(iv)
+    };
+
+
+    CK_RV rv = C_DigestInit(ti->session[0], &dmech);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_DigestInit(ti->session[0], &dmech);
+    assert_int_equal(rv, CKR_OPERATION_ACTIVE);
+
+    rv = C_SignInit(ti->session[0], &smech, ti->key);
+    assert_int_equal(rv, CKR_OPERATION_ACTIVE);
+
+    rv = C_SignInit(ti->session[1], &smech, ti->key);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_DigestInit(ti->session[1], &dmech);
+    assert_int_equal(rv, CKR_OPERATION_ACTIVE);
+
+    rv = C_EncryptInit(ti->session[1], &emech, ti->key);
+    assert_int_equal(rv, CKR_OPERATION_ACTIVE);
+}
+
+int main() {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_session_operation_state,
+                test_setup, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
Operation state for things like CKR_OPERATION_ACTIVE should be
session scope, not token scope. Correct this by moving opdata
managment back into the session_ctx structure. Also, since some
memory leaks occur if C_Logout() and C_CloseSession() are not
called, and entangled in the opdata managment, fix those leaks
as well.

Fixes: #142

Signed-off-by: William Roberts <william.c.roberts@intel.com>