### PR TITLE
pkcs11-tool: fix CKA_VALUE request for aes key

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -264,7 +264,12 @@ class NewKeyCommandBase(Command):
                 CKA_CLASS: CKO_SECRET_KEY
             }, {
                 CKA_KEY_TYPE: CKK_AES
-            }, {
+            },
+            # placate pkcs11 tool asking for CKA_VALUE
+            {
+                CKA_VALUE: ""
+            },
+            {
                 CKA_VALUE_LEN: y['sym-keybits'] / 8
             },
             {


### PR DESCRIPTION
pkcs11-tool requests CKA_VALUE for secret objects. Since this is a
common tool and client, just placate it with an empty CKA_VALUE field.

Example:
pkcs11-tool --module /home/wcrobert/workspace/tpm2-pkcs11/src/.libs/libtpm2_pkcs11.so --login --label label --list-objects

Fixes Error:
Secret Key Object; AES
warning: PKCS11 function C_GetAttributeValue(VALUE) failed: rv = CKR_ATTRIBUTE_TYPE_INVALID (0x12)

  label:      3
  ID:         31363634663637356533646332376632
  Usage:      encrypt, decrypt

Fixes: #326

Signed-off-by: William Roberts <william.c.roberts@intel.com>