### PR TITLE
test: use relative path to determine location of libtpm2_pkcs11

### DIFF
--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -142,7 +142,7 @@ echo "Adding 1 x509 Certificate under token \"label\""
 #
 # Build an OpenSSL config file
 #
-modpath=$(echo /workspace/tpm2-pkcs11/*/src/.libs/libtpm2_pkcs11.so)
+modpath="$PWD/src/.libs/libtpm2_pkcs11.so"
 osslconf="$TPM2_PKCS11_STORE/ossl.cnf"
 cat << EOF > "$osslconf"
 openssl_conf = openssl_init


### PR DESCRIPTION
Running the integration test outside Travis CI fails because `create_pkcs_store.sh` relies on a hardcoded `/workspace` build directory. Specify locations relative to the current build directory `$PWD` instead to make the tests portable.