### PR TITLE
EC keygen and ECDSA sign and verify support

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -8,10 +8,6 @@
 set -e
 
 source $TRAVIS_BUILD_DIR/.ci/docker-prelude.sh
-apt-get install -y curl
-if [ -d build ]; then
-  rm -rf build
-fi
 
 # export ptool location
 export PATH=$PATH:"$TRAVIS_BUILD_DIR"/tools

--- a/src/lib/openssl_compat.c
+++ b/src/lib/openssl_compat.c
@@ -1,0 +1,61 @@
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+
+#include "openssl_compat.h"
+
+#ifndef SRC_LIB_OPENSSL_COMPAT_C_
+#define SRC_LIB_OPENSSL_COMPAT_C_
+
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+
+/*
+ * Pre openssl 1.1 doesn't have EC_POINT_point2buf, so use EC_POINT_point2oct to
+ * create an API compatible version of it.
+ */
+size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
+                          point_conversion_form_t form,
+                          unsigned char **pbuf, BN_CTX *ctx) {
+
+    /* Get the required buffer length */
+    size_t len = EC_POINT_point2oct(group, point, form, NULL, 0, NULL);
+    if (!len) {
+        return 0;
+    }
+
+    /* allocate it */
+    unsigned char *buf = OPENSSL_malloc(len);
+    if (!buf) {
+        return 0;
+    }
+
+    /* convert it */
+    len = EC_POINT_point2oct(group, point, form, buf, len, ctx);
+    if (!len) {
+        OPENSSL_free(buf);
+        return 0;
+    }
+
+    *pbuf = buf;
+    return len;
+}
+
+size_t OBJ_length(const ASN1_OBJECT *obj) {
+
+    if (!obj) {
+        return 0;
+    }
+
+    return obj->length;
+}
+
+const unsigned char *OBJ_get0_data(const ASN1_OBJECT *obj) {
+
+    if (!obj) {
+        return NULL;
+    }
+
+    return obj->data;
+}
+
+#endif
+#endif /* SRC_LIB_OPENSSL_COMPAT_C_ */

--- a/src/lib/openssl_compat.h
+++ b/src/lib/openssl_compat.h
@@ -1,0 +1,18 @@
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+
+#ifndef SRC_LIB_OPENSSL_COMPAT_H_
+#define SRC_LIB_OPENSSL_COMPAT_H_
+
+#if (OPENSSL_VERSION_NUMBER < 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L) /* OpenSSL 1.1.0 */
+#define LIB_TPM2_OPENSSL_OPENSSL_PRE11
+#endif
+
+
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
+                          point_conversion_form_t form,
+                          unsigned char **pbuf, BN_CTX *ctx);
+#endif
+
+#endif /* SRC_LIB_OPENSSL_COMPAT_H_ */

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -127,16 +127,22 @@ struct tpm_object_data {
 
     uint32_t handle;
 
+    CK_MECHANISM_TYPE mechanism;
     union {
         struct {
             twist modulus;
             uint32_t exponent;
         } rsa;
+        struct {
+            twist ecpoint;
+        } ecc;
     };
 
     twist pubblob;
     twist privblob;
 };
+
+void tpm_objdata_free(tpm_object_data *objdata);
 
 CK_RV tpm2_generate_key(
         tpm_ctx *tpm,

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -96,6 +96,15 @@ bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech);
 bool utils_mech_is_rsa_pkcs(CK_MECHANISM_TYPE mech);
 
 /**
+ * True if the mechanism is an EC ECDSA signing scheme.
+ * @param mech
+ *  The mechanism to check.
+ * @return
+ *  True if it is, false otherwise.
+ */
+bool utils_mech_is_ecdsa(CK_MECHANISM_TYPE mech);
+
+/**
  *
  * @param size
  * @return

--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -9,6 +9,7 @@
 #include <openssl/rsa.h>
 #include <openssl/bn.h>
 #include <openssl/err.h>
+#include <openssl/objects.h>
 
 #include "test.h"
 
@@ -65,20 +66,13 @@ static int test_teardown(void **state) {
 GENERIC_ATTR_TYPE_CONVERT(CK_BBOOL);
 GENERIC_ATTR_TYPE_CONVERT(CK_ULONG);
 
-static void verify_missing_rsa_pub_attrs(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h) {
+static void verify_missing_pub_attrs_rsa(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h) {
 
-    CK_BYTE tmp[4][256] = { 0 };
+    CK_BYTE tmp[2][256] = { 0 };
 
-    /*
-     * Skip checking shared values until bug:
-     *   -https://github.com/tpm2-software/tpm2-pkcs11/issues/148
-     * is resolved.
-     */
     CK_ATTRIBUTE attrs[] = {
-            ADD_ATTR_ARRAY(CKA_KEY_TYPE, tmp[0]),
-            ADD_ATTR_ARRAY(CKA_CLASS,    tmp[1]),
-            ADD_ATTR_ARRAY(CKA_MODULUS,  tmp[2]),
-            ADD_ATTR_ARRAY(CKA_MODULUS_BITS,  tmp[3]),
+            ADD_ATTR_ARRAY(CKA_MODULUS,  tmp[0]),
+            ADD_ATTR_ARRAY(CKA_MODULUS_BITS,  tmp[1]),
     };
 
     CK_RV rv = C_GetAttributeValue(session, h, attrs, ARRAY_LEN(attrs));
