### PR TITLE
Makefile.am: delete default for test_unit_test_twist_SOURCES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,7 +197,6 @@ check_PROGRAMS += \
 
 test_unit_test_twist_CFLAGS    = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_twist_LDADD     = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
-test_unit_test_twist_SOURCES   = test/unit/test_twist.c
 
 endif
 # END UNIT


### PR DESCRIPTION
see https://www.gnu.org/software/automake/manual/html_node/Default-_005fSOURCES.html.