### PR TITLE
Style fixes

### DIFF
--- a/docs/coding_standard_c.txt
+++ b/docs/coding_standard_c.txt
@@ -111,21 +111,21 @@ Variables should be declared and scoped to the smallest scope of use.
 ```c
 /* This should be avoided */
 void foo() {
-	unsigned i;
-	do_something();
-	for(i=0; i < 100; i++) {
-		do_more(i);
-	}
+    unsigned i;
+    do_something();
+    for(i=0; i < 100; i++) {
+        do_more(i);
+    }
 }
 
 /* Proper variable scope */
 void foo() {
 
-	do_something();
-	unsigned i;
-	for(i=0; i < 100; i++) {
-		do_more(i);
-	}
+    do_something();
+    unsigned i;
+    for(i=0; i < 100; i++) {
+        do_more(i);
+    }
 }
 ```
 

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -87,7 +87,7 @@ class NewKeyCommandBase(Command):
 
         pubattrs = None
         privattrs = None
-        
+
         if alg.startswith('rsa'):
             pubattrs = [
                 {
@@ -106,7 +106,7 @@ class NewKeyCommandBase(Command):
                     CKA_PUBLIC_EXPONENT: 65537
                 },
             ]
-            
+
             privattrs = [
                 {
                     CKA_KEY_TYPE: CKK_RSA

--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -229,14 +229,14 @@ class Db(object):
         c = self._conn.cursor()
         priv = list_dict_to_kvp(privattrs)
         values =  [priv, tid]
-        
+
         if not pubattrs:
             sql = 'UPDATE tobjects SET privattrs=? WHERE id=?'
         else:
             pub = list_dict_to_kvp(pubattrs)
             values.append(pub)
             sql = 'UPDATE tobjects SET privattrs=?, pubattrs=? WHERE id=?'
-        
+
         c.execute(sql, values)
 
     def updatepin(self,


### PR DESCRIPTION
Coding standard says:

> Always use space characters, 4 spaces per level of indentation.

So fix it.

And then fix trailing whitespace introduced recently by 5b8be97ae93944249ffb0d8d10e025b65eb72e87