### PR TITLE
 Tests: Add logout to test_so_state_pin_init_good to free memory on the TPM

### DIFF
--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -437,7 +437,6 @@ static void swap_pin(CK_SESSION_HANDLE handle, CK_USER_TYPE user_type, CK_UTF8CH
     // swap the pin back
     rv = C_SetPIN(handle, newpin, newpinlen, oldpin, oldpinlen);
     assert_int_equal(rv, CKR_OK);
-    logout(handle);
 }
 
 static void test_user_state_pin_change_good(void **state) {
@@ -448,6 +447,8 @@ static void test_user_state_pin_change_good(void **state) {
     user_login(handle);
 
     swap_pin(handle, CKU_USER, C(GOOD_USERPIN), sizeof(GOOD_USERPIN) - 1);
+
+    logout(handle);
 }
 
 static void test_so_state_pin_change_good(void **state) {
@@ -458,6 +459,8 @@ static void test_so_state_pin_change_good(void **state) {
     so_login(handle);
 
     swap_pin(handle, CKU_SO, C(GOOD_SOPIN), sizeof(GOOD_SOPIN) - 1);
+
+    logout(handle);
 }
 
 static void test_ro_function_state_pin_change_bad(void **state) {

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -298,8 +298,6 @@ static void test_so_global_login_logout_good(void **state) {
 
     logout(slot0_session1);
     logout_expects(slot1_session0, CKR_USER_NOT_LOGGED_IN);
-
-    logout_expects(slot1_session0, CKR_USER_NOT_LOGGED_IN);
 }
 
 /**

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -507,6 +507,8 @@ static void test_so_state_pin_init_good(void **state) {
 
     rv = C_InitPIN(handle, C(GOOD_USERPIN), sizeof(GOOD_USERPIN) - 1);
     assert_int_equal(rv, CKR_OK);
+
+    logout(handle);
 }
 
 int main() {


### PR DESCRIPTION
The test `test_so_state_pin_init_good()` in `pkcs-login-logout.int.c` does not log out. As a consequence, `tpm_flushcontext()` is not called and at some point the TPM memory may overflow. Thus, a call to `logout()` was added.

Additionally, a redundant line of code with no purpose was removed.

The utility function `swap_pin()` function calls `logout()` which is not obvious. This call was moved to the tests which call `swap_pin()`.