### PR TITLE
attributes: add CKA_SENSITIVE

### DIFF
--- a/src/lib/attrs.c
+++ b/src/lib/attrs.c
@@ -686,6 +686,10 @@ static CK_RV attr_common_add_privatekey(attr_list **private_attrs) {
     bool r = attr_list_add_bool(new_attrs, CKA_SIGN_RECOVER, CK_FALSE);
     goto_error_false(r);
 
+    r = attr_list_add_bool(new_attrs, CKA_SENSITIVE, CK_FALSE);
+    goto_error_false(r);
+
+
     r = attr_list_add_bool(new_attrs, CKA_UNWRAP, CK_FALSE);
     goto_error_false(r);
 

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -400,6 +400,8 @@ CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
            /* If it's not found it defaults to empty. */
            t->pValue = NULL;
            t->ulValueLen = CK_UNAVAILABLE_INFORMATION;
+           LOGV("Invalid Attribute for tid %lu: type(%lu) ulValueLen(%lu), pData(%s)",
+                   tobj->id, t->type, t->ulValueLen, t->pValue ? "non-null" : "null");
            rv = CKR_ATTRIBUTE_TYPE_INVALID;
        }
     }

--- a/tools/tpm2_pkcs11/objects.py
+++ b/tools/tpm2_pkcs11/objects.py
@@ -187,6 +187,7 @@ class PKCS11PrivateKey(PKCS11Key):
     def __init__(self, objtype, attrs, auth=None, tpm_priv=None, tpm_pub=None):
 
         add = {
+            CKA_SENSITIVE: True,
             CKA_SUBJECT: attrs[CKA_SUBJECT] if CKA_SUBJECT in attrs else '',
             CKA_DECRYPT: attrs[CKA_DECRYPT],
             CKA_SIGN: attrs[CKA_SIGN],


### PR DESCRIPTION
Refactoring the attribute handling resulted in the loss of CKA_SENSITIVE
attribute. Correct this by adding it in for all PKCS11 Private Keys as
well as PKCS11 Secret Keys.

Fixes: #347

Signed-off-by: William Roberts <william.c.roberts@intel.com>