### PR TITLE
Include config.h for --with-storedir to work

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -18,6 +18,7 @@
 
 #include <sqlite3.h>
 
+#include "config.h"
 #include "db.h"
 #include "log.h"
 #include "mutex.h"


### PR DESCRIPTION
config.h needs to be included in order for configure --with-storedir to work.

Fixes: #29b2536f ("db: add search logic")

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>