### PR TITLE
Update to latest tpm2_tools tpm2_changeauth command layout

### DIFF
--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -186,7 +186,7 @@ class Tpm2(object):
         _, priv = tempfile.mkstemp(prefix='', suffix='.priv', dir=self._tmp)
         _, pub = tempfile.mkstemp(prefix='', suffix='.pub', dir=self._tmp)
 
-        parent_path = "file:" + str(phandle)
+        parent_path = str(phandle)
         cmd = [
             'tpm2_import', '-V', '-C', parent_path, '-i', privkey, '-u', pub,
             '-r', priv
@@ -224,9 +224,9 @@ class Tpm2(object):
 
         #tpm2_load -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
         cmd = [
-            'tpm2_changeauth', '-C', str(pctx), '-c', str(objctx), '-P',
-            'hex:' + oldobjauth.decode(), '-p', 'hex:' + newobjauth.decode(),
-            '-r', newpriv
+            'tpm2_changeauth', '-C', str(pctx), '-c', str(objctx), '-p',
+            'hex:' + oldobjauth.decode(), '-r', newpriv,
+            'hex:' + newobjauth.decode(),
         ]
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         _, stderr = p.communicate()


### PR DESCRIPTION
With latest commit in tpm2_tools (b561c7d5) the tpm2_changeauth behaviour
was changed.

From the man pages the tpm2_changeauth command layout changed from
`tpm2_changeauth -C primary.ctx -P foo -p bar -c key.ctx -r new.priv`
to
`tpm2_changeauth -C primary.ctx -p foo        -c key.ctx -r new.priv bar`

Thus -P became -p and
the previous -p was removed and passed as regular argument
Fixes: #258 

Signed-off-by: Peter Huewe <peter.huewe@infineon.com>