### PR TITLE
tpm2_ptool: move 'noqa' annotation to end of line

### DIFF
--- a/tools/tpm2_pkcs11/tpm2_ptool.py
+++ b/tools/tpm2_pkcs11/tpm2_ptool.py
@@ -2,21 +2,21 @@ from .command import commandlet
 
 # These imports are required to add the commandlet even though they appear unused
 # Store level commands
-from .commandlets_store import InitCommand  # noqa # pylint: disable=unused-import
-from .commandlets_store import DestroyCommand  # noqa # pylint: disable=unused-import
+from .commandlets_store import InitCommand  # pylint: disable=unused-import # noqa
+from .commandlets_store import DestroyCommand  # pylint: disable=unused-import # noqa
 
 # Token Level Commands
-from .commandlets_token import AddTokenCommand  # noqa # pylint: disable=unused-import
-from .commandlets_token import AddEmptyTokenCommand  # noqa # pylint: disable=unused-import
-from .commandlets_token import RmTokenCommand  # noqa # pylint: disable=unused-import
+from .commandlets_token import AddTokenCommand  # pylint: disable=unused-import # noqa
+from .commandlets_token import AddEmptyTokenCommand  # pylint: disable=unused-import # noqa
+from .commandlets_token import RmTokenCommand  # pylint: disable=unused-import # noqa
 
-from .commandlets_token import VerifyCommand  # noqa # pylint: disable=unused-import
+from .commandlets_token import VerifyCommand  # pylint: disable=unused-import # noqa
 
-from .commandlets_token import InitPinCommand  # noqa # pylint: disable=unused-import
-from .commandlets_token import ChangePinCommand  # noqa # pylint: disable=unused-import
+from .commandlets_token import InitPinCommand  # pylint: disable=unused-import # noqa
+from .commandlets_token import ChangePinCommand  # pylint: disable=unused-import # noqa
 
-from .commandlets_keys import AddKeyCommand  # noqa # pylint: disable=unused-import
-from .commandlets_keys import ImportCommand  # noqa # pylint: disable=unused-import
+from .commandlets_keys import AddKeyCommand  # pylint: disable=unused-import # noqa
+from .commandlets_keys import ImportCommand  # pylint: disable=unused-import # noqa
 
 def main():
     '''The main entry point.'''


### PR DESCRIPTION
lgtm.com does not recognise the suppression comment [if there is trailing text after it](https://help.semmle.com/lgtm-enterprise/user/help/alert-suppression.html#format), while Pylint does not mind a trailing comment, so move `noqa` to the end to appease both Pylint and LGTM.