### PR TITLE
general: fix and unify parse_lib_version()

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -35,7 +35,7 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
     char buf[] = PACKAGE_VERSION;
 
     char *minor_str = "0";
-    char *major_str = &buf[0];
+    const char *major_str = &buf[0];
 
     char *split = strchr(buf, '.');
     if (split) {
@@ -43,7 +43,7 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
         minor_str = split + 1;
     }
 
-    if (!major_str || !major_str[0] || !minor_str[0]) {
+    if (!major_str[0] || !minor_str[0]) {
         *major = *minor = 0;
         return;
     }
@@ -52,24 +52,22 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
     unsigned long val;
     errno = 0;
     val = strtoul(major_str, &endptr, 10);
-    if (errno != 0 || endptr[0]) {
+    if (errno != 0 || endptr[0] || val > UINT8_MAX) {
         LOGW("Could not strtoul(%s): %s", major_str, strerror(errno));
         *major = *minor = 0;
         return;
     }
 
-    assert(val > UINT8_MAX);
     *major = val;
 
     endptr = NULL;
     val = strtoul(minor_str, &endptr, 10);
-    if (errno != 0 || endptr[0]) {
+    if (errno != 0 || endptr[0] || val > UINT8_MAX) {
         LOGW("Could not strtoul(%s): %s", minor_str, strerror(errno));
         *major = *minor = 0;
         return;
     }
 
-    assert(val > UINT8_MAX);
     *minor = val;
 }
 

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -122,18 +122,16 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
 
     char buf[] = PACKAGE_VERSION;
 
-    char *minor_str = NULL;
-    char *major_str = &buf[0];
+    char *minor_str = "0";
+    const char *major_str = &buf[0];
 
     char *split = strchr(buf, '.');
     if (split) {
         split[0] = '\0';
         minor_str = split + 1;
-    } else {
-        minor_str = "0";
     }
 
-    if (!major_str || !major_str[0] || !minor_str[0]) {
+    if (!major_str[0] || !minor_str[0]) {
         *major = *minor = 0;
         return;
     }


### PR DESCRIPTION
The previous commit 4313073a420c40fb99de4c0c078febd8627e2901 exposed some problems of the [`parse_lib_version`](https://github.com/tpm2-software/tpm2-pkcs11/blob/4313073a420c40fb99de4c0c078febd8627e2901/src/lib/general.c#L33) function because its short commit id, which is [used as the `PACKAGE_VERSION`](https://github.com/tpm2-software/tpm2-pkcs11/blob/4313073a420c40fb99de4c0c078febd8627e2901/configure.ac#L29), is a decimal number > `UINT8_MAX`. This results in a [failing integration test](https://travis-ci.org/tpm2-software/tpm2-pkcs11/jobs/623306231#L2829) due to a [wrong comparison operator](https://github.com/tpm2-software/tpm2-pkcs11/blob/4313073a420c40fb99de4c0c078febd8627e2901/src/lib/general.c#L61) in the assertions, which should be `<=` instead of `>`.

Unify the code of `parse_lib_version` in [`general.c`](https://github.com/tpm2-software/tpm2-pkcs11/blob/4313073a420c40fb99de4c0c078febd8627e2901/src/lib/general.c#L33) and [`pkcs-misc.int.c`](https://github.com/tpm2-software/tpm2-pkcs11/blob/4313073a420c40fb99de4c0c078febd8627e2901/test/integration/pkcs-misc.int.c#L121) and simplify it a bit (no need for a null pointer check for the constant `major_str` pointer).