### PR TITLE
Use yaml.safe_load for importing yaml

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -85,7 +85,7 @@ class NewKeyCommandBase(Command):
         # and populate the db with the data. This allows use of the public data
         # without needed to load any objects which requires a pin to do.
         #
-        y = yaml.load(tertiarypubdata)
+        y = yaml.safe_load(tertiarypubdata)
 
         pubattrs = None
         privattrs = None

--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -107,7 +107,7 @@ class InitCommand(Command):
 
                         # verify handle is persistent
                         output = tpm2.getcap('handles-persistent')
-                        y = yaml.load(output)
+                        y = yaml.safe_load(output)
                         if handle not in y:
                             sys.exit('Handle 0x%x is not persistent' % (handle))
 

--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -328,7 +328,7 @@ class AddTokenCommand(Command):
             # value reported by the TPM.
             #
             fixed_properties = tpm2.getcap('properties-fixed')
-            y = yaml.load(fixed_properties)
+            y = yaml.safe_load(fixed_properties)
             sym_size = y['TPM2_PT_CONTEXT_SYM_SIZE']['value']
 
             if sym_support:

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -42,7 +42,7 @@ class Tpm2(object):
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         stdout, stderr = p.communicate()
-        y = yaml.load(stdout)
+        y = yaml.safe_load(stdout)
         rc = p.wait()
         handle = y['persistent-handle'] if rc == 0 else None
         if (p.wait()):


### PR DESCRIPTION
According to the yaml documentation yaml.load is deprecated since PyYAML
5.1 without specifying the loader.
Since we are not doing special stuff, we can use the safe_load function
instead.

Fixes #213

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>