### PR TITLE
tpm2_ptool: update to changed output of tpm2_evictcontrol

### DIFF
--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -44,7 +44,7 @@ class Tpm2(object):
         stdout, stderr = p.communicate()
         y = yaml.load(stdout)
         rc = p.wait()
-        handle = y['persistentHandle'] if rc == 0 else None
+        handle = y['persistent-handle'] if rc == 0 else None
         if (p.wait()):
             raise RuntimeError("Could not execute tpm2_evictcontrol: %s",
                                stderr)


### PR DESCRIPTION
Upstream commit https://github.com/tpm2-software/tpm2-tools/commit/9c3e6387be57352eb7ceba289cab8dd5f82efeb9 added a key called `persistent-handle` to the YAML output of `tpm2_evictcontrol`. The old key `persistentHandle` was not removed, resulting in duplicate output, which was fixed by https://github.com/tpm2-software/tpm2-tools/commit/f68e69b93b98721fe896b4c530c5cf9dacdeb415. Therefore `tpm2_ptool` needs to be updated to the new name as well, otherwise [the CI fails](https://travis-ci.org/tpm2-software/tpm2-pkcs11/jobs/531999796#L2695).