### PR TITLE
cleanups on str padding

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -21,8 +21,8 @@
   #define VERSION "UNKNOWN"
 #endif
 
-#define LIBRARY_DESCRIPTION "TPM2.0 Cryptoki"
-#define LIBRARY_MANUFACTURER "tpm2-software.github.io"
+#define LIBRARY_DESCRIPTION (CK_UTF8CHAR_PTR)"TPM2.0 Cryptoki"
+#define LIBRARY_MANUFACTURER (CK_UTF8CHAR_PTR)"tpm2-software.github.io"
 
 #define CRYPTOKI_VERSION { \
            .major = CRYPTOKI_VERSION_MAJOR, \
@@ -34,17 +34,16 @@ CK_RV general_get_info(CK_INFO *info) {
 
     CK_INFO _info = {
         .cryptokiVersion = CRYPTOKI_VERSION,
-        .manufacturerID = LIBRARY_MANUFACTURER,
         .flags = 0,
-        .libraryDescription = LIBRARY_DESCRIPTION,
         .libraryVersion = {
             /* TODO get from build VERSION */
             .major = 42,
             .minor = 42
         },
     };
-    str_pad(_info.manufacturerID, sizeof(_info.manufacturerID));
-    str_pad(_info.libraryDescription, sizeof(_info.libraryDescription));
+
+    str_padded_copy(_info.manufacturerID, LIBRARY_MANUFACTURER, sizeof(_info.manufacturerID));
+    str_padded_copy(_info.libraryDescription, LIBRARY_DESCRIPTION, sizeof(_info.libraryDescription));
 
     *info = _info;
 

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -74,7 +74,6 @@ CK_RV slot_get_list (CK_BYTE token_present, CK_SLOT_ID *slot_list, CK_ULONG_PTR 
 CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
 
     token *token;
-    CK_TOKEN_INFO token_info;
 
     check_pointer(info);
 
@@ -83,14 +82,14 @@ CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
         return CKR_SLOT_ID_INVALID;
     }
 
-    memset(info, 0, sizeof(*info));
-
+    CK_TOKEN_INFO token_info;
     if (token_get_info(token, &token_info)) {
         return CKR_GENERAL_ERROR;
     }
 
     str_padded_copy(info->manufacturerID, token_info.manufacturerID, sizeof(info->manufacturerID));
     str_padded_copy(info->slotDescription, token_info.label, sizeof(info->slotDescription));
+
     info->hardwareVersion = token_info.hardwareVersion;
     info->firmwareVersion = token_info.firmwareVersion;
 

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -63,6 +63,7 @@ void token_free(token *t) {
 CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {
     check_pointer(t);
     check_pointer(info);
+
     int rval;
     time_t rawtime;
     struct tm tminfo;

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -23,16 +23,7 @@
 
 #define UNUSED(x) (void)x
 
-/*
- * Pads the buffer 'buf' with blanks to the desired 'buf_len'.
- * The trailing '\0' byte is removed, so the buffer is NOT null terminared afterwards!
- * */
-static inline void str_pad(unsigned char * buf, size_t buf_len) {
-    size_t str_len = strlen((char *)buf);
-    memset(buf + str_len, ' ', buf_len - str_len);
-}
-
-static inline void str_padded_copy(unsigned char * dst, const unsigned char * src, size_t dst_len) {
+static inline void str_padded_copy(CK_UTF8CHAR_PTR dst, const CK_UTF8CHAR_PTR src, size_t dst_len) {
     memset(dst, ' ', dst_len);
     memcpy(dst, src, strnlen((char *)(src), dst_len));
 }


### PR DESCRIPTION
The PKCS11 string interfaces to the user are not NULL terminated
and are padded with leading spaces. There was some redundant code
so clean it up.

Signed-off-by: William Roberts <william.c.roberts@intel.com>