### PR TITLE
mechanism: Report only mechanisms supported by TPM

### DIFF
--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -99,50 +99,15 @@ CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
     return CKR_OK;
 }
 
-static const CK_MECHANISM_TYPE mechs[] = {
-    CKM_AES_CBC,
-    CKM_AES_CFB1,
-    CKM_AES_ECB,
-    CKM_ECDSA,
-    CKM_ECDSA_SHA1,
-    CKM_EC_KEY_PAIR_GEN,
-    CKM_RSA_PKCS,
-    CKM_RSA_PKCS_KEY_PAIR_GEN,
-    CKM_RSA_PKCS_OAEP,
-    CKM_RSA_X_509,
-    CKM_SHA_1,
-    CKM_SHA1_RSA_PKCS,
-    CKM_SHA256,
-    CKM_SHA256_RSA_PKCS,
-    CKM_SHA384,
-    CKM_SHA384_RSA_PKCS,
-    CKM_SHA512,
-    CKM_SHA512_RSA_PKCS,
-};
 
 CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_list, CK_ULONG_PTR count) {
-
-    if (!slot_get_token(slot_id)) {
+    token *t = slot_get_token(slot_id);
+    if (!t) {
         return CKR_SLOT_ID_INVALID;
     }
 
-    if (!count){
-        return CKR_ARGUMENTS_BAD;
-    }
-
-    if (!mechanism_list) {
-        *count = ARRAY_LEN(mechs);
-        return CKR_OK;
-    }
-
-    if (*count < ARRAY_LEN(mechs)) {
-        return CKR_BUFFER_TOO_SMALL;
-    }
-
-    *count = ARRAY_LEN(mechs);
-    memcpy(mechanism_list, mechs, sizeof(mechs));
-
-    return CKR_OK;
+    CK_RV rv = tpm2_getmechanisms(t->tctx, mechanism_list, count);
+    return rv;
 }
 
 CK_RV slot_mechanism_info_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE type, CK_MECHANISM_INFO *info) {

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -178,4 +178,6 @@ CK_RV tpm2_generate_key(
 
         tpm_object_data *objdata);
 
+CK_RV tpm2_getmechanisms(tpm_ctx *ctx, CK_MECHANISM_TYPE *mechanism_list, CK_ULONG_PTR count);
+
 #endif /* SRC_PKCS11_TPM_H_ */


### PR DESCRIPTION
Query the TPM whether a specified mechanism can be supported or not.
Unfortunately the mapping is not 1:1.
There might be cases where the combination of supported algorithms by
the TPM show that a mechanism is supported, but eventually cannot be
used for *certain* use cases.
(e.g. `aes` reported as supported, but `TPM2_EncryptDecrypt` is not
implemented, then we cannot use it for encrypt or decrypt).
These cases can maybe be specified/handled in more detail in
`slot_mechanism_info_get`.

This logic atleast filters out mechanism, which are definitely not
supported by the specific TPM (e.g. `sha512`).
 
Signed-off-by: Peter Huewe <peter.huewe@infineon.com>