### PR TITLE
Improve pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,16 +64,10 @@ pkgconfigdir          = $(libdir)/pkgconfig
 pkgconfig_DATA =
 CLEANFILES += $(pkgconfig_DATA)
 
-%.pc : %.pc.in
-	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
-	        s,[@]libdir[@],$(libdir),g; \
-	        s,[@]includedir[@],$(includedir),g;" $^ > $@
-
 ### PKCS#11 Library Definition ###
 libtpm2_pkcs11 = src/libtpm2_pkcs11.la
 pkgconfig_DATA += lib/tpm2-pkcs11.pc
-EXTRA_DIST += lib/tpm2-pkcs11.map lib/tpm2-pkcs11.pc.in
+EXTRA_DIST += lib/tpm2-pkcs11.map
 
 if HAVE_LD_VERSION_SCRIPT
 src_libtpm2_pkcs11_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/tpm2-pkcs11.map

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ m4_ifdef([_AX_CODE_COVERAGE_RULES],
          [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
 AX_ADD_AM_MACRO_STATIC([])
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile lib/tpm2-pkcs11.pc])
 
 # enable autoheader config.h file
 AC_CONFIG_HEADERS([src/lib/config.h])

--- a/lib/tpm2-pkcs11.pc.in
+++ b/lib/tpm2-pkcs11.pc.in
@@ -1,6 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tpm2-pkcs11
 Description: TPM2 PKCS#11 library.
 URL: https://github.com/tpm2-software/tpm2-pkcs11
 Version: @VERSION@
-Cflags: -I@includedir@
-Libs: -ltss2-esys -L@libdir@
+Cflags: -I${includedir}
+Libs: -ltss2-esys -L${libdir}


### PR DESCRIPTION
Apply the changes made upstream in https://github.com/tpm2-software/tpm2-tss/pull/1372 to tpm2-pkcs11:
- Use `AC_CONFIG_FILES` instead of `sed` for variable substitutions.
- Define variables for `libdir` and `includedir` in the pkg-config files so that the user can determine where the files have been installed. This is standard practice, see the [example pkg-config file](https://people.freedesktop.org/~dbn/pkg-config-guide.html#using).