### PR TITLE
Delete codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - test


### PR DESCRIPTION
Our code coverage jumped incorrectly from 74ish% to 90+%. You can see the jump in this commit that has no bearing on codecov: https://codecov.io/gh/tpm2-software/tpm2-pkcs11/commit/58b5cbc1b4f9939f57fdf805cccf99f05c97b754

I'm not sure if this is an issue with codecov or with this configuration. Not sure why we are ignoring test, I guess we want to see coverage metrics but ignore the line hit data under test?

I'd like to see what this build comes back with.