### PR TITLE
tpm2_pkcs11/utils.py: hash_pass needs unique salt

### DIFF
--- a/tools/tpm2_pkcs11/utils.py
+++ b/tools/tpm2_pkcs11/utils.py
@@ -41,7 +41,10 @@ def rand_str(num):
     return binascii.hexlify(os.urandom(32))
 
 
-def hash_pass(password, iters=100000, salt=os.urandom(32)):
+def hash_pass(password, iters=100000, salt=None):
+
+    if salt is None:
+        salt = os.urandom(32)
 
     phash = hashlib.pbkdf2_hmac('sha256', password, salt, iters)
     rhash = phash


### PR DESCRIPTION
the os.random() call for salt, when not specified, is only invoked once,
causing each call to get the same nonce. Move it to the function body
so if None, then it gets invoked will cause unique nonces per
invocation.

Signed-off-by: William Roberts <william.c.roberts@intel.com>