### PR TITLE
Change AES-256 to AES-128 in pkcs11 store setup script to support PC Client TPMs

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -82,8 +82,8 @@ tpm2_ptool initpin --label=label --sopin=mysopin --userpin=myuserpin --path=$TPM
 # add 2 aes and 2 rsa keys under tokens 1 and 2
 for t in "label" "wrap-sw"; do
 	echo "Adding 2 AES 256 keys under token \"$t\""
-	tpm2_ptool addkey --algorithm=aes256 --label="$t" --userpin=myuserpin --path=$TPM2_PKCS11_STORE
-	tpm2_ptool addkey --algorithm=aes256 --label="$t" --key-label=mykeylabel --userpin=myuserpin --path=$TPM2_PKCS11_STORE
+	tpm2_ptool addkey --algorithm=aes128 --label="$t" --userpin=myuserpin --path=$TPM2_PKCS11_STORE
+	tpm2_ptool addkey --algorithm=aes128 --label="$t" --key-label=mykeylabel --userpin=myuserpin --path=$TPM2_PKCS11_STORE
 	echo "Added AES Keys"
 
 	echo "Adding 2 RSA 2048 keys under token \"$t\""


### PR DESCRIPTION
For PC Client spec conform TPMs, AES-256 [is not mandatory](https://trustedcomputinggroup.org/wp-content/uploads/Errata_v1.1_TCG_PC_Client_Platform_TPM_Profile_PTP_2.0_r1.03_v22.pdf#page=6) and should not be used for the test setup.