### PR TITLE
Pad manufacturer id and library description and add nullpointer check

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -32,18 +32,21 @@
          }
 
 CK_RV general_get_info(CK_INFO *info) {
+    check_pointer(info);
 
-    static CK_INFO _info = {
+    CK_INFO _info = {
         .cryptokiVersion = CRYPTOKI_VERSION,
-        .manufacturerID = " "TPM2_TOKEN_MANUFACTURER,
+        .manufacturerID = TPM2_TOKEN_MANUFACTURER,
         .flags = 0,
-        .libraryDescription = " "LIBRARY_DESCRIPTION,
+        .libraryDescription = LIBRARY_DESCRIPTION,
         .libraryVersion = {
             /* TODO get from build VERSION */
             .major = 42,
             .minor = 42
         },
     };
+    str_pad(_info.manufacturerID, sizeof(_info.manufacturerID));
+    str_pad(_info.libraryDescription, sizeof(_info.libraryDescription));
 
     *info = _info;
 

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -32,6 +32,15 @@ static inline int min(size_t a, size_t b) {
     return a < b ? a : b;
 }
 
+/*
+ * Pads the buffer 'buf' with blanks to the desired 'buf_len'.
+ * The trailing '\0' byte is removed, so the buffer is NOT null terminared afterwards!
+ * */
+static inline void str_pad(unsigned char * buf, size_t buf_len) {
+    size_t str_len = strlen((char *)buf);
+    memset(buf + str_len, ' ', buf_len - str_len);
+}
+
 static inline void str_padded_copy(unsigned char * dst, const unsigned char * src, size_t dst_len) {
     memset(dst, ' ', dst_len);
     memcpy(dst, src, min(strlen((char *)(src)), dst_len));

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -102,6 +102,26 @@ static void test_get_slot_list(void **state) {
     assert_true(tinfo.flags & CKF_TOKEN_INITIALIZED);
 }
 
+static void test_get_info(void **state) {
+
+    UNUSED(state);
+    CK_INFO info;
+    CK_RV rv;
+
+    // check if null pointer is handled correctly
+    rv = C_GetInfo(NULL);
+    assert_int_equal(rv, CKR_ARGUMENTS_BAD);
+
+    // check for successful invocation
+    rv = C_GetInfo(&info);
+    assert_int_equal(rv, CKR_OK);
+
+    // check whether cryptoki version is correct
+    assert_int_equal(info.cryptokiVersion.major, 2);
+    assert_int_equal(info.cryptokiVersion.minor, 40);
+
+}
+
 static void test_random_good(void **state) {
 
     test_info *ti = test_info_from_state(state);
@@ -313,6 +333,8 @@ int main() {
         cmocka_unit_test_setup_teardown(test_c_getfunctionlist_bad,
                 NULL, NULL),
         cmocka_unit_test_setup_teardown(test_get_slot_list,
+                NULL, NULL),
+        cmocka_unit_test_setup_teardown(test_get_info,
                 NULL, NULL),
 
         /*


### PR DESCRIPTION
According to the standard these fields must be padded with blanks and
should not be null terminated.
Also it makes sense to check whether the supplied pointer is not null
and add a test

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>