### PR TITLE
db: use ESYS_TR instead of raw handle

### DIFF
--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -510,23 +510,15 @@ CK_RV tpm_stirrandom(tpm_ctx *ctx, CK_BYTE_PTR seed, CK_ULONG seed_len) {
     return CKR_OK;
 }
 
-bool tpm_register_handle(tpm_ctx *ctx, uint32_t *handle) {
+bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle) {
 
-    ESYS_TR object;
-
-    TSS2_RC rval =
-        Esys_TR_FromTPMPublic(
-            ctx->esys_ctx,
-            *handle,
-            ESYS_TR_NONE,
-            ESYS_TR_NONE,
-            ESYS_TR_NONE,
-            &object);
+    TSS2_RC rval = Esys_TR_Deserialize(ctx->esys_ctx,
+                        (uint8_t *)handle_blob,
+                        twist_len(handle_blob), handle);
     if (rval != TSS2_RC_SUCCESS) {
-        LOGE("Esys_TR_FromTPMPublic: 0x%x", rval);
+        LOGE("Esys_TR_Deserialize: 0x%x:", rval);
         return false;
     }
-    *handle = object;
 
     return true;
 }

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -71,6 +71,8 @@ bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle);
 
 twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth);
 
+bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
+
 /**
  * Perform a signing operation using the TPM.
  * @param ctx

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -26,7 +26,7 @@
 #include "openssl_compat.h"
 #include "utils.h"
 
-#define TOKEN_COUNT 2
+#define TOKEN_COUNT 3
 
 #define GOOD_USERPIN "myuserpin"
 #define GOOD_SOPIN   "mysopin"

--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -115,14 +115,14 @@ class Db(object):
 
         return c.lastrowid
 
-    def addprimary(self, handle, objauth, hierarchy='o'):
+    def addprimary(self, tr_handle, objauth, hierarchy='o'):
 
         # Subordiante commands will need some of this data
         # when deriving subordinate objects, so pass it back
         pobject = {
             # General Metadata
             'hierarchy': hierarchy,
-            'handle': handle,
+            'handle': Db._blobify(tr_handle),
             'objauth': objauth,
         }
 
@@ -239,7 +239,7 @@ class Db(object):
             CREATE TABLE IF NOT EXISTS pobjects(
                 id INTEGER PRIMARY KEY,
                 hierarchy TEXT NOT NULL,
-                handle INTEGER NOT NULL,
+                handle BLOB NOT NULL,
                 objauth TEXT NOT NULL
             );
             '''),

--- a/tools/tpm2_pkcs11/utils.py
+++ b/tools/tpm2_pkcs11/utils.py
@@ -31,6 +31,11 @@ def list_dict_to_kvp(l):
     x = "\n".join(kvp_row(d) for d in l)
     return x
 
+def bytes_to_file(bites, tmpdir):
+    path = os.path.join(tmpdir, "primary.handle")
+    open(path, 'w+b').write(bites)
+    return path
+
 
 def dict_from_kvp(kvp):
     return dict(x.split('=') for x in kvp.split('\n'))
@@ -100,9 +105,8 @@ def query_yes_no(question, default="no"):
                              "(or 'y' or 'n').\n")
 
 
-def load_sealobject(token, tpm2, db, pobjauth, pin, is_so):
+def load_sealobject(token, db, tpm2, pobjhandle, pobjauth, pin, is_so):
 
-    pobj = db.getprimary(token['pid'])
     sealobject = db.getsealobject(token['id'])
     if is_so:
         sealpub = sealobject['sopub']
@@ -116,9 +120,9 @@ def load_sealobject(token, tpm2, db, pobjauth, pin, is_so):
     sealauth = hash_pass(pin.encode(), salt)['hash']
 
     # Load the so sealobject using the PARENTS AUTH (primaryobject)
-    sealctx = tpm2.load(pobj['handle'], pobjauth, sealpriv, sealpub)
+    sealctx = tpm2.load(pobjhandle, pobjauth, sealpriv, sealpub)
 
-    return pobj, sealctx, sealauth
+    return sealctx, sealauth
 
 
 class AESCipher:


### PR DESCRIPTION
Raw handles are not TPM MITM attack safe, however, ESYS_TR's are so
use them.

Fixes: #130

Signed-off-by: William Roberts <william.c.roberts@intel.com>