### PR TITLE
tools/tests: add a test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,7 +191,8 @@ noinst_LTLIBRARIES = $(libtpm2_test_pkcs11) $(libtpm2_test_internal)
 
 ## End of test libraries, start tests ##
 
-TESTS = $(check_PROGRAMS)
+TESTS = $(check_PROGRAMS) \
+    tools/run-python-tests
 check_PROGRAMS += \
     test/unit/test_twist
 

--- a/tools/run-python-tests
+++ b/tools/run-python-tests
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd "${BASH_SOURCE%/*}" || exit 1
+exec "${PYTHON_INTERPRETER:-python}" setup.py test

--- a/tools/tests/test_tpm2_ptool.py
+++ b/tools/tests/test_tpm2_ptool.py
@@ -1,0 +1,19 @@
+# tpm2_ptool command tests
+
+import os
+import subprocess
+import unittest
+
+tpm2_ptool = os.path.realpath(os.path.join(os.path.dirname(__file__),
+                                           '..', 'tpm2_ptool'))
+
+
+class TestTpm2Ptool(unittest.TestCase):
+    def test_usage(self):
+        # usage -> rc=2
+        rc = subprocess.call(['tpm2_ptool'])
+        self.assertEqual(rc, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/tpm2_pkcs11/command.py
+++ b/tools/tpm2_pkcs11/command.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 
 class commandlet(object):
@@ -62,6 +63,7 @@ class commandlet(object):
             commandlet.get()[d['which']](d)
         else:
             opt_parser.print_usage()
+            sys.exit(2)
 
 
 class Command(object):


### PR DESCRIPTION
Without bits from my simple branch this might not pass CI.

CI should run these commands:
PYTHON_INTERPRETER=python2 python setup.py test
PYTHON_INTERPRETER=python3 python setup.py test

It can either fail because there is required modules are not defiined or installed or tpm2_ptool fails to run without arguments.

Signed-off-by: Markus Linnala <markus.linnala@gmail.com>