### PR TITLE
Populate MECHANISM_INFO for supported mechanisms

### DIFF
--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -118,23 +118,78 @@ CK_RV slot_mechanism_info_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE type, CK_ME
         return CKR_SLOT_ID_INVALID;
     }
 
-    // TODO support more of these and check with the TPM for sizes.
+    /* TODO pull these from TPM, currently they match the simulator */
+    CK_ULONG aes_min_keysize = 128/8; // in bytes
+    CK_ULONG aes_max_keysize = 256/8; // in bytes
+    CK_ULONG ecc_min_keysize = 256;
+    CK_ULONG ecc_max_keysize = 384;
+    CK_ULONG rsa_min_keysize = 1024;
+    CK_ULONG rsa_max_keysize = 2048;
+
     switch(type) {
+    /* AES based crypto */
+    /* Todo: Check if HW or Software and support */
     case CKM_AES_KEY_GEN:
-        info->ulMinKeySize = 128;
-        info->ulMaxKeySize = 512;
+        info->ulMinKeySize = aes_min_keysize;
+        info->ulMaxKeySize = aes_max_keysize;
         info->flags = CKF_GENERATE;
         break;
+    case CKM_AES_CBC:
+    case CKM_AES_CFB1:
+    case CKM_AES_ECB:
+        info->ulMinKeySize = aes_min_keysize;
+        info->ulMaxKeySize = aes_max_keysize;
+        info->flags = 0;
+        break;
+
+    /* RSA based crypto */
     case CKM_RSA_PKCS_KEY_PAIR_GEN:
-        info->ulMinKeySize = 1024;
-        info->ulMaxKeySize = 4096;
-        info->flags = CKF_GENERATE_KEY_PAIR;
+        info->ulMinKeySize = rsa_min_keysize;
+        info->ulMaxKeySize = rsa_max_keysize;
+        info->flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
         break;
+    case CKM_RSA_PKCS:
+    case CKM_RSA_X_509:
+        info->ulMinKeySize = rsa_min_keysize;
+        info->ulMaxKeySize = rsa_max_keysize;
+        info->flags = CKF_HW | CKF_ENCRYPT | CKF_DECRYPT | CKF_SIGN | CKF_VERIFY;
+        break;
+    case CKM_RSA_PKCS_OAEP:
+        info->ulMinKeySize = rsa_min_keysize;
+        info->ulMaxKeySize = rsa_max_keysize;
+        info->flags = CKF_HW | CKF_ENCRYPT| CKF_DECRYPT;
+        break;
+    case CKM_SHA1_RSA_PKCS:
+    case CKM_SHA256_RSA_PKCS:
+    case CKM_SHA384_RSA_PKCS:
+    case CKM_SHA512_RSA_PKCS:
+        info->ulMinKeySize = rsa_min_keysize;
+        info->ulMaxKeySize = rsa_max_keysize;
+        info->flags = CKF_HW | CKF_SIGN | CKF_VERIFY;
+        break;
+
+    /* ECC based crypto */
+    /* TODO: Add ECC specific flags */
     case CKM_EC_KEY_PAIR_GEN:
-        info->ulMinKeySize = 192;
-        info->ulMaxKeySize = 256;
-        info->flags = CKF_GENERATE_KEY_PAIR;
+        info->ulMinKeySize = ecc_min_keysize;
+        info->ulMaxKeySize = ecc_max_keysize;
+        info->flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
         break;
+    case CKM_ECDSA:
+    case CKM_ECDSA_SHA1:
+        info->ulMinKeySize = ecc_min_keysize;
+        info->ulMaxKeySize = ecc_max_keysize;
+        info->flags = CKF_HW | CKF_SIGN | CKF_VERIFY;
+        break;
+
+    /* Hashes */
+    case CKM_SHA_1:
+    case CKM_SHA256:
+        info->ulMinKeySize = 0;
+        info->ulMaxKeySize = 0;
+        info->flags = CKF_HW | CKF_DIGEST;
+        break;
+
     default:
         return CKR_MECHANISM_INVALID;
     }

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -117,9 +117,70 @@ void test_get_mechanism_info_good(void **state) {
     CK_RV rv = C_GetMechanismInfo(slot_id, CKM_AES_KEY_GEN, &mech_info);
     assert_int_equal(rv, CKR_OK);
 
-    assert_int_equal(mech_info.ulMaxKeySize, 512);
-    assert_int_equal(mech_info.ulMinKeySize, 128);
+    assert_int_equal(mech_info.ulMaxKeySize, 256/8);
+    assert_int_equal(mech_info.ulMinKeySize, 128/8);
     assert_int_equal(mech_info.flags, CKF_GENERATE);
+
+    /* Test all other mechanisms */
+    CK_ULONG aes_mechs[] = {
+        CKM_AES_CBC,
+        CKM_AES_CFB1,
+        CKM_AES_ECB,
+    };
+    for (size_t i = 0; i < ARRAY_LEN(aes_mechs); i++) {
+        rv = C_GetMechanismInfo(slot_id, aes_mechs[i], &mech_info);
+        assert_int_equal(rv, CKR_OK);
+
+        assert_int_equal(mech_info.ulMinKeySize, 128/8);
+        assert_int_equal(mech_info.ulMaxKeySize, 256/8);
+        assert_int_equal(mech_info.flags, 0);
+    }
+
+    CK_ULONG rsa_mechs[] = {
+        CKM_RSA_PKCS_KEY_PAIR_GEN,
+        CKM_RSA_PKCS,
+        CKM_RSA_X_509,
+        CKM_RSA_PKCS_OAEP,
+        CKM_SHA1_RSA_PKCS,
+        CKM_SHA256_RSA_PKCS,
+        CKM_SHA384_RSA_PKCS,
+        CKM_SHA512_RSA_PKCS,
+    };
+    for (size_t i = 0; i < ARRAY_LEN(rsa_mechs); i++) {
+        rv = C_GetMechanismInfo(slot_id, rsa_mechs[i], &mech_info);
+        assert_int_equal(rv, CKR_OK);
+
+        assert_int_equal(mech_info.ulMinKeySize, 1024);
+        assert_int_equal(mech_info.ulMaxKeySize, 2048);
+        assert_int_not_equal(mech_info.flags, 0);
+    }
+
+    CK_ULONG ecc_mechs[] = {
+        CKM_EC_KEY_PAIR_GEN,
+        CKM_ECDSA,
+        CKM_ECDSA_SHA1,
+    };
+    for (size_t i = 0; i < ARRAY_LEN(ecc_mechs); i++) {
+        rv = C_GetMechanismInfo(slot_id, ecc_mechs[i], &mech_info);
+        assert_int_equal(rv, CKR_OK);
+
+        assert_int_equal(mech_info.ulMinKeySize, 256);
+        assert_int_equal(mech_info.ulMaxKeySize, 384);
+        assert_int_not_equal(mech_info.flags, 0);
+    }
+
+    CK_ULONG hash_mechs[] = {
+        CKM_SHA_1,
+        CKM_SHA256,
+    };
+    for (size_t i = 0; i < ARRAY_LEN(hash_mechs); i++) {
+        rv = C_GetMechanismInfo(slot_id, hash_mechs[i], &mech_info);
+        assert_int_equal(rv, CKR_OK);
+
+        assert_int_equal(mech_info.ulMinKeySize, 0);
+        assert_int_equal(mech_info.ulMaxKeySize, 0);
+        assert_int_not_equal(mech_info.flags, 0);
+    }
 }
 
 void test_get_mechanism_info_bad(void **state) {


### PR DESCRIPTION
This patch populates the MECHANISM_INFO structure for each of the supported
mechanisms, as a preparation to pull this information from the TPM.

The min/max keysizes were taken from the `Implementation.h` from the simulator,
for now.
Maybe RSA1k keys should be removed from the list, as e.g. TCG PTP spec lists
them as 'support for 1024-bits keys is not recommended'.
The AES Keysizes are in bytes according to the standard, not bits, so this also
fixes a bug.

The usage flags were largely derived from tables like
http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/errata01/os/pkcs11-curr-v2.40-errata01-os-complete.html#_Toc441850404

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>