### PR TITLE
key.c: Store private attributes too

### DIFF
--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -189,6 +189,11 @@ static CK_RV rsa_add_missing_attrs(tobject *public_tobj, tobject *private_tobj, 
     }
 
     rv = tobject_append_attrs(public_tobj, newpubattrs, pubindex);
+    if (rv != CKR_OK) {
+        goto error;
+    }
+
+    rv = tobject_append_attrs(private_tobj, newprivattrs, privindex);
 
 error:
     tmp_rv = utils_attr_free(newprivattrs, privindex);


### PR DESCRIPTION
With the latest changes the MODULUS_BITS attribute was not stored in the
private tobj. This caused the sign operation to fail, if the key was
generated using the C_GenerateKeyPair Method with the following error
message:

`ERROR on line: "269" in file: "src/lib/sign.c": Signing key has no
modulus`

Fixes: 9f043bf ("object: make public objects a first class citizen")
Signed-off-by: Peter Huewe <peterhuewe@gmx.de>