### PR TITLE
ci: install curl and json-c for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,6 +4,8 @@ extraction:
     prepare:
       packages:
       - autoconf-archive
+      - libcurl4-openssl-dev
+      - libjson-c-dev
       - libssl-dev
     after_prepare:
     - cd "$LGTM_WORKSPACE"


### PR DESCRIPTION
tpm2-tss now needs curl and json-c to build, see https://github.com/tpm2-software/tpm2-tools/pull/1877.