### PR TITLE
rsa: fix public and private attributes

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -96,15 +96,6 @@ class NewKeyCommandBase(Command):
                 {
                     CKA_CLASS: CKO_PUBLIC_KEY
                 },
-                {
-                    CKA_MODULUS: y['rsa']
-                },
-                {
-                    CKA_MODULUS_BITS : y['bits']
-                },
-                {
-                    CKA_PUBLIC_EXPONENT: 65537
-                },
             ]
 
             privattrs = [
@@ -118,6 +109,21 @@ class NewKeyCommandBase(Command):
                     CKA_MODULUS_BITS : y['bits']
                 },
             ]
+
+            moddetails = [
+                {
+                    CKA_MODULUS: y['rsa']
+                },
+                {
+                    CKA_MODULUS_BITS : y['bits']
+                },
+                {
+                    CKA_PUBLIC_EXPONENT: 65537
+                }
+            ]
+
+            pubattrs.extend(moddetails)
+            privattrs.extend(moddetails)
 
             pubmech = [
                 { CKM_RSA_X_509: "" },


### PR DESCRIPTION
Per:
  - http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850406:

Sections:
  - 2.1.2
  - 2.1.3

public and private RSA key objects need:
  - CKA_MODULUS
  - CKA_MODULUS_BITS
  - CKA_PUBLIC_EXPONENT

Ensure that all objects have them set in the tests.

Fixes: #203

Signed-off-by: William Roberts <william.c.roberts@intel.com>