### PR TITLE
tpm2_ptool: update tpm2-tools option from -b to -a

### DIFF
--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -136,7 +136,7 @@ class Tpm2(object):
             cmd.extend(['-p', 'hex:%s' % objauth.decode()])
 
         if objattrs != None:
-            cmd.extend(['-b', objattrs])
+            cmd.extend(['-a', objattrs])
 
         if seal != None:
             cmd.extend(['-i', '-'])
@@ -199,7 +199,7 @@ class Tpm2(object):
             cmd.extend(['-p', 'hex:%s' % objauth.decode()])
 
         if objattrs != None:
-            cmd.extend(['-b', objattrs])
+            cmd.extend(['-a', objattrs])
 
         if seal != None:
             cmd.extend(['-i', '-'])


### PR DESCRIPTION
This has been changed upstream in https://github.com/tpm2-software/tpm2-tools/pull/1582, cf. the currently [failing build](https://travis-ci.org/tpm2-software/tpm2-pkcs11/jobs/554728372#L2746).