### PR TITLE
test: Fix true/false assignment

### DIFF
--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -388,7 +388,8 @@ static CK_RV object_add_missing_attrs(tobject *public_tobj, tobject *private_tob
     CK_BBOOL extractable = CK_FALSE;
     a = tobject_get_attribute_by_type(private_tobj, CKA_EXTRACTABLE);
     if (!a) {
-        ADD_ATTR(CK_BBOOL, CKA_EXTRACTABLE, !sensitive, newprivattrs, privindex);
+        extractable = !sensitive;
+        ADD_ATTR(CK_BBOOL, CKA_EXTRACTABLE, extractable, newprivattrs, privindex);
     } else {
         tmp_rv = generic_CK_BBOOL(a, &extractable);
         if (tmp_rv != CKR_OK) {

--- a/test/integration/pkcs-get-attribute-value.int.c
+++ b/test/integration/pkcs-get-attribute-value.int.c
@@ -285,7 +285,7 @@ static void test_all_priv_ecc_obj_attrs(void **state) {
         CK_OBJECT_HANDLE h = handles[i];
 
         /* verify missing attrs */
-        verify_missing_priv_attrs_common(session, keytype, h);
+        verify_missing_priv_attrs_common(session, keytype, h, CK_FALSE);
         verify_missing_priv_attrs_ecc(session, h);
     }
 }
@@ -357,7 +357,7 @@ static void test_all_priv_rsa_obj_attrs(void **state) {
         CK_OBJECT_HANDLE h = handles[i];
 
         /* verify missing attrs */
-        verify_missing_priv_attrs_common(session, keytype, h);
+        verify_missing_priv_attrs_common(session, keytype, h, CK_FALSE);
         verify_missing_priv_attrs_rsa(session, h);
     }
 }

--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -153,7 +153,7 @@ static void test_rsa_keygen_missing_attributes(void **state) {
     verify_missing_pub_attrs_common(session, CKK_RSA, pub_handle_dup);
     verify_missing_pub_attrs_rsa(session, pub_handle_dup);
 
-    verify_missing_priv_attrs_common(session, CKK_RSA, priv_handle_dup);
+    verify_missing_priv_attrs_common(session, CKK_RSA, priv_handle_dup, CK_FALSE);
     verify_missing_priv_attrs_rsa(session, priv_handle_dup);
 }
 static void test_rsa_keygen_p11tool_templ(void **state) {
@@ -162,7 +162,7 @@ static void test_rsa_keygen_p11tool_templ(void **state) {
     CK_SESSION_HANDLE session = ti->handle;
 
     CK_BBOOL ck_true = CK_TRUE;
-    CK_BBOOL ck_false = CK_TRUE;
+    CK_BBOOL ck_false = CK_FALSE;
     CK_BYTE id[] = "p11-templ-key-id-rsa";
     CK_ULONG bits = 2048;
     CK_BYTE exp[] = { 0x00, 0x01, 0x00, 0x01 }; //65537 in BN
@@ -259,7 +259,7 @@ static void test_rsa_keygen_p11tool_templ(void **state) {
     verify_missing_pub_attrs_common(session, CKK_RSA, pub_handle_dup);
     verify_missing_pub_attrs_rsa(session, pub_handle_dup);
 
-    verify_missing_priv_attrs_common(session, CKK_RSA, priv_handle_dup);
+    verify_missing_priv_attrs_common(session, CKK_RSA, priv_handle_dup, CK_TRUE);
     verify_missing_priv_attrs_rsa(session, priv_handle_dup);
 }
 
@@ -269,7 +269,7 @@ static void test_ecc_keygen_p11tool_templ(void **state) {
     CK_SESSION_HANDLE session = ti->handle;
 
     CK_BBOOL ck_true = CK_TRUE;
-    CK_BBOOL ck_false = CK_TRUE;
+    CK_BBOOL ck_false = CK_FALSE;
     CK_BYTE id[] = "p11-templ-key-id-ecc";
     CK_UTF8CHAR label[] = "p11-templ-key-label-ecc";
 
@@ -385,7 +385,7 @@ static void test_ecc_keygen_p11tool_templ(void **state) {
 
     /* verify missing attrs */
     verify_missing_pub_attrs_common(session, CKK_EC, pub_handle_dup);
-    verify_missing_priv_attrs_common(session, CKK_EC, priv_handle_dup);
+    verify_missing_priv_attrs_common(session, CKK_EC, priv_handle_dup, CK_TRUE);
 
     verify_missing_pub_attrs_ecc(session, pub_handle_dup);
     verify_missing_priv_attrs_ecc(session, priv_handle_dup);
@@ -397,7 +397,7 @@ static void test_destroy(void **state) {
     CK_SESSION_HANDLE session = ti->handle;
 
     CK_BBOOL ck_true = CK_TRUE;
-    CK_BBOOL ck_false = CK_TRUE;
+    CK_BBOOL ck_false = CK_FALSE;
     CK_BYTE id[] = "p11-templ-key-id-ecc-destroy";
     CK_UTF8CHAR label[] = "p11-templ-key-label-ecc-destroy";
 

--- a/test/integration/test.c
+++ b/test/integration/test.c
@@ -314,7 +314,7 @@ void verify_missing_priv_attrs_ecc(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h
     assert_int_equal(count, ARRAY_LEN(attrs));
 }
 
-void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h) {
+void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h, CK_BBOOL extractable) {
 
     CK_BYTE tmp[5][256] = { 0 };
 
@@ -353,21 +353,21 @@ void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE key
             CK_BBOOL v = CK_FALSE;
             rv = generic_CK_BBOOL(a, &v);
             assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CK_TRUE);
+            assert_int_equal(v, !extractable);
             count++;
         } break;
         case CKA_EXTRACTABLE: {
             CK_BBOOL v = CK_TRUE;
             rv = generic_CK_BBOOL(a, &v);
             assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CK_FALSE);
+            assert_int_equal(v, extractable);
             count++;
         } break;
         case CKA_NEVER_EXTRACTABLE: {
             CK_BBOOL v = CK_FALSE;
             rv = generic_CK_BBOOL(a, &v);
             assert_int_equal(rv, CKR_OK);
-            assert_int_equal(v, CK_TRUE);
+            assert_int_equal(v, !extractable);
             count++;
         } break;
         default:

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -80,7 +80,7 @@ void get_keypair(CK_SESSION_HANDLE session, CK_KEY_TYPE key_type, CK_OBJECT_HAND
 
 void verify_missing_pub_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h);
 
-void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h);
+void verify_missing_priv_attrs_common(CK_SESSION_HANDLE session, CK_KEY_TYPE keytype, CK_OBJECT_HANDLE h, CK_BBOOL extractable);
 
 void verify_missing_pub_attrs_ecc(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE h);
 


### PR DESCRIPTION
A variable with the name ck_false should have the value CK_FALSE,
not CK_TRUE!

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>