@@ -88,18 +82,6 @@ static void verify_missing_rsa_pub_attrs(CK_SESSION_HANDLE session, CK_OBJECT_HA
     for (i=0; i < ARRAY_LEN(attrs); i++) {
         CK_ATTRIBUTE_PTR a = &attrs[i];
         switch(a->type) {
-        case CKA_KEY_TYPE: {
-            CK_ULONG v = 0;
-            rv = generic_CK_ULONG(a, &v);
-            assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CKK_RSA);
-        } break;
-        case CKA_CLASS: {
-            CK_ULONG v = 0;
-            rv = generic_CK_ULONG(a, &v);
-            assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CKO_PUBLIC_KEY);
-        } break;
         case CKA_MODULUS: {
             assert_int_not_equal(0, a->ulValueLen);
             assert_non_null(a->pValue);
@@ -116,15 +98,42 @@ static void verify_missing_rsa_pub_attrs(CK_SESSION_HANDLE session, CK_OBJECT_HA
     }
 }
 
-static void verify_missing_rsa_priv_attrs(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h) {
+static void verify_missing_pub_attrs_ecc(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h) {
+
+    CK_BYTE tmp[2][256] = { 0 };
+
+    CK_ATTRIBUTE attrs[] = {
+            ADD_ATTR_ARRAY(CKA_EC_PARAMS,  tmp[0]),
+            ADD_ATTR_ARRAY(CKA_EC_POINT,    tmp[1]),
+    };
+
+    CK_RV rv = C_GetAttributeValue(session, h, attrs, ARRAY_LEN(attrs));
+    assert_int_equal(rv, CKR_OK);
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(attrs); i++) {
+        CK_ATTRIBUTE_PTR a = &attrs[i];
+        switch(a->type) {
+        /* TODO more robust checking here:
+         *  - they are valid DER.
+         *  - The DER values are sane.
+         *  - They match what was expected in generation.
+         */
+        case CKA_EC_PARAMS:
+        case CKA_EC_POINT:
+            assert_int_not_equal(0, a->ulValueLen);
+            assert_non_null(a->pValue);
+        break;
+        default:
+            assert_true(0);
+        }
+    }
+}
+
+static void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h) {
 
     CK_BYTE tmp[5][256] = { 0 };
 
-    /*
-     * Skip checking shared values until bug:
-     *   -https://github.com/tpm2-software/tpm2-pkcs11/issues/148
-     * is resolved.
-     */
     CK_ATTRIBUTE attrs[] = {
             ADD_ATTR_ARRAY(CKA_KEY_TYPE, tmp[0]),
             ADD_ATTR_ARRAY(CKA_CLASS, tmp[1]),
@@ -144,7 +153,7 @@ static void verify_missing_rsa_priv_attrs(CK_SESSION_HANDLE session, CK_OBJECT_H
             CK_ULONG v = 0;
             rv = generic_CK_ULONG(a, &v);
             assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CKK_RSA);
+            assert_int_equal(v, keytype);
         } break;
         case CKA_CLASS: {
             CK_ULONG v = 0;
@@ -176,6 +185,40 @@ static void verify_missing_rsa_priv_attrs(CK_SESSION_HANDLE session, CK_OBJECT_H
     }
 }
 
+static void verify_missing_pub_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h) {
+
+    CK_BYTE tmp[2][256] = { 0 };
+
+    CK_ATTRIBUTE attrs[] = {
+            ADD_ATTR_ARRAY(CKA_KEY_TYPE, tmp[0]),
+            ADD_ATTR_ARRAY(CKA_CLASS,    tmp[1]),
+    };
+
+    CK_RV rv = C_GetAttributeValue(session, h, attrs, ARRAY_LEN(attrs));
+    assert_int_equal(rv, CKR_OK);
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(attrs); i++) {
+        CK_ATTRIBUTE_PTR a = &attrs[i];
+        switch(a->type) {
+        case CKA_KEY_TYPE: {
+            CK_ULONG v = 0;
+            rv = generic_CK_ULONG(a, &v);
+            assert_int_equal(rv, CKR_OK);
+            assert_int_equal(v, keytype);
+        } break;
+        case CKA_CLASS: {
+            CK_ULONG v = 0;
+            rv = generic_CK_ULONG(a, &v);
+            assert_int_equal(rv, CKR_OK);
+            assert_int_equal(v, CKO_PUBLIC_KEY);
+        } break;
+        default:
+            assert_true(0);
+        }
+    }
+}
+
 static void test_rsa_keygen_p11tool_templ(void **state) {
 
     test_info *ti = test_info_from_state(state);
@@ -183,10 +226,10 @@ static void test_rsa_keygen_p11tool_templ(void **state) {
 
     CK_BBOOL ck_true = CK_TRUE;
     CK_BBOOL ck_false = CK_TRUE;
-    CK_BYTE id[] = "p11-templ-key-id";
+    CK_BYTE id[] = "p11-templ-key-id-rsa";
     CK_ULONG bits = 2048;
     CK_BYTE exp[] = { 0x00, 0x01, 0x00, 0x01 }; //65537 in BN
-    CK_UTF8CHAR label[] = "p11-templ-key-label";
+    CK_UTF8CHAR label[] = "p11-templ-key-label-rsa";
 
     CK_ATTRIBUTE pub[] = {
         ADD_ATTR_BASE(CKA_TOKEN,   ck_true),
@@ -276,16 +319,145 @@ static void test_rsa_keygen_p11tool_templ(void **state) {
     assert_int_equal(rv, CKR_OK);
 
     /* verify missing attrs */
-    verify_missing_rsa_pub_attrs(session, pub_handle_dup);
-    verify_missing_rsa_priv_attrs(session, priv_handle_dup);
+    verify_missing_pub_attrs_common(session, CKK_RSA, pub_handle_dup);
+    verify_missing_priv_attrs_common(session, CKK_RSA, priv_handle_dup);
+    verify_missing_pub_attrs_rsa(session, pub_handle_dup);
+}
+
+static void test_ecc_keygen_p11tool_templ(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE session = ti->handle;
+
+    CK_BBOOL ck_true = CK_TRUE;
+    CK_BBOOL ck_false = CK_TRUE;
+    CK_BYTE id[] = "p11-templ-key-id-ecc";
+    CK_UTF8CHAR label[] = "p11-templ-key-label-ecc";
+
+    /*
+     * DER-encoding of an ANSI X9.62 Parameters value
+     *
+     * Windows, surprisingly, had great documentation on how this works:
+     * https://docs.microsoft.com/en-us/windows/desktop/seccertenroll/about-object-identifier
+     */
+    CK_BYTE ec_params[] = {
+        0x06, 0x08, 0x2a, 0x86, 0x48,
+        0xce, 0x3d, 0x03, 0x01, 0x07
+    };
+
+    CK_ATTRIBUTE pub[] = {
+        ADD_ATTR_BASE(CKA_TOKEN,   ck_true),
+        ADD_ATTR_BASE(CKA_PRIVATE, ck_true),
+        ADD_ATTR_ARRAY(CKA_ID, id),
+        ADD_ATTR_BASE(CKA_VERIFY, ck_true),
+        ADD_ATTR_ARRAY(CKA_EC_PARAMS, ec_params),
+        ADD_ATTR_STR(CKA_LABEL, label)
+    };
+
+    CK_ATTRIBUTE priv[] = {
+        ADD_ATTR_ARRAY(CKA_ID, id),
+        ADD_ATTR_BASE(CKA_SIGN, ck_true),
+        ADD_ATTR_BASE(CKA_PRIVATE, ck_true),
+        ADD_ATTR_BASE(CKA_TOKEN,   ck_true),
+        ADD_ATTR_STR(CKA_LABEL, label),
+        ADD_ATTR_BASE(CKA_SENSITIVE, ck_false)
+    };
+
+    CK_MECHANISM mech = {
+        .mechanism = CKM_EC_KEY_PAIR_GEN,
+        .pParameter = NULL,
+        .ulParameterLen = 0
+    };
+
+    CK_OBJECT_HANDLE pubkey;
+    CK_OBJECT_HANDLE privkey;
+
+    user_login(session);
+
+    CK_RV rv = C_GenerateKeyPair (session,
+            &mech,
+            pub, ARRAY_LEN(pub),
+            priv, ARRAY_LEN(priv),
+            &pubkey, &privkey);
+    assert_int_equal(rv, CKR_OK);
+
+    /* verify that we can use it via a sign operation */
+    mech.mechanism =  CKM_ECDSA;
+    rv = C_SignInit(session, &mech, privkey);
+    assert_int_equal(rv, CKR_OK);
+
+    CK_BYTE sig[1024];
+
+    /*
+     * echo -n 'my foo msg' | openssl sha256 | cut -d' ' -f 2-2 | xxd -r -p | xxd -i
+     */
+    CK_BYTE sha256_msg_hash[] = {
+        0xcd, 0xd8, 0x92, 0x1d, 0xf0, 0xcd, 0x29, 0xba, 0x4b, 0x8b, 0x87, 0x12,
+        0x15, 0x07, 0x46, 0xdf, 0xb1, 0x91, 0x50, 0x81, 0xf7, 0xd4, 0x9b, 0xd5,
+        0x67, 0x58, 0xae, 0x5a, 0xa3, 0x2e, 0x47, 0x0d
+    };
+
+    CK_ULONG siglen = sizeof(sig);
+
+    rv = C_Sign(session, sha256_msg_hash, sizeof(sha256_msg_hash), sig,
+            &siglen);
+    assert_int_equal(rv, CKR_OK);
+    /*
+     * Skip checking the siglen. This comes back as a DER encoded R + S portions of the signature.
+     * R + S is 2 times the curve size in bytes (so 64 for P256) but we're not returning that, were
+     * returning the DER encoded format that tools expect, in DER format which may cause leading
+     * bytes to be dropped from, R + S, so the output size isn't stable. But it's definitely not 0.
+     */
+    assert_int_not_equal(siglen, 0);
+
+    /* try the public key verification */
+    rv = C_VerifyInit(session, &mech, pubkey);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_Verify(session, sha256_msg_hash, sizeof(sha256_msg_hash),
+            sig, siglen);
+    assert_int_equal(rv, CKR_OK);
+
+    /* verify we can find it via pub templ */
+    rv = C_FindObjectsInit(session, pub, ARRAY_LEN(pub));
+    assert_int_equal(rv, CKR_OK);
+
+    CK_OBJECT_HANDLE pub_handle_dup;
+    CK_ULONG count = 0;
+    rv = C_FindObjects(session, &pub_handle_dup, 1, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(session);
+    assert_int_equal(rv, CKR_OK);
+
+    /* verify we can find it via priv templ */
+    rv = C_FindObjectsInit(session, priv, ARRAY_LEN(priv));
+    assert_int_equal(rv, CKR_OK);
+
+    count = 0;
+    CK_OBJECT_HANDLE priv_handle_dup;
+    rv = C_FindObjects(session, &priv_handle_dup, 1, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(session);
+    assert_int_equal(rv, CKR_OK);
+
+    /* verify missing attrs */
+    verify_missing_pub_attrs_common(session, CKK_EC, pub_handle_dup);
+    verify_missing_priv_attrs_common(session, CKK_EC, priv_handle_dup);
+    verify_missing_pub_attrs_ecc(session, pub_handle_dup);
 
 }
 
 int main() {
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_rsa_keygen_p11tool_templ,
+        cmocka_unit_test_setup_teardown(test_ecc_keygen_p11tool_templ,
                 test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_rsa_keygen_p11tool_templ,
+            test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);


### PR DESCRIPTION
* Probably want to copy the sign/verify bit to sign/verify tests as the sign/verify in keygen is really about ensuring that the objects function as intended post key generation.