### PR TITLE
build: link against tss2-mu

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -113,8 +113,8 @@ if ENABLE_INTEGRATION
 LIB_TEST := test/integration/libtest.a
 noinst_LIBRARIES = $(LIB_TEST)
 test_integration_libtest_a_SOURCES = $(LIB_SRC)
-test_integration_libtest_a_CFLAGS = -fPIC $(AM_CFLAGS)
-TESTS_LDADD += $(LIB_TEST)
+test_integration_libtest_a_CFLAGS = -fPIC $(AM_CFLAGS) $(TSS2_MU_CFLAGS)
+TESTS_LDADD += $(LIB_TEST) $(TSS2_MU_LIBS)
 
 TESTS = $(check_PROGRAMS)
 check_PROGRAMS += \

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,7 @@ AC_CONFIG_HEADERS([src/lib/config.h])
 
 # test for TSS dependecies
 PKG_CHECK_MODULES([TSS2_ESYS],   [tss2-esys])
+PKG_CHECK_MODULES([TSS2_MU],     [tss2-mu])
 PKG_CHECK_MODULES([TCTI_DEVICE], [tss2-tcti-device])
 PKG_CHECK_MODULES([TCTI_MSSIM],  [tss2-tcti-mssim])
 


### PR DESCRIPTION
Currently the linking of [`libtest`](https://github.com/tpm2-software/tpm2-pkcs11/blob/7b67ce0a43095ba671824e3763c4290828b7e169/Makefile.am#L110) relies on the fact that the upstream tpm2-tss pkg-config file explicitly requires tss2-mu. Since this is wrong and will be changed upstream, but we need access to the marshalling functions, explicitly link against tss2-mu. See https://github.com/tpm2-software/tpm2-tss/pull/1417 for a more detailed discussion.

Signed-off-by: Jonas Witschel <diabonas@gmx.de>