### PR TITLE
object: implement C_DestroyObject()

### DIFF
--- a/docs/P11.md
+++ b/docs/P11.md
@@ -158,3 +158,31 @@ Yz7D/B5JEGSHmJTQLEtt0qlTj0lSbVo3w5e5MT6MsC1IiRjT2BlvWsZiOQ+OyKNE
 9QIDAQAB
 -----END PUBLIC KEY-----
 ```
+
+## Destroying Objects
+This will show how to delete an object. The first step is having an object to delete on the token
+and obtaining a URL to the object you want to delete. Look at the section on *Adding Object via tpm2_ptool.py*.
+The URL should be:
+```
+	URL: pkcs11:model=TPM2%20PKCS%2311;manufacturer=Intel;serial=0000000000000000;token=p11kit;object=myfirstkey;type=secret-key
+```
+Now that we know what object to delete, lets delete it. Ensure you provide the `--login` option and the password:
+```
+$ GNUTLS_PIN=myuserpin p11tool --login --delete 'pkcs11:model=TPM2%20PKCS%2311;manufacturer=Intel;serial=0000000000000000;token=p11kit;object=myfirstkey;type=secret-key'
+Object 0:
+	URL: pkcs11:library-description=%20TPM2.0%20Cryptoki%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00;library-manufacturer=%20Intel%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00;model=TPM2%20PKCS%2311;manufacturer=Intel;serial=0000000000000000;token=p11kit;id=%62%33%34%39%39%38%63%32%37%66%37%38%39%61%62%66;object=myfirstkey;type=secret-key
+	Type: Secret key
+	Label: myfirstkey
+	Flags: CKA_ALWAYS_AUTH; CKA_NEVER_EXTRACTABLE; CKA_SENSITIVE;
+	ID: 62:33:34:39:39:38:63:32:37:66:37:38:39:61:62:66
+
+Are you sure you want to delete those objects? (y/N): y
+
+1 objects deleted
+```
+
+And verify that it's gone:
+```
+$ p11tool --list-all "$token"
+No matching objects found
+```

--- a/docs/PKCS11_TOOL.md
+++ b/docs/PKCS11_TOOL.md
@@ -137,3 +137,22 @@ Public Key Object; EC  EC_POINT 256 bits
   ID:         3437
   Usage:      verify
 ```
+
+## Destroying Objects
+
+Let's destroy the key we created in the *Generating ECC Keypair* segment, IDs 3436 and 3437 for both the private and public portions
+respectively.
+
+### Private Key
+```
+pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --login --pin=myuserpin --delete-object --type=privkey --id 3436
+Using slot 0 with a present token (0x1)
+```
+### Public Key
+```
+pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --login --pin=myuserpin --delete-object --type=pubkey --id 3437
+Using slot 0 with a present token (0x1)
+```
+
+**Note**: The tool doesn't have any output about successful delete, only when it fails. However, you can run the command
+in *Listing Objects* to verify that it is indeed deleted.

