### PR TITLE
db: fix sqlite3 unrecognized hex scalar token

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -1565,9 +1565,9 @@ CK_RV db_setup(sqlite3 *db, const char *path) {
         "BEFORE INSERT ON tobjects\n"
         "BEGIN\n"
         "    SELECT CASE WHEN\n"
-        "        (SELECT COUNT (*) FROM tobjects) >= 0x00FFFFFF\n"
+        "        (SELECT COUNT (*) FROM tobjects) >= 16777215\n"
         "    THEN\n"
-        "        RAISE(FAIL, \"Maximum object count of 0x00FFFFFF reached.\")\n"
+        "        RAISE(FAIL, \"Maximum object count of 16777215 reached.\")\n"
         "    END;\n"
         "END;\n"
     };

--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -396,9 +396,9 @@ class Db(object):
                 BEFORE INSERT ON tobjects
                 BEGIN
                     SELECT CASE WHEN
-                        (SELECT COUNT (*) FROM tobjects) >= 0x00FFFFFF
+                        (SELECT COUNT (*) FROM tobjects) >= 16777215
                     THEN
-                        RAISE(FAIL, "Maximum object count of 0xFFFFFFFF reached.")
+                        RAISE(FAIL, "Maximum object count of 16777215 reached.")
                     END;
                 END;
             '''),


### PR DESCRIPTION
Fixes errors like:
ERROR: unrecognized token: "0x00FFFFFF"

Fixes: #379

Signed-off-by: William Roberts <william.c.roberts@intel.com>