### PR TITLE
build: replace netstat by ss, add -O2 and use AX_ADD_FORTIFY_SOURCE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,8 +257,8 @@ AS_IF([test x"$enable_hardening" != xno], [
   add_hardened_c_flag([-fstack-protector-all])
   add_hardened_c_flag([-Wstrict-overflow=5])
 
-  add_hardened_define_flag([-U_FORTIFY_SOURCE])
-  add_hardened_define_flag([-D_FORTIFY_SOURCE=2])
+  add_hardened_c_flag([-O2])
+  AX_ADD_FORTIFY_SOURCE
 
   add_hardened_c_flag([-fPIC])
   add_hardened_ld_flag([[-shared]])

--- a/configure.ac
+++ b/configure.ac
@@ -130,9 +130,9 @@ AC_DEFUN([integration_test_checks], [
   AS_IF([test "x$tpm_server" != "xyes"],
     [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])
 
-  AC_CHECK_PROG([netstat], [netstat], [yes], [no])
-    AS_IF([test "x$netstat" != "xyes"],
-      [AC_MSG_ERROR([Integration tests enabled but netstat executable not found.])])
+  AC_CHECK_PROG([ss], [ss], [yes], [no])
+    AS_IF([test "x$ss" != "xyes"],
+      [AC_MSG_ERROR([Integration tests enabled but ss executable not found.])])
 
   AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])
 ]) # end function integration_test_checks

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -28,7 +28,7 @@ in known package managers are likely too old.
 ### Optional Dependencies for Enabling Testing
 1. [CMocka](https://cmocka.org/)
 2. [TPM2.0 Simulator v194](https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm974.tar.gz/download): **Tested with version 974**
-3. [netstat](https://sourceforge.net/projects/net-tools/)
+3. [ss](https://wiki.linuxfoundation.org/networking/iproute2)
 4. [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd)
 
 ## Step 2 - Bootstrapping
@@ -56,12 +56,12 @@ that *are outside of normal autoconf/automake options*, which are documented [he
   * Requires the following items to be found on PATH:
     * [tpm2-ptool](../tools/tpm2_ptool.py)
     * [tpm2-tools](#step-1---satisfy-dependencies)
-    * [netstat](#step-1---satisfy-dependencies)
+    * [ss](#step-1---satisfy-dependencies)
   * Example:
     ```sh
     export PATH="/home/wcrobert/workspace/tpm2-tools/tools:/home/wcrobert/workspace/tpm2-pkcs11/tools:$HOME/workspace/ibmtpm974/src:$PATH"
     ```
-    **Normally** only tpm2-tools, IBM TPM Simulator and tpm2-ptool need to be added to `PATH`. Most other things, like CMocka and netstat, are already
+    **Normally** only tpm2-tools, IBM TPM Simulator and tpm2-ptool need to be added to `PATH`. Most other things, like CMocka and ss, are already
     installed and thus on `PATH`. Your results will very based on what you build from source and/or install in non-standard locations.
 3. `--disable-dlclose` - Works around a [dlclose(3)](https://linux.die.net/man/3/dlclose) issue as documented in this
     [commit](https://github.com/tpm2-software/tpm2-tools/commit/130582559d7c51d18e3ce82803c30bc161d9c34d).

--- a/test/integration/scripts/int-test-setup.sh
+++ b/test/integration/scripts/int-test-setup.sh
@@ -143,9 +143,9 @@ in
             sleep 1 # give daemon time to bind to ports
             PID=$(cat ${SIM_PID_FILE})
             echo "simulator PID: ${PID}";
-            netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
+            ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
             ret_data=$?
-            netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
+            ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
             ret_cmd=$?
             if [ \( $ret_data -eq 0 \) -a \( $ret_cmd -eq 0 \) ]; then
                 echo "Simulator with PID ${PID} bound to port ${SIM_PORT_DATA} and " \


### PR DESCRIPTION
Propagate two changes to the build system already implemented in other tpm2-software projects:

- [Replace `netstat` by `ss`](https://github.com/tpm2-software/tpm2-tss/pull/1234) since the former is deprecated.
- [Add `-O2` required for fortification and use `AX_ADD_FORTIFY_SOURCE`](https://github.com/tpm2-software/tpm2-tools/pull/1590).