### PR TITLE
C_GetSlots: set size on CKR_BUFFER_TOO_SMALL

### DIFF
--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -57,6 +57,7 @@ CK_RV slot_get_list (CK_BYTE token_present, CK_SLOT_ID *slot_list, CK_ULONG_PTR 
     }
 
     if (*count < global.token_cnt) {
+        *count = global.token_cnt;
         return CKR_BUFFER_TOO_SMALL;
     }
 

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -17,10 +17,20 @@ static test_info *test_info_new(void) {
     test_info *ti = calloc(1, sizeof(*ti));
     assert_non_null(ti);
 
-    /* get the slots */
-    CK_SLOT_ID slots[6];
-    CK_ULONG count = ARRAY_LEN(slots);
-    CK_RV rv = C_GetSlotList(true, slots, &count);
+    /* get the slots and verify that count is updated
+     * when buffer is null or count is too small */
+    CK_SLOT_ID slots[TOKEN_COUNT];
+    CK_ULONG count = 0;
+    CK_RV rv = C_GetSlotList(true, NULL, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, TOKEN_COUNT);
+
+    CK_ULONG count2 = count - 1;
+    rv = C_GetSlotList(true, slots, &count2);
+    assert_int_equal(rv, CKR_BUFFER_TOO_SMALL);
+    assert_int_equal(count2, count);
+
+    rv = C_GetSlotList(true, slots, &count);
     assert_int_equal(rv, CKR_OK);
     assert_int_equal(count, TOKEN_COUNT);
 


### PR DESCRIPTION
When the size is too small, the count ptr should also be set
to the proper size per section 5.2 of:
  - http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959708

Fixes: #299

Signed-off-by: William Roberts <william.c.roberts@intel.com>