### PR TITLE
configure.ac: state on “./configure --help” how to disable the hardening

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,8 +236,8 @@ AM_CONDITIONAL([HAVE_P11KIT], [test "x$have_p11kit" = "xyes"])
 # END P11 CONFIG
 
 AC_ARG_ENABLE([hardening],
-  [AS_HELP_STRING([--enable-hardening],
-    [Enable compiler and linker options to frustrate memory corruption exploits @<:@yes@:>@])],
+  [AS_HELP_STRING([--disable-hardening],
+    [Disable compiler and linker options to frustrate memory corruption exploits])],
   [hardening="$enableval"],
   [hardening="yes"])
 


### PR DESCRIPTION
For features enabled by default the output of “./configure --help” shall state how to disable them.

Printing on “./configure --help” --disable-X implies that by default the feature X is enabled.