### PR TITLE
Fix tools options

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -54,7 +54,7 @@ tpm2_ptool init --pobj-pin=mypobjpin --path=$TPM2_PKCS11_STORE
 
 # Test the existing primary object init functionality
 tpm2_createprimary -p foopass -o $TPM2_PKCS11_STORE/primary.ctx -g sha256 -G rsa
-handle=`tpm2_evictcontrol -a o -c $TPM2_PKCS11_STORE/primary.ctx | grep -Po '(?<=persistent-handle: )\S+'`
+handle=`tpm2_evictcontrol -C o -c $TPM2_PKCS11_STORE/primary.ctx | grep -Po '(?<=persistent-handle: )\S+'`
 
 tpm2_ptool init --pobj-pin=anotherpobjpin --primary-handle=$handle --primary-auth=foopass --path=$TPM2_PKCS11_STORE
 

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -158,7 +158,7 @@ class Tpm2(object):
     def getcap(self, cap):
 
         # tpm2_getcap -Q -l $cap
-        cmd = ['tpm2_getcap', '-c', cap]
+        cmd = ['tpm2_getcap', cap]
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         stdout, stderr = p.communicate()
         rc = p.wait()

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -100,7 +100,7 @@ class Tpm2(object):
         cmd = ['tpm2_encryptdecrypt', '-c', ctx, '-p', 'hex:' + auth.decode()]
 
         if decrypt:
-            cmd.extend(['-D'])
+            cmd.extend(['-d'])
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=os.environ)
         stdout, stderr = p.communicate(input=data)


### PR DESCRIPTION
Several tpm2-tools options changed:

-  tpm2_evictcontrol: `-a` became `-C` (tpm2-software/tpm2-tools@3c097b83)
-  tpm2_getcap : `-c` became an argument (tpm2-software/tpm2-tools@cfc2538a)
-  tpm2_encryptdecrypt: `-D` became `-d` (tpm2-software/tpm2-tools@75a86d5c2, note: the commit message is wrong)

Hence, these options have to be changed here, as well.