### PR TITLE
configure.ac: tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -286,7 +286,7 @@ AS_IF([test x"$hardening" != x"no"], [
 
 ], [
   AC_MSG_WARN([Compiling with --disable-hardening is dangerous!
-you should consider fixing the configure script compiler flags
+You should consider fixing the configure script compiler flags
 and submitting patches upstream!])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,6 @@ AC_ARG_ENABLE(
   [AS_HELP_STRING([--disable-dlclose],
                             [Some versions of libc cause a sigsegv on exit with dlclose(),
                             this disables the dlclose() and works around that bug])],
-  []
   [AC_DEFINE([DISABLE_DLCLOSE], [1],
   [Some versions of libc cause a sigsegv on exit with dlcolse(), this disables the dlclose()
   and works around that bug])]

--- a/configure.ac
+++ b/configure.ac
@@ -92,8 +92,7 @@ AS_IF([test "x$esapi_sf" = "xyes"],
 AC_ARG_ENABLE(
   [unit],
   [AS_HELP_STRING([--enable-unit],
-    [build cmocka unit tests])],
-  [enable_unit=$enableval],
+    [build cmocka unit tests])],,
   [enable_unit=no])
 
 AC_DEFUN([unit_test_checks],[
@@ -118,8 +117,7 @@ AM_CONDITIONAL([UNIT], [test "x$enable_unit" = "xyes"])
 AC_ARG_ENABLE(
   [integration],
   [AS_HELP_STRING([--enable-integration],
-    [build and execute integration tests])],
-  [enable_integration=$enableval],
+    [build and execute integration tests])],,
   [enable_integration=no])
 
 AC_DEFUN([integration_test_checks], [
@@ -173,8 +171,7 @@ AC_DEFUN([handle_store_dir],[
 AC_ARG_WITH(
   [storedir],
   [AS_HELP_STRING([--with-storedir=DIR],[Store directory for searching, defaults to /etc/tpm2_pkcs11])],
-    [handle_store_dir],
-  []
+    [handle_store_dir]
 )
 
 # END WITH STOREDIR
@@ -186,8 +183,7 @@ AC_ARG_WITH(
 AC_ARG_ENABLE(
   [pack],
   [AS_HELP_STRING([--enable-pack=]@<:@yes/no@:>@,
-    [Pack the structures. (default is no, except on Windows, where it defaults to packing)])],
-  [enable_pack=$enableval],
+    [Pack the structures. (default is no, except on Windows, where it defaults to packing)])],,
   [enable_pack=no])
 
 AS_IF([test "x$enable_pack" = "xyes"],

--- a/configure.ac
+++ b/configure.ac
@@ -232,14 +232,13 @@ AM_CONDITIONAL([HAVE_P11KIT], [test "x$have_p11kit" = "xyes"])
 
 AC_ARG_ENABLE([hardening],
   [AS_HELP_STRING([--disable-hardening],
-    [Disable compiler and linker options to frustrate memory corruption exploits])],
-  [hardening="$enableval"],
-  [hardening="yes"])
+    [Disable compiler and linker options to frustrate memory corruption exploits])],,
+  [enable_hardening="yes"])
 
 # Good information on adding flags, and dealing with compilers can be found here:
 #   https://github.com/zcash/zcash/issues/1832
 #   https://github.com/kmcallister/autoharden/
-AS_IF([test x"$hardening" != x"no"], [
+AS_IF([test x"$enable_hardening" != xno], [
 
   AC_DEFUN([add_hardened_c_flag], [
     AX_CHECK_COMPILE_FLAG([$1],


### PR DESCRIPTION
* Replace variable hardening with enable_hardening, as the latter is filled implicitly by configure/AC_ARG_ENABLE and has the same purpose as the former.
* Typo
* Remove redundant code (AC_ARG_ENABLE(a, b, c, d) sets anyway enable_a to $enableval, so the third parameter can only do additional things)