### PR TITLE
Fix change of tool options

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -53,7 +53,7 @@ set -e
 tpm2_ptool init --pobj-pin=mypobjpin --path=$TPM2_PKCS11_STORE
 
 # Test the existing primary object init functionality
-tpm2_createprimary -p foopass -o $TPM2_PKCS11_STORE/primary.ctx -g sha256 -G rsa
+tpm2_createprimary -p foopass -c $TPM2_PKCS11_STORE/primary.ctx -g sha256 -G rsa
 handle=`tpm2_evictcontrol -C o -c $TPM2_PKCS11_STORE/primary.ctx | grep -Po '(?<=persistent-handle: )\S+'`
 
 tpm2_ptool init --pobj-pin=anotherpobjpin --primary-handle=$handle --primary-auth=foopass --path=$TPM2_PKCS11_STORE

--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -274,7 +274,7 @@ class AddTokenCommand(Command):
             if args['wrap'] != 'auto':
                 if args['wrap'] == 'software' and sym_support:
                     print(
-                        "Warning: confifuring software wrapping key when TPM has support.\n"
+                        "Warning: configuring software wrapping key when TPM has support.\n"
                         "THIS IS NOT RECOMENDED")
                     sym_support = False
                 elif args['wrap'] == 'tpm' and not sym_support:

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -66,11 +66,11 @@ class Tpm2(object):
 
         ctx = os.path.join(self._tmp, uuid.uuid4().hex + '.out')
 
-        #tpm2_load -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
+        #tpm2_load -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -c $file_load_key_ctx
         if priv != None:
             cmd = [
                 'tpm2_load', '-C', str(pctx), '-P', 'hex:' + pauth.decode(), '-u',
-                pub, '-r', priv, '-n', '/dev/null', '-o', ctx
+                pub, '-r', priv, '-n', '/dev/null', '-c', ctx
             ]
         else:
             cmd = [

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -18,7 +18,7 @@ class Tpm2(object):
     def createprimary(self, ownerauth, objauth):
         ctx = os.path.join(self._tmp, "context.out")
         cmd = [
-            'tpm2_createprimary', '-p', 'hex:%s' % objauth.decode(), '-o', ctx,
+            'tpm2_createprimary', '-p', 'hex:%s' % objauth.decode(), '-c', ctx,
             '-g', 'sha256', '-G', 'rsa'
         ]
 


### PR DESCRIPTION
Some tool options changed and thus have to be changed here, too.

- tpm2_createprimary: `-o` became `-c` (tpm2-software/tpm2-tools@3939d715)
- tpm2_load: `-o` became `-c` (tpm2-software/tpm2-tools@888f63c4)

Additionally, a typo was fixed.