### PR TITLE
object: make public objects a first class citizen

### DIFF
--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -158,10 +158,6 @@ CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj)
             continue;
         }
 
-        if (tobj->link) {
-            tobj = tobj->link;
-        }
-
         // Already loaded, ignored.
         if (tobj->handle) {
             *loaded_tobj = tobj;

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -125,7 +125,8 @@ CK_RV tpm_session_stop(tpm_ctx *ctx);
 typedef struct tpm_object_data tpm_object_data;
 struct tpm_object_data {
 
-    uint32_t handle;
+    uint32_t privhandle;
+    uint32_t pubhandle;
 
     CK_MECHANISM_TYPE mechanism;
     union {

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -185,19 +185,6 @@ static void get_keypair(CK_SESSION_HANDLE session, CK_KEY_TYPE key_type, CK_OBJE
 
     rv = C_FindObjectsFinal(session);
     assert_int_equal(rv, CKR_OK);
-
-    /*
-     * whitebox test handle identifier link sanity
-     * Turning down the high bit in the public handle should
-     * result in the same handle id as the private portion of
-     * the object.
-     */
-    CK_OBJECT_HANDLE x = *pub_handle;
-    /* clear high bit, no sign extension as unsigned type */
-    x = x << 1;
-    x = x >> 1;
-
-    assert_int_equal(x, *priv_handle);
 }
 
 #endif /* TEST_INTEGRATION_TEST_H_ */

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -52,7 +52,7 @@ class Tpm2(object):
 
     def load(self, pctx, pauth, priv, pub):
 
-        if not isinstance(priv, str):
+        if priv != None and not isinstance(priv, str):
             sealprivf = NamedTemporaryFile()
             sealprivf.write(priv)
             sealprivf.flush()
@@ -67,10 +67,16 @@ class Tpm2(object):
         ctx = os.path.join(self._tmp, uuid.uuid4().hex + '.out')
 
         #tpm2_load -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
-        cmd = [
-            'tpm2_load', '-C', str(pctx), '-P', 'hex:' + pauth.decode(), '-u',
-            pub, '-r', priv, '-n', '/dev/null', '-o', ctx
-        ]
+        if priv != None:
+            cmd = [
+                'tpm2_load', '-C', str(pctx), '-P', 'hex:' + pauth.decode(), '-u',
+                pub, '-r', priv, '-n', '/dev/null', '-o', ctx
+            ]
+        else:
+            cmd = [
+                'tpm2_loadexternal', '-u', pub
+            ]
+
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         _, stderr = p.communicate()
         rc = p.wait()


### PR DESCRIPTION
The linking mechanism made C_DestroyObject and certificate support
a nightmare.

Just make the public portion of an object a seperate and descrete object
in the db that uses only the public portion of a TPM object and can
be loaded to the null hierarchy via loadexternal.

Signed-off-by: William Roberts <william.c.roberts@intel.com>