### PR TITLE
build: use PKG_INSTALLDIR to determine pkgconfigdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,7 @@ CLEANFILES = AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
 pkgconfig_DATA =
-CLEANFILES += $(pkgconfig_DATA)
+DISTCLEANFILES = $(pkgconfig_DATA)
 
 ### PKCS#11 Library Definition ###
 libtpm2_pkcs11 = src/libtpm2_pkcs11.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,6 @@ EXTRA_DIST += AUTHORS
 CLEANFILES = AUTHORS
 
 # pkg-config setup. pc-file declarations happen in the corresponding modules
-pkgconfigdir          = $(libdir)/pkgconfig
 pkgconfig_DATA =
 CLEANFILES += $(pkgconfig_DATA)
 

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ AC_PROG_CC
 LT_INIT
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
+PKG_INSTALLDIR()
+
 # enable "silent-rules" option by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
Apply the changes from https://github.com/tpm2-software/tpm2-tss/pull/1384:
- Use `PKG_INSTALLDIR` to determine the pkg-config directory, which allows changing it with `./configure --with-pkgconfigdir`.
- Use distclean instead of clean for .pc files, since they are generated by configure since 88aac7c66e5e5e12a9100035b5ae858e6e5ad47e.