### PR TITLE
Retrieve Token and Slot Info from TPM

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -21,10 +21,8 @@
   #define VERSION "UNKNOWN"
 #endif
 
-/* TODO These should probably emanate from the fixed properties
- * via get capability.
- */
 #define LIBRARY_DESCRIPTION "TPM2.0 Cryptoki"
+#define LIBRARY_MANUFACTURER "tpm2-software.github.io"
 
 #define CRYPTOKI_VERSION { \
            .major = CRYPTOKI_VERSION_MAJOR, \
@@ -36,7 +34,7 @@ CK_RV general_get_info(CK_INFO *info) {
 
     CK_INFO _info = {
         .cryptokiVersion = CRYPTOKI_VERSION,
-        .manufacturerID = TPM2_TOKEN_MANUFACTURER,
+        .manufacturerID = LIBRARY_MANUFACTURER,
         .flags = 0,
         .libraryDescription = LIBRARY_DESCRIPTION,
         .libraryVersion = {

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -73,26 +73,26 @@ CK_RV slot_get_list (CK_BYTE token_present, CK_SLOT_ID *slot_list, CK_ULONG_PTR 
 
 CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
 
-    const CK_BYTE manufacturerID[] = "foo";
-    const CK_BYTE slotDescription[] = "bar";
+    token *token;
+    CK_TOKEN_INFO token_info;
 
     check_pointer(info);
 
-    if (!slot_get_token(slot_id)) {
+    token = slot_get_token(slot_id);
+    if (!token) {
         return CKR_SLOT_ID_INVALID;
     }
 
     memset(info, 0, sizeof(*info));
 
-    /* TODO pull these from TPM */
-    info->firmwareVersion.major =
-            info->firmwareVersion.minor = 13;
+    if (token_get_info(token, &token_info)) {
+        return CKR_GENERAL_ERROR;
+    }
 
-    info->hardwareVersion.major =
-    info->hardwareVersion.minor = 42;
-
-    str_padded_copy(info->manufacturerID, manufacturerID, sizeof(info->manufacturerID));
-    str_padded_copy(info->slotDescription, slotDescription, sizeof(info->slotDescription));
+    str_padded_copy(info->manufacturerID, token_info.manufacturerID, sizeof(info->manufacturerID));
+    str_padded_copy(info->slotDescription, token_info.label, sizeof(info->slotDescription));
+    info->hardwareVersion = token_info.hardwareVersion;
+    info->firmwareVersion = token_info.firmwareVersion;
 
     info->flags = CKF_TOKEN_PRESENT | CKF_HW_SLOT;
 

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -114,6 +114,9 @@ CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {
     time (&rawtime);
     tminfo = gmtime(&rawtime);
     strftime ((char *)info->utcTime, sizeof(info->utcTime), "%Y%m%d%H%M%S", tminfo);
+    // The last two bytes must be '0', not NULL/'\0' terminated.
+    info->utcTime[14] = '0';
+    info->utcTime[15] = '0';
 
     return CKR_OK;
 }

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -35,6 +35,21 @@ void tpm_ctx_free(tpm_ctx *ctx);
 CK_RV tpm_ctx_new(tpm_ctx **tctx);
 
 /**
+ * Retrieves Spec Version, FW Version, Manufacturer and Model from TPM
+ * and populates the provided CK_TOKEN_INFO structure.
+ *
+ * If the manufacturer id is specified in TPM2_MANUFACTURER_MAP it will be
+ * extended with a human readable form of the manufacturer
+ * @param ctx
+ *  The tpm api context.
+ * @param info
+ *  The CK_TOKEN_INFO structure where the data is written to
+ * @return
+ *  CKR_OK on success, CKR_ARGUMENTS_BAD, or CKR_GENERAL_ERROR otherwise
+ */
+CK_RV tpm_get_token_info (tpm_ctx *ctx, CK_TOKEN_INFO *info);
+
+/**
  * Generates random bytes from the TPM
  * @param ctx
  *  The tpm api context.


### PR DESCRIPTION
This patchset retrieves the token info from the TPM and maps the result also to the slot info.

Signed-off by: Peter Huewe <peter.huewe@infineon.com>