### PR TITLE
tpm: remove tpm hashing only use SW

### DIFF
--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -17,12 +17,9 @@
 
 typedef struct digest_op_data digest_op_data;
 struct digest_op_data {
-    bool use_sw_hash;
+    tobject *tobj;
     CK_MECHANISM_TYPE mechanism;
-    union {
-        uint32_t sequence_handle;
-        EVP_MD_CTX *mdctx;
-    };
+    EVP_MD_CTX *mdctx;
 };
 
 digest_op_data *digest_op_data_new(void);

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -115,10 +115,6 @@ CK_RV tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR 
  */
 CK_RV tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_TYPE mech, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG siglen);
 
-CK_RV tpm_hash_init(tpm_ctx *ctx, CK_MECHANISM_TYPE mode, uint32_t *sequence_handle);
-CK_RV tpm_hash_update(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG data_len);
-CK_RV tpm_hash_final(tpm_ctx *ctx, uint32_t sequence_handle, CK_BYTE_PTR data, CK_ULONG_PTR data_len);
-
 typedef struct tpm_encrypt_data tpm_encrypt_data;
 CK_RV tpm_encrypt_data_init(tpm_ctx *ctx, uint32_t handle, twist auth, CK_MECHANISM_PTR, tpm_encrypt_data **encdata);
 void tpm_encrypt_data_free(tpm_encrypt_data *encdata);


### PR DESCRIPTION
Since we don't use the tickets produced by the TPM and have no
fantastic way of exposing that feature, just do any required
hashing in SW.

Fixes: #307

Signed-off-by: William Roberts <william.c.roberts@intel.com>