### PR TITLE
test: update TPM2TOOLS_TCTI for tss2-tctildr

### DIFF
--- a/test/integration/scripts/int-test-setup.sh
+++ b/test/integration/scripts/int-test-setup.sh
@@ -195,7 +195,7 @@ if [ $? -ne 0 ]; then
     echo "failed to start tabrmd with name ${TABRMD_NAME}"
 fi
 
-export TPM2TOOLS_TCTI="abrmd:${TABRMD_TEST_TCTI_CONF}"
+export TPM2TOOLS_TCTI="tabrmd:${TABRMD_TEST_TCTI_CONF}"
 echo ${TPM2TOOLS_TCTI}
 
 export TPM2_PKCS11_TCTI="abrmd:${TABRMD_TEST_TCTI_CONF}"


### PR DESCRIPTION
Currently the integration tests fail with
```
Traceback (most recent call last):
  File "/home/jonas/tpm2-software/tpm2-pkcs11/tools/tpm2_pkcs11/commandlets_store.py", line 96, in __call__
    handle = Tpm2.evictcontrol(ownerauth, ctx)
  File "/home/jonas/tpm2-software/tpm2-pkcs11/tools/tpm2_pkcs11/tpm2.py", line 47, in evictcontrol
    handle = y['persistent-handle'] if rc == 0 else None
TypeError: 'NoneType' object is not subscriptable
'NoneType' object is not subscriptable
```
because `tpm2_evictcontrol` gives the error
```
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:116:handle_from_name() Failed to load TCTI for name "abrmd": libtss2-tcti-abrmd.so: cannot open shared object file: No such file or directory
ERROR:tcti:src/tss2-tcti/tctildr.c:417:Tss2_TctiLdr_Initialize_Ex() Failed to instantiate TCTI
ERROR: Could not load tcti, got: "abrmd:bus_type=session,bus_name=com.intel.tss2.Tabrmd<port>"
```
(without returning a non-zero exit code). This is because the upstream change https://github.com/tpm2-software/tpm2-tools/pull/1615 makes it necessary to change `TPM2TOOLS_TCTI` from `abrmd` to `tabrmd`.