### PR TITLE
token: refactor and cache mechanism query

### DIFF
--- a/src/lib/digest.c
+++ b/src/lib/digest.c
@@ -37,7 +37,7 @@ void digest_op_data_free(digest_op_data **opdata) {
     *opdata = NULL;
 }
 
-const EVP_MD *ossl_halg_from_mech(CK_MECHANISM_TYPE mech) {
+static const EVP_MD *ossl_halg_from_mech(CK_MECHANISM_TYPE mech) {
 
     switch(mech) {
         case CKM_SHA_1:
@@ -63,6 +63,11 @@ const EVP_MD *ossl_halg_from_mech(CK_MECHANISM_TYPE mech) {
     }
     /* no return, not possible */
 }
+
+bool digest_is_supported(CK_MECHANISM_TYPE type) {
+    return ossl_halg_from_mech(type) != NULL;
+}
+
 
 static CK_RV digest_sw_init(digest_op_data *opdata) {
 

--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -22,6 +22,8 @@ struct digest_op_data {
     EVP_MD_CTX *mdctx;
 };
 
+bool digest_is_supported(CK_MECHANISM_TYPE type);
+
 digest_op_data *digest_op_data_new(void);
 void digest_op_data_free(digest_op_data **opdata);
 

--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -244,6 +244,8 @@ CK_RV general_init(void *init_args) {
      *
      * THESE MUST GO AFTER MUTEX INIT above!!
      */
+    tpm_init();
+
     rv = db_init();
     if (rv != CKR_OK) {
         goto err;
@@ -271,6 +273,8 @@ CK_RV general_finalize(void *reserved) {
 
     db_destroy();
     slot_destroy();
+
+    tpm_destroy();
 
     return CKR_OK;
 }

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -101,97 +101,28 @@ CK_RV slot_get_info (CK_SLOT_ID slot_id, CK_SLOT_INFO *info) {
 
 
 CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_list, CK_ULONG_PTR count) {
+
     token *t = slot_get_token(slot_id);
     if (!t) {
         return CKR_SLOT_ID_INVALID;
     }
 
-    CK_RV rv = tpm2_getmechanisms(t->tctx, mechanism_list, count);
-    return rv;
+    return token_get_mechanism_list(t, mechanism_list, count);
 }
 
 CK_RV slot_mechanism_info_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE type, CK_MECHANISM_INFO *info) {
 
     check_pointer(info);
 
-    if (!slot_get_token(slot_id)) {
+    token *t = slot_get_token(slot_id);
+    if (!t) {
         return CKR_SLOT_ID_INVALID;
     }
 
-    /* TODO pull these from TPM, currently they match the simulator */
-    CK_ULONG aes_min_keysize = 128/8; // in bytes
-    CK_ULONG aes_max_keysize = 256/8; // in bytes
-    CK_ULONG ecc_min_keysize = 256;
-    CK_ULONG ecc_max_keysize = 384;
-    CK_ULONG rsa_min_keysize = 1024;
-    CK_ULONG rsa_max_keysize = 2048;
-
-    switch(type) {
-    /* AES based crypto */
-    /* Todo: Check if HW or Software and support */
-    case CKM_AES_KEY_GEN:
-        info->ulMinKeySize = aes_min_keysize;
-        info->ulMaxKeySize = aes_max_keysize;
-        info->flags = CKF_GENERATE;
-        break;
-    case CKM_AES_CBC:
-    case CKM_AES_CFB1:
-    case CKM_AES_ECB:
-        info->ulMinKeySize = aes_min_keysize;
-        info->ulMaxKeySize = aes_max_keysize;
-        info->flags = 0;
-        break;
-
-    /* RSA based crypto */
-    case CKM_RSA_PKCS_KEY_PAIR_GEN:
-        info->ulMinKeySize = rsa_min_keysize;
-        info->ulMaxKeySize = rsa_max_keysize;
-        info->flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
-        break;
-    case CKM_RSA_PKCS:
-    case CKM_RSA_X_509:
-        info->ulMinKeySize = rsa_min_keysize;
-        info->ulMaxKeySize = rsa_max_keysize;
-        info->flags = CKF_HW | CKF_ENCRYPT | CKF_DECRYPT | CKF_SIGN | CKF_VERIFY;
-        break;
-    case CKM_RSA_PKCS_OAEP:
-        info->ulMinKeySize = rsa_min_keysize;
-        info->ulMaxKeySize = rsa_max_keysize;
-        info->flags = CKF_HW | CKF_ENCRYPT| CKF_DECRYPT;
-        break;
-    case CKM_SHA1_RSA_PKCS:
-    case CKM_SHA256_RSA_PKCS:
-    case CKM_SHA384_RSA_PKCS:
-    case CKM_SHA512_RSA_PKCS:
-        info->ulMinKeySize = rsa_min_keysize;
-        info->ulMaxKeySize = rsa_max_keysize;
-        info->flags = CKF_HW | CKF_SIGN | CKF_VERIFY;
-        break;
-
-    /* ECC based crypto */
-    /* TODO: Add ECC specific flags */
-    case CKM_EC_KEY_PAIR_GEN:
-        info->ulMinKeySize = ecc_min_keysize;
-        info->ulMaxKeySize = ecc_max_keysize;
-        info->flags = CKF_HW | CKF_GENERATE_KEY_PAIR;
-        break;
-    case CKM_ECDSA:
-    case CKM_ECDSA_SHA1:
-        info->ulMinKeySize = ecc_min_keysize;
-        info->ulMaxKeySize = ecc_max_keysize;
-        info->flags = CKF_HW | CKF_SIGN | CKF_VERIFY;
-        break;
-
-    /* Hashes */
-    case CKM_SHA_1:
-    case CKM_SHA256:
-        info->ulMinKeySize = 0;
-        info->ulMaxKeySize = 0;
-        info->flags = CKF_HW | CKF_DIGEST;
-        break;
-
-    default:
-        return CKR_MECHANISM_INVALID;
+    /* tpm builds and maintains cache */
+    CK_RV rv = tpm_get_mech_info(t->tctx, type, info);
+    if (rv != CKR_OK) {
+        return rv;
     }
 
     return CKR_OK;

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -412,3 +412,36 @@ CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj)
     // Found no match on key id
     return CKR_KEY_HANDLE_INVALID;
 }
+
+CK_RV token_get_mechanism_list(token *t, CK_MECHANISM_TYPE_PTR mechanism_list, CK_ULONG_PTR count) {
+
+    check_pointer(count);
+
+    /* build a cache of mechanisms */
+    static bool is_mech_list_initialized = false;
+    static CK_MECHANISM_TYPE mech_list_cache[64];
+    static CK_ULONG mech_cache_len = ARRAY_LEN(mech_list_cache);
+    if (!is_mech_list_initialized) {
+        CK_RV rv = tpm2_getmechanisms(t->tctx, mech_list_cache, &mech_cache_len);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+        is_mech_list_initialized = true;
+    }
+
+    if (mechanism_list) {
+
+        if (*count < mech_cache_len) {
+            *count = mech_cache_len;
+            return CKR_BUFFER_TOO_SMALL;
+        }
+
+        memcpy(mechanism_list, mech_list_cache,
+                ARRAY_BYTES(mech_cache_len, mech_list_cache));
+    }
+
+    *count = mech_cache_len;
+
+    return CKR_OK;
+
+}

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -112,4 +112,17 @@ void token_unlock(token *t);
  */
 CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 
+/**
+ * Retrieves the supported mechanism list for the token.
+ * @param t
+ *  The token to query.
+ * @param mechanism_list
+ *  The mechanism list to populate.
+ * @param count
+ *  The length of the mechanism_list, which is set to the actual length on return.
+ * @return
+ *  CKR_* status codes.
+ */
+CK_RV token_get_mechanism_list(token *t, CK_MECHANISM_TYPE_PTR mechanism_list, CK_ULONG_PTR count);
+
 #endif /* SRC_TOKEN_H_ */

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -54,6 +54,8 @@ CK_RV tpm_ctx_new(const char *tcti, tpm_ctx **tctx);
  */
 CK_RV tpm_get_token_info (tpm_ctx *ctx, CK_TOKEN_INFO *info);
 
+CK_RV tpm_get_mech_info(tpm_ctx *ctx, CK_MECHANISM_TYPE t, CK_MECHANISM_INFO_PTR info);
+
 /**
  * Generates random bytes from the TPM
  * @param ctx
@@ -182,5 +184,9 @@ CK_RV tpm2_generate_key(
         tpm_object_data *objdata);
 
 CK_RV tpm2_getmechanisms(tpm_ctx *ctx, CK_MECHANISM_TYPE *mechanism_list, CK_ULONG_PTR count);
+
+void tpm_init(void);
+
+void tpm_destroy(void);
 
 #endif /* SRC_PKCS11_TPM_H_ */

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -20,6 +20,7 @@
 #define str(s) #s
 
 #define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+#define ARRAY_BYTES(l, t) (l * sizeof(t[0]))
 
 #define UNUSED(x) (void)x
 


### PR DESCRIPTION
Various code paths ask the tpm for a list of supported mechanisms. Going
to the TPM is slow, and this information never changes. Cache the
results so we only pay for the slowness once and refactor the code paths
so it calls into the cache layer.

This also updates all the callers to ask the TPM for supported
algorithms and keysizes rather than keeping lists hardcoded to
the simualtor.

Fixes: #310

Signed-off-by: William Roberts <william.c.roberts@intel.com>