### PR TITLE
ci: don't limit the amount of parallel jobs for make check

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -78,7 +78,7 @@ fi
 
 ../configure --enable-unit --enable-integration --enable-esapi-session-manage-flags $config_flags
 make -j$(nproc)
-make -j$(nproc) check
+make -j check
 
 if [ "$CC" == "gcc" ] && [ "$PYTHON_INTERPRETER" == "python3" ]; then
     bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Similar to https://github.com/tpm2-software/tpm2-tss/pull/1446, much of the CI time is spent on running the integration test suite, which is not CPU bound, so allowing more parallel jobs allows for some speedup. This reduces the CI time from about [00:18 real-time/01:12 total](https://travis-ci.org/tpm2-software/tpm2-pkcs11/builds/555571745) to about [00:09 real-time/00:33 total](https://travis-ci.org/tpm2-software/tpm2-pkcs11/builds/555982412).