### PR TITLE
Fix breakage of tpm2_ptool due to latest tool update.

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -329,7 +329,7 @@ class AddTokenCommand(Command):
             #
             fixed_properties = tpm2.getcap('properties-fixed')
             y = yaml.safe_load(fixed_properties)
-            sym_size = y['TPM2_PT_CONTEXT_SYM_SIZE']['value']
+            sym_size = y['TPM2_PT_CONTEXT_SYM_SIZE']['raw']
 
             if sym_support:
                 # Now we create the wrappingbject, with algorithm aes256


### PR DESCRIPTION
https://github.com/tpm2-software/tpm2-tools/commit/54ef8cb2f5ed1f26d9f04852456a0f437600f92a
renamed everything from 'value' to 'raw' if the value was not touched,
which broke tpm2_ptool.

Fixes #228 

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>