### PR TITLE
Fix CodeCov.io Codecoverage

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -8,7 +8,7 @@
 set -e
 
 source $TRAVIS_BUILD_DIR/.ci/docker-prelude.sh
-
+apt-get install -y curl
 if [ -d build ]; then
   rm -rf build
 fi
@@ -83,6 +83,10 @@ fi
 ../configure --enable-unit --enable-integration --enable-esapi-session-manage-flags $config_flags
 make -j$(nproc)
 make -j$(nproc) check
+
+if [ "$CC" == "gcc" ] && [ "$PYTHON_INTERPRETER" == "python3" ]; then
+    bash <(curl -s https://codecov.io/bash)
+fi
 
 popd
 

--- a/.ci/travis.run
+++ b/.ci/travis.run
@@ -19,7 +19,8 @@ if [ "$TRAVIS_BRANCH" != "coverity_scan" ]; then
   #
   # Execute the build and test procedure by running .ci/docker.run
   #
-  docker run --env-file .ci/docker.env \
+  ci_env=`bash <(curl -s https://codecov.io/env)`
+  docker run $ci_env --env-file .ci/docker.env \
     -v `pwd`:/workspace/tpm2-pkcs11 tpm2software/tpm2-tss \
     /bin/bash -c '/workspace/tpm2-pkcs11/.ci/docker.run'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,3 @@ script:
   - ./.ci/travis.run
 after_failure:
   - cat build/test-suite.log
-after_success:
-  - |
-    if [ "$CC" == "gcc" ] && [ "$PYTHON_INTERPRETER" == "python3" ]; then
-        bash <(curl -s https://codecov.io/bash)
-    fi


### PR DESCRIPTION
The current codecov.io code coverage job in travis fails,
since the testing is done within a docker container and the
outside job cannot access the coverage reports.

https://docs.codecov.io/docs/testing-with-docker provides two solutions
for this - either copy the files via a shared folder, or just run
codecov within the container.

We now run it within the container, for this we need to install curl
first.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>