### PR TITLE
Fix integration tests for latest tpm2-tools

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -54,7 +54,7 @@ tpm2_ptool init --pobj-pin=mypobjpin --path=$TPM2_PKCS11_STORE
 
 # Test the existing primary object init functionality
 tpm2_createprimary -p foopass -o $TPM2_PKCS11_STORE/primary.ctx -g sha256 -G rsa
-handle=`tpm2_evictcontrol -a o -c $TPM2_PKCS11_STORE/primary.ctx | cut -d\: -f2-2 | sed 's/^ *//g'`
+handle=`tpm2_evictcontrol -a o -c $TPM2_PKCS11_STORE/primary.ctx | grep -Po '(?<=persistent-handle: )\S+'`
 
 tpm2_ptool init --pobj-pin=anotherpobjpin --primary-handle=$handle --primary-auth=foopass --path=$TPM2_PKCS11_STORE
 


### PR DESCRIPTION
With commit 9c3e6387 ("tpm2_evictcontrol: support saving ESYS_TR") in
tpm2-tools, the output of tpm2_evictcontrol was changed in a way that
the test setup script for tpm2-pkcs11 broke, as it did not parse the
output correctly.

Instead of using cut and set and hoping that the parameter is at the
correct position, we use a more robust grep.

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>