--- a/docs/PKCS11_TOOL.md
+++ b/docs/PKCS11_TOOL.md
@@ -76,3 +76,64 @@ $ pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --label="label" --pin mynew
 Using slot 0 with a present token (0x1)
 00000000: 2e50 bc47                                .P.G
 ```
+
+## Listing Objects
+
+To list objects, we simply use the `--list-objects` option:
+```
+pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --list-objects
+Private Key Object; EC
+  label:      p11-templ-key-label-ecc
+  ID:         7031312d74656d706c2d6b65792d69642d65636300
+  Usage:      sign
+Public Key Object; EC  EC_POINT 256 bits
+  EC_POINT:   04410452526c163439c3c5e5a943466a606439fbc7284eafd12221c4473ecb2fba3c586816d54f9ff108489877c5cfa857ba05cfba33dfe3e9b739107f672f787838d6
+  EC_PARAMS:  06082a8648ce3d030107
+  label:      p11-templ-key-label-ecc
+  ID:         7031312d74656d706c2d6b65792d69642d65636300
+  Usage:      verify
+...
+```
+
+**Note**: Your output will likely differ, but the tool should output a list of objects and some attributes.
+
+## Creating Objects
+
+Outside of using [tpm2_ptool.py](PKCS11_TOOL.md) to add objects, p11tool supports creating objects
+through the PKCS#11 interface.
+
+### Generating RSA Keypair
+
+This will generate an RSA keypair using pkcs11-tool:
+```
+pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --label="label" --login --pin=myuserpin --keypairgen
+Using slot 0 with a present token (0x1)
+Key pair generated:
+Private Key Object; RSA
+  label:      label
+  ID:         3332
+  Usage:      none
+Public Key Object; RSA 2048 bits
+  label:      label
+  ID:         3333
+  Usage:      none
+```
+
+### Generating ECC Keypair
+
+This will generate an EC keypair using pkcs11-tool:
+```
+pkcs11-tool --module ./src/.libs/libtpm2_pkcs11.so --label="my-ecc-keypair" --login --pin=myuserpin --keypairgen --usage-sign --key-type EC:prime256v1
+Using slot 0 with a present token (0x1)
+Key pair generated:
+Private Key Object; EC
+  label:      my-ecc-keypair
+  ID:         3436
+  Usage:      sign
+Public Key Object; EC  EC_POINT 256 bits
+  EC_POINT:   04410436e7d2c84725234ec8d4b14bc31a50d382eb578cbc7315ae95561875314eb5a22a390bbfabef6269a35a18b1d95b2abc553071c419c3e866db0c3f13c0288ac6
+  EC_PARAMS:  06082a8648ce3d030107
+  label:      my-ecc-keypair
+  ID:         3437
+  Usage:      verify
+```

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -44,4 +44,14 @@ CK_RV db_update_for_pinchange(
 
 CK_RV db_add_new_object(token *tok, tobject *tobj);
 
+/**
+ * Updates an existing tobjects attributes to the new set
+ * contained in the tobject.
+ * @param tobj
+ *  The tobject to update.
+ * @return
+ *  CKR_OK on success.
+ */
+CK_RV db_update_attrs(tobject *tobj);
+
 #endif /* SRC_PKCS11_LIB_DB_H_ */

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -54,4 +54,12 @@ CK_RV db_add_new_object(token *tok, tobject *tobj);
  */
 CK_RV db_update_attrs(tobject *tobj);
 
+/**
+ * Delete a tobject from the DB.
+ * @param tobj
+ *  The tobject to remove.
+ * @return
+ */
+CK_RV db_delete_object(tobject *tobj);
+
 #endif /* SRC_PKCS11_LIB_DB_H_ */

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -15,6 +15,7 @@ typedef struct token token;
 
 typedef struct encrypt_op_data encrypt_op_data;
 struct encrypt_op_data {
+    tobject *tobj;
     tpm_encrypt_data *tpm_enc_data;
 };
 

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -44,6 +44,8 @@ struct objattrs {
 typedef struct tobject tobject;
 struct tobject {
 
+    unsigned active;     /** number of active users */
+
     CK_OBJECT_HANDLE id; /** external handle */
 
     twist pub;           /** public tpm data */
@@ -167,5 +169,27 @@ CK_RV object_mech_is_supported(tobject *tobj, CK_MECHANISM_PTR mech);
  *  The attribute array.
  */
 objattrs *tobject_get_attrs(tobject *tobj);
+
+/**
+ * Marks a tobject no longer being used by an operation.
+ *
+ * @param tobj
+ *  The tobject to retire.
+ * @return
+ *  CKR_OK on success, CKR_GENERAL_ERROR if not active.
+ */
+CK_RV tobject_user_decrement(tobject *tobj);
+
+/**
+ * Marks a tobject as in use by an operation.
+ *
+ * @param tobj
+ *  The tobject to mark as in use.
+ * @return
+ *  CKR_OK on success, CKR_GENERAL_ERROR if not active.
+ */
+CK_RV tobject_user_increment(tobject *tobj);
+
+CK_RV object_destroy(session_ctx *ctx, CK_OBJECT_HANDLE object);
 
 #endif /* SRC_PKCS11_OBJECT_H_ */

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -142,54 +142,6 @@ void session_ctx_logout_event(session_ctx *ctx) {
     }
 }
 
-CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj) {
-
-    tpm_ctx *tpm = tok->tctx;
-
-    if (!tok->tobjects) {
-        return CKR_KEY_HANDLE_INVALID;
-    }
-
-    list *cur = &tok->tobjects->l;
-    while(cur) {
-        tobject *tobj = list_entry(cur, tobject, l);
-        cur = cur->next;
-        if (tobj->id != key) {
-            continue;
-        }
-
-        // Already loaded, ignored.
-        if (tobj->handle) {
-            *loaded_tobj = tobj;
-            return CKR_OK;
-        }
-
-        sobject *sobj = &tok->sobject;
-
-        bool result = tpm_loadobj(
-                tpm,
-                tok->sobject.handle, sobj->authraw,
-                tobj->pub, tobj->priv,
-                &tobj->handle);
-        if (!result) {
-            return CKR_GENERAL_ERROR;
-        }
-
-        CK_RV rv = utils_ctx_unwrap_objauth(tok, tobj->objauth,
-                &tobj->unsealed_auth);
-        if (rv != CKR_OK) {
-            LOGE("Error unwrapping tertiary object auth");
-            return rv;
-        }
-
-        *loaded_tobj = tobj;
-        return CKR_OK;
-    }
-
-    // Found no match on key id
-    return CKR_KEY_HANDLE_INVALID;
-}
-
 CK_RV _session_ctx_opdata_get(session_ctx *ctx, operation op, void **data) {
 
     if (op != ctx->opdata.op) {

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -80,9 +80,6 @@ CK_FLAGS session_ctx_flags_get(session_ctx *ctx);
 
 token *session_ctx_get_token(session_ctx *ctx);
 
-// XXX moveme
-CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
-
 /**
  * Given a user, performs a login event, causing a transition to it's correct end state based
  * on current session state and user triggering the event.

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -99,6 +99,89 @@ CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
     return CKR_OK;
 }
 
+static const CK_MECHANISM_TYPE mechs[] = {
+    CKM_RSA_PKCS_KEY_PAIR_GEN,
+    CKM_RSA_PKCS,
+    CKM_RSA_9796,
+    CKM_RSA_X_509,
+    CKM_MD2_RSA_PKCS,
+    CKM_MD5_RSA_PKCS,
+    CKM_SHA1_RSA_PKCS,
+    CKM_RIPEMD128_RSA_PKCS,
+    CKM_RIPEMD160_RSA_PKCS,
+    CKM_RSA_PKCS_OAEP,
+    CKM_RSA_X9_31_KEY_PAIR_GEN,
+    CKM_RSA_X9_31,
+    CKM_SHA1_RSA_X9_31,
+    CKM_RSA_PKCS_PSS,
+    CKM_SHA1_RSA_PKCS_PSS,
+    CKM_DSA_KEY_PAIR_GEN,
+    CKM_DSA,
+    CKM_DSA_SHA1,
+    CKM_DH_PKCS_KEY_PAIR_GEN,
+    CKM_DH_PKCS_DERIVE,
+    CKM_X9_42_DH_KEY_PAIR_GEN,
+    CKM_X9_42_DH_DERIVE,
+    CKM_X9_42_DH_HYBRID_DERIVE,
+    CKM_X9_42_MQV_DERIVE,
+    CKM_SHA256_RSA_PKCS,
+    CKM_SHA384_RSA_PKCS,
+    CKM_SHA512_RSA_PKCS,
+    CKM_SHA256_RSA_PKCS_PSS,
+    CKM_SHA384_RSA_PKCS_PSS,
+    CKM_SHA512_RSA_PKCS_PSS,
+    CKM_RC2_KEY_GEN,
+    CKM_RC2_ECB,
+    CKM_RC2_CBC,
+    CKM_RC2_MAC,
+    CKM_RC2_MAC_GENERAL,
+    CKM_RC2_CBC_PAD,
+    CKM_RC4_KEY_GEN,
+    CKM_RC4,
+    CKM_DES_KEY_GEN,
+    CKM_DES_ECB,
+    CKM_DES_CBC,
+    CKM_DES_MAC,
+    CKM_DES_MAC_GENERAL,
+    CKM_DES_CBC_PAD,
+    CKM_DES2_KEY_GEN,
+    CKM_DES3_KEY_GEN,
+    CKM_DES3_ECB,
+    CKM_DES3_CBC,
+    CKM_DES3_MAC,
+    CKM_DES3_MAC_GENERAL,
+    CKM_DES3_CBC_PAD,
+    CKM_MD5,
+    CKM_MD5_HMAC,
+    CKM_MD5_HMAC_GENERAL,
+    CKM_SHA_1,
+    CKM_SHA_1_HMAC,
+    CKM_SHA_1_HMAC_GENERAL,
+    CKM_SHA256,
+    CKM_SHA256_HMAC,
+    CKM_SHA256_HMAC_GENERAL,
+    CKM_SHA384,
+    CKM_SHA384_HMAC,
+    CKM_SHA384_HMAC_GENERAL,
+    CKM_SHA512,
+    CKM_SHA512_HMAC,
+    CKM_SHA512_HMAC_GENERAL,
+    CKM_CAST_KEY_GEN,
+    CKM_ECDSA_KEY_PAIR_GEN,
+    CKM_EC_KEY_PAIR_GEN,
+    CKM_ECDSA,
+    CKM_ECDSA_SHA1,
+    CKM_ECDH1_DERIVE,
+    CKM_ECDH1_COFACTOR_DERIVE,
+    CKM_AES_KEY_GEN,
+    CKM_AES_ECB,
+    CKM_AES_CBC,
+    CKM_AES_MAC,
+    CKM_AES_MAC_GENERAL,
+    CKM_AES_CBC_PAD,
+    CKM_AES_CTR,
+};
+
 CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_list, CK_ULONG_PTR count) {
 
     if (!slot_get_token(slot_id)) {
@@ -108,89 +191,6 @@ CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_
     if (!count){
         return CKR_ARGUMENTS_BAD;
     }
-
-    static const CK_MECHANISM_TYPE mechs[] = {
-        CKM_RSA_PKCS_KEY_PAIR_GEN,
-        CKM_RSA_PKCS,
-        CKM_RSA_9796,
-        CKM_RSA_X_509,
-        CKM_MD2_RSA_PKCS,
-        CKM_MD5_RSA_PKCS,
-        CKM_SHA1_RSA_PKCS,
-        CKM_RIPEMD128_RSA_PKCS,
-        CKM_RIPEMD160_RSA_PKCS,
-        CKM_RSA_PKCS_OAEP,
-        CKM_RSA_X9_31_KEY_PAIR_GEN,
-        CKM_RSA_X9_31,
-        CKM_SHA1_RSA_X9_31,
-        CKM_RSA_PKCS_PSS,
-        CKM_SHA1_RSA_PKCS_PSS,
-        CKM_DSA_KEY_PAIR_GEN,
-        CKM_DSA,
-        CKM_DSA_SHA1,
-        CKM_DH_PKCS_KEY_PAIR_GEN,
-        CKM_DH_PKCS_DERIVE,
-        CKM_X9_42_DH_KEY_PAIR_GEN,
-        CKM_X9_42_DH_DERIVE,
-        CKM_X9_42_DH_HYBRID_DERIVE,
-        CKM_X9_42_MQV_DERIVE,
-        CKM_SHA256_RSA_PKCS,
-        CKM_SHA384_RSA_PKCS,
-        CKM_SHA512_RSA_PKCS,
-        CKM_SHA256_RSA_PKCS_PSS,
-        CKM_SHA384_RSA_PKCS_PSS,
-        CKM_SHA512_RSA_PKCS_PSS,
-        CKM_RC2_KEY_GEN,
-        CKM_RC2_ECB,
-        CKM_RC2_CBC,
-        CKM_RC2_MAC,
-        CKM_RC2_MAC_GENERAL,
-        CKM_RC2_CBC_PAD,
-        CKM_RC4_KEY_GEN,
-        CKM_RC4,
-        CKM_DES_KEY_GEN,
-        CKM_DES_ECB,
-        CKM_DES_CBC,
-        CKM_DES_MAC,
-        CKM_DES_MAC_GENERAL,
-        CKM_DES_CBC_PAD,
-        CKM_DES2_KEY_GEN,
-        CKM_DES3_KEY_GEN,
-        CKM_DES3_ECB,
-        CKM_DES3_CBC,
-        CKM_DES3_MAC,
-        CKM_DES3_MAC_GENERAL,
-        CKM_DES3_CBC_PAD,
-        CKM_MD5,
-        CKM_MD5_HMAC,
-        CKM_MD5_HMAC_GENERAL,
-        CKM_SHA_1,
-        CKM_SHA_1_HMAC,
-        CKM_SHA_1_HMAC_GENERAL,
-        CKM_SHA256,
-        CKM_SHA256_HMAC,
-        CKM_SHA256_HMAC_GENERAL,
-        CKM_SHA384,
-        CKM_SHA384_HMAC,
-        CKM_SHA384_HMAC_GENERAL,
-        CKM_SHA512,
-        CKM_SHA512_HMAC,
-        CKM_SHA512_HMAC_GENERAL,
-        CKM_CAST_KEY_GEN,
-        CKM_ECDSA_KEY_PAIR_GEN,
-        CKM_EC_KEY_PAIR_GEN,
-        CKM_ECDSA,
-        CKM_ECDSA_SHA1,
-        CKM_ECDH1_DERIVE,
-        CKM_ECDH1_COFACTOR_DERIVE,
-        CKM_AES_KEY_GEN,
-        CKM_AES_ECB,
-        CKM_AES_CBC,
-        CKM_AES_MAC,
-        CKM_AES_MAC_GENERAL,
-        CKM_AES_CBC_PAD,
-        CKM_AES_CTR,
-    };
 
     if (!mechanism_list) {
         *count = ARRAY_LEN(mechs);
@@ -215,12 +215,22 @@ CK_RV slot_mechanism_info_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE type, CK_ME
         return CKR_SLOT_ID_INVALID;
     }
 
+    // TODO support more of these and check with the TPM for sizes.
     switch(type) {
     case CKM_AES_KEY_GEN:
         info->ulMinKeySize = 128;
         info->ulMaxKeySize = 512;
-        //XXX What should flags look like?
-        info->flags = 0;
+        info->flags = CKF_GENERATE;
+        break;
+    case CKM_RSA_PKCS_KEY_PAIR_GEN:
+        info->ulMinKeySize = 1024;
+        info->ulMaxKeySize = 4096;
+        info->flags = CKF_GENERATE_KEY_PAIR;
+        break;
+    case CKM_EC_KEY_PAIR_GEN:
+        info->ulMinKeySize = 192;
+        info->ulMaxKeySize = 256;
+        info->flags = CKF_GENERATE_KEY_PAIR;
         break;
     default:
         return CKR_MECHANISM_INVALID;

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -36,6 +36,12 @@ void token_free_list(token *t, size_t len) {
 
 void token_free(token *t) {
 
+    /*
+     * for each session remove them
+     */
+    session_table_free_ctx_all(t);
+    session_table_free(t->s_table);
+
     twist_free(t->pobject.objauth);
 
     twist_free(t->sopobjauth);
@@ -58,12 +64,6 @@ void token_free(token *t) {
     }
 
     tpm_ctx_free(t->tctx);
-
-    /*
-     * for each session remove them
-     */
-    session_table_free_ctx_all(t);
-    session_table_free(t->s_table);
 
     mutex_destroy(t->mutex);
 }

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -126,4 +126,20 @@ CK_RV token_initpin(token *tok, CK_UTF8CHAR_PTR new_pin, CK_ULONG new_len);
 void token_lock(token *t);
 void token_unlock(token *t);
 
+/**
+ * Look up and possibly load an unloaded tobject.
+ * @param tok
+ *  The token to look up the object on.
+ * @param key
+ *  The object handle to look for.
+ * @param loaded_tobj
+ *  The pointer to the backing tobject
+ * @return
+ *   CKR_OK - everything is good.
+ *   CKR_INVALID_KEY_HANDLE - not found
+ *   CKR_KEY_HANDLE_INVALID - invalid key handle
+ *   Others like: CKR_GENERAL_ERROR and CKR_HOST_MEMORY
+ */
+CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
+
 #endif /* SRC_TOKEN_H_ */

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -2088,17 +2088,29 @@ static CK_RV handle_ckobject_class(CK_ATTRIBUTE_PTR attr, CK_ULONG index, void *
     UNUSED(index);
     UNUSED(udata);
 
-    CK_OBJECT_CLASS class = CKA_PRIVATE;
+    CK_OBJECT_CLASS class[2] = {
+        CKA_PRIVATE,    /* p11tool */
+        CKO_PRIVATE_KEY /* pkcs11-tool */
+    };
 
-    if (attr->ulValueLen != sizeof(class)) {
+    if (attr->ulValueLen != sizeof(class[0])) {
         LOGE("Expected CK_OBJECT_CLASS length to be %zu got %lu", sizeof(class), attr->ulValueLen);
         return CKR_ATTRIBUTE_VALUE_INVALID;
     }
 
     CK_OBJECT_CLASS_PTR class_ptr = (CK_OBJECT_CLASS_PTR)attr->pValue;
 
-    if (class != *class_ptr) {
-        LOGE("Expected CK_OBJECT_CLASS to be %lu got %lu", class, *class_ptr);
+    size_t i;
+    bool found = false;
+    for (i=0; i < ARRAY_LEN(class); i++) {
+        if (*class_ptr == class[i]) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        LOGE("Unexpected CK_OBJECT_CLASS got %lu", *class_ptr);
         return CKR_ATTRIBUTE_VALUE_INVALID;
     }
 

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -2354,7 +2354,9 @@ static CK_RV tpm_object_data_populate_rsa(TPM2B_PUBLIC *out_pub, tpm_object_data
     }
 
     objdata->rsa.exponent = out_pub->publicArea.parameters.rsaDetail.exponent;
-
+    if (objdata->rsa.exponent == 0) {
+        objdata->rsa.exponent = 65537;
+    }
     return CKR_OK;
 }
 

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -472,7 +472,7 @@ CK_RV C_CopyObject (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ATTRI
 }
 
 CK_RV C_DestroyObject (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object) {
-    TOKEN_UNSUPPORTED;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RW(object_destroy, session, object);
 }
 
 CK_RV C_GetObjectSize (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ULONG_PTR size) {

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -119,7 +119,7 @@ void test_get_mechanism_info_good(void **state) {
 
     assert_int_equal(mech_info.ulMaxKeySize, 512);
     assert_int_equal(mech_info.ulMinKeySize, 128);
-    assert_int_equal(mech_info.flags, 0);
+    assert_int_equal(mech_info.flags, CKF_GENERATE);
 }
 
 void test_get_mechanism_info_bad(void **state) {

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -139,7 +139,7 @@ static inline void so_login_bad_pin(CK_SESSION_HANDLE handle) {
         return CKR_OK; \
     }
 
-static void get_keypair(CK_SESSION_HANDLE session, CK_KEY_TYPE key_type, CK_OBJECT_HANDLE_PTR pub_handle, CK_OBJECT_HANDLE_PTR priv_handle) {
+static inline void get_keypair(CK_SESSION_HANDLE session, CK_KEY_TYPE key_type, CK_OBJECT_HANDLE_PTR pub_handle, CK_OBJECT_HANDLE_PTR priv_handle) {
 
     assert_non_null(pub_handle);
     assert_non_null(priv_handle);


### PR DESCRIPTION
Implement C_DestroyObject by reference counting when tobjects are in use
internally in the library across operations. If C_Destroy() occurs when
the reference count is > 1, then it should fail with
CKR_FUNCTION_FAILED. Otherwise, delete it from the token tobject list
and and remove the DB entry.

Fixes #144

Signed-off-by: William Roberts <william.c.roberts@intel.com>