### PR TITLE
 build: add necessary files for integration tests to distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -163,6 +163,12 @@ test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-
 endif
 # END INTEGRATION
 
+EXTRA_DIST += \
+    test/integration/pkcs11-tool.sh \
+    test/integration/tls-tests.sh \
+    test/integration/test.h \
+    test/integration/fixtures
+
 ### Unit Tests ###
 if UNIT
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AC_INIT([tpm2-pkcs11],
 
 AC_CONFIG_MACRO_DIR([m4])
 
+# propagate configure arguments to distcheck
+AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
+
 AX_IS_RELEASE([dash-version])
 AX_CHECK_ENABLE_DEBUG([info])
 

--- a/test/integration/scripts/int-test-setup.sh
+++ b/test/integration/scripts/int-test-setup.sh
@@ -105,9 +105,8 @@ in
         TABRMD_OPTS="--session"
         TABRMD_TEST_TCTI_CONF="bus_type=session"
         # start an instance of the simulator for the test, have it use a random port
-        SIM_LOG_FILE=${TEST_BIN}_simulator.log
-        SIM_PID_FILE=${TEST_BIN}_simulator.pid
-#        SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm_server_XXXXXX)
+        SIM_LOG_FILE="$SIM_TMP_DIR/simulator.log"
+        SIM_PID_FILE="$SIM_TMP_DIR/simulator.pid"
         BACKOFF_FACTOR=2
         BACKOFF=1
         for i in $(seq 10); do
@@ -163,8 +162,8 @@ in
 esac
 
 # start tpm2-abrmd daemon
-TABRMD_LOG_FILE=${TEST_BIN}_tabrmd.log
-TABRMD_PID_FILE=${TEST_BIN}_tabrmd.pid
+TABRMD_LOG_FILE="$SIM_TMP_DIR/tabrmd.log"
+TABRMD_PID_FILE="$SIM_TMP_DIR/tabrmd.pid"
 tabrmd_start ${TABRMD_BIN} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE} "${TABRMD_OPTS}"
 if [ $? -ne 0 ]; then
     echo "failed to start tabrmd with name ${TABRMD_NAME}"

--- a/test/integration/tls-tests.sh
+++ b/test/integration/tls-tests.sh
@@ -24,7 +24,8 @@ function cleanup() {
   if [ "$1" != "no-kill" ]; then
       pkill -P $$ || true
   fi
-  rm -f index.txt index.txt.attr serial
+  rm -f index.txt index.txt.attr serial serial.old index.txt.old index.txt.attr.old \
+        02.pem client.csr client.crt client_tpm.pem
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Add files necessary to run integration tests from a tarball created by `make dist`, and setup running `make distcheck` with tests enabled to catch such issues in the CI.