### PR TITLE
DO NOT MERGE TESTING CI

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -51,6 +51,10 @@ CK_RV general_get_info(CK_INFO *info) {
     return CKR_OK;
 }
 
+void unused_function(int x) {
+	printf("foobar\n");
+}
+
 CK_RV general_get_func_list(CK_FUNCTION_LIST **function_list) {
 
     if (function_list == NULL_PTR) {


### PR DESCRIPTION
We should see CI fail with:

src/lib/general.c: In function ‘unused_function’:
src/lib/general.c:54:26: error: unused parameter ‘x’ [-Werror=unused-parameter]
 void unused_function(int x) {
                          ^
Signed-off-by: William Roberts <william.c.roberts@intel.com>