### PR TITLE
Report CKF_USER_PIN_INITIALIZED in TokenInfo if initialized

### DIFF
--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -88,6 +88,7 @@ CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {
 
     if (t->config.is_initialized) {
         info->flags |= CKF_TOKEN_INITIALIZED;
+        info->flags |= CKF_USER_PIN_INITIALIZED;
     }
 
     // Identification


### PR DESCRIPTION
In our current approach, the token is initialized with tpm2_ptool addtoken
command, where the userpin is mandatory.
Thus if the token is initialized, the userpin is also initialized, so the
token should report this.

This is needed e.g. for correct functionality with nss / firefox.

Fixes #235 

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>