### PR TITLE
Add DB schema for future upgrades

### DIFF
--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -295,6 +295,7 @@ class Db(object):
     # secondary
     # tertiary
     #
+    # NOTE: Update the DB Schema Version at the bottom if the db format changes!
     def create(self):
         c = self._conn.cursor()
         sql = [
@@ -368,6 +369,17 @@ class Db(object):
                 attrs TEXT NOT NULL,
                 FOREIGN KEY (sid) REFERENCES sobjects(id) ON DELETE CASCADE
             );
+            '''),
+            textwrap.dedent('''
+            CREATE TABLE IF NOT EXISTS schema(
+                id INTEGER PRIMARY KEY,
+                schema_version INTEGER NOT NULL
+            );
+            '''),
+            # NOTE: Update the DB Schema Version if the format above changes!
+            # REPLACE updates the value if it exists, or inserts it if it doesn't
+            textwrap.dedent('''
+            REPLACE INTO schema (id, schema_version) VALUES (1, 1);
             '''),
         ]
 


### PR DESCRIPTION
We need a way to track the current version of our db format.
If the format (e.g. table structure or names) change, an update path/tool
can be created based on the schema version.

Fixes #195

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>