### PR TITLE
tpm2_ptool: fix py3 error with init

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -83,7 +83,7 @@ class InitCommand(Command):
 
                     if not use_existing_primary:
                         pobjauth = pobjauth if pobjauth != None else rand_hex_str(
-                        )
+                        ).decode('ascii')
                         ctx = tpm2.createprimary(ownerauth, pobjauth)
                         tr_handle = tpm2.evictcontrol(ownerauth, ctx)
                         shall_evict = True


### PR DESCRIPTION
Pass auto-generated primary authentication values as strings, so the
subsequent call to tpm2_createprimary receives the correct option value.
Otherwise, Python 3 would pass the string representation of a bytes()
object that tpm2_createprimary cannot handle.

Fixes: #361

Signed-off-by: Daniel Kobras <kobras@puzzle-itc.de>