### PR TITLE
pkg-config: fix "Libs" and add private dependencies

### DIFF
--- a/lib/tpm2-pkcs11.pc.in
+++ b/lib/tpm2-pkcs11.pc.in
@@ -1,11 +1,10 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+p11_module_path=@P11_MODULE_PATH@
 
 Name: tpm2-pkcs11
-Description: TPM2 PKCS#11 library.
+Description: TPM2 PKCS#11 library
 URL: https://github.com/tpm2-software/tpm2-pkcs11
 Version: @VERSION@
-Cflags: -I${includedir}
-Libs: -ltss2-esys -L${libdir}
+Requires.private: tss2-esys tss2-mu sqlite3 libcrypto
+Cflags: @PTHREAD_CFLAGS@
+Libs: -L${p11_module_path} -ltpm2_pkcs11
+Libs.private: @PTHREAD_LIBS@


### PR DESCRIPTION
- `Libs` should contain the linker flags necessary to link the library, not its private dependencies.
- Since there is not header file, there is no need to add `-I` to `Cflags`.
- Add internal dependencies according to the Makefile to `Requires.private` and `Libs.private`. This is necessary for static linking.