### PR TITLE
tpm2_ptool: quote arguments properly

### DIFF
--- a/tools/tpm2_ptool
+++ b/tools/tpm2_ptool
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-"${PYTHON_INTERPRETER:-python}" -m tpm2_pkcs11.tpm2_ptool $@
+"${PYTHON_INTERPRETER:-python}" -m tpm2_pkcs11.tpm2_ptool "$@"


### PR DESCRIPTION
Fixes case like:

    tpm2_ptool import --path 'path with space'

Signed-off-by: Markus Linnala <markus.linnala@gmail.com>