### PR TITLE
tpm2_ptool: make --path optional work correctly

### DIFF
--- a/tools/tpm2_pkcs11/command.py
+++ b/tools/tpm2_pkcs11/command.py
@@ -5,9 +5,26 @@ import os
 class commandlet(object):
     '''Decorator class for commandlet. You can add commandlets to the tool with this decorator.'''
 
-    DEFAULT_STORE_PATH = os.path.join(
-        os.environ.get("HOME"),
-        ".tpm2_pkcs11") if os.environ.get("HOME") else os.getcwd()
+    @staticmethod
+    def get_default_store_path():
+
+        # always use the env variable no matter what
+        if "TPM2_PKCS11_STORE" in os.environ:
+            return os.environ.get("TPM2_PKCS11_STORE")
+
+        # look for a store in home
+        if "HOME" in os.environ:
+            store = os.path.join(os.environ.get("HOME"), ".tpm2_pkcs11")
+            if os.path.exists(store):
+                return store
+
+        # is their a system store and can I access it?
+        store = "/etc/tpm2_pkcs11"
+        if os.path.exists(store) and os.access(store, os.W_OK):
+            return store
+
+        # nothing else available, use cwd
+        return os.getcwd()
 
     _commandlets = {}
 
@@ -52,8 +69,13 @@ class commandlet(object):
                 g.add_argument(
                     '--path',
                     type=os.path.expanduser,
-                    help='The location of the store directory.',
-                    default=commandlet.DEFAULT_STORE_PATH)
+                    help='The location of the store directory. If not specified performs '
+                    +'a search by looking at environment variable TPM2_PKCS11_STORE '
+                    + 'and if not set then '
+                    + '$HOME/.tpm2_pkcs11 and if not found, then '
+                    + '/etc/tpm2_pkcs11 and if not found or no write access, then '
+                    + 'defaults to using the current working directory.',
+                    default=commandlet.get_default_store_path())
 
         args = opt_parser.parse_args()
 

--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -65,9 +65,7 @@ class InitCommand(Command):
         use_existing_primary = 'primary' in args and args['primary']
 
         path = args['path']
-        if not os.path.exists(path):
-            os.mkdir(path)
-        elif not os.path.isdir(path):
+        if not os.path.isdir(path):
             sys.exit("Specified path is not a directory, got: %s" % (path))
 
         ownerauth = args['owner_auth']


### PR DESCRIPTION
Mirror the C db code when searching for a store path by:
1. if set, just use the environment variable TPM2_PKCS11_STORE
2. if not set try:
  a. does $HOME/.tpm2_pkcs11 directory exist, if so use it.
  b. does /etc/tpm2_pkcs11 directory exist, if so use it.
  c. A final default of the current working directory.

Update the help output to reflect this.

Also do NOT automatically mkdir paths, as we don't want to willy nilly
create directories if they don't exist.

Signed-off-by: William Roberts <william.c.roberts@intel.com>