### PR TITLE
ci: fix build with gcc not running plain build

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -52,11 +52,10 @@ fi
 # Bootstrap the project
 ./bootstrap
 
-# clang has asan enabled with options exported that fail
-# make distcheck, so only do this with gcc.
-# Do a make distcheck in the root, clear it and than
-# cd to the variant directory.
-if [ "$CC" == "gcc" ]; then
+# clang and gcc can have features enabled in the config_flags that
+# avoid error checking or cause make distcheck to fail. So run a
+# pure check with gcc before adding those flags.
+if [[ "$CC" != clang* ]]; then
     ./configure --enable-esapi-session-manage-flags
     make distcheck
     make distclean
@@ -68,7 +67,7 @@ pushd ./build
 
 # Run scan-build for gcc only.
 # Scan-build does not work with clang because of asan linking errors.
-if [[ "$CC" == gcc* ]]; then
+if [[ "$CC" != clang* ]]; then
     scan-build ../configure --enable-unit --enable-integration --enable-debug=yes $config_flags
     scan-build --status-bugs make -j$(nproc)
 
@@ -80,7 +79,7 @@ fi
 make -j$(nproc)
 make -j check
 
-if [ "$CC" == "gcc" ] && [ "$PYTHON_INTERPRETER" == "python3" ]; then
+if [[ "$CC" != clang* ]] && [ "$PYTHON_INTERPRETER" == "python3" ]; then
     bash <(curl -s https://codecov.io/bash)
 fi
 


### PR DESCRIPTION
The ocnditional checks were checking if CC == gcc, which is not valid
when:
  - CC is empty, which is a comon implication for configure to choose
gcc.
  - when gcc has the version number tacked onto it, like gcc-6.

Just check that CC != clang* and assume it's gcc and run a configure
without any options disabled and also perform the make distcheck to
make sure the release tarball doesn't break.

Now you'll also see errors during the build like:
../../src/lib/object.c:650:12: error: 'my_unused_func' defined but not used [-Werror=unused-function]
 static int my_unused_func(void) {
            ^

Fixes: #211

Signed-off-by: William Roberts <william.c.roberts@intel.com>