### PR TITLE
tpm: Handle CKA_KEY_TYPE attribute for GenerateKeyPair

### DIFF
--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -550,6 +550,7 @@ CK_RV check_common_attrs(
     static const attr_handler common_attr_check_handlers[] = {
         { CKA_PRIVATE,         handle_sensitive      },
         { CKA_EXTRACTABLE,     handle_extractable    },
+        { CKA_KEY_TYPE,        ATTR_HANDLER_IGNORE   },
         { CKA_TOKEN,           ATTR_HANDLER_IGNORE   },
         { CKA_ID,              ATTR_HANDLER_IGNORE   },
         { CKA_LABEL,           ATTR_HANDLER_IGNORE   },


### PR DESCRIPTION
Add a handler for CKA_KEY_TYPE, this basically checks whether the key type
matches the selected mechanism.
This is done by checking whether the selected TPM algorithm matches the key type.

Fixes #168 

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>