### PR TITLE
C_CreateObject: minimal RSA Java support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ nbproject/
 build/
 m4/*
 !m4/ld-version-script.m4
+
+# Java class files
+*.class

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,8 @@ AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(TSS2_ESYS_LIBS) \
                   $(TSS2_MU_LIBS) $(TSS2_TCTILDR_LIBS) $(TSS2_RC_LIBS) \
 		  $(SQLITE3_LIBS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(YAML_LIBS)
 
+JAVAROOT=$(top_builddir)/test/integration
+
 # ax_code_coverage
 if AUTOCONF_CODE_COVERAGE_2019_01_06
 include $(top_srcdir)/aminclude_static.am
@@ -73,6 +75,7 @@ AM_TESTS_ENVIRONMENT = \
     TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures \
     PATH=$(abs_top_srcdir)/tools:./src:$(PATH) \
     PYTHONPATH=$(abs_top_srcdir)/tools \
+    TEST_JAVA_ROOT=$(JAVAROOT) \
     dbus-run-session
 
 TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(p11lib_LTLIBRARIES) $(AM_LDFLAGS) $(CMOCKA_LIBS) $(CRYPTO_LIBS)
@@ -83,7 +86,7 @@ TESTS_CFLAGS = $(CMOCKA_CFLAGS)
 check_PROGRAMS =
 check_SCRIPTS =
 
-TEST_EXTENSIONS = .sh .int
+TEST_EXTENSIONS = .sh .int .nosetup .java
 
 ### Integration Tests ###
 if ENABLE_INTEGRATION
@@ -165,6 +168,14 @@ test_integration_pkcs_keygen_int_SOURCES = test/integration/pkcs-keygen.int.c te
 test_integration_pkcs_session_state_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_session_state_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
 test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-state.c test/integration/test.c
+
+#
+# Java Tests
+#
+check_SCRIPTS+=test/integration/pkcs11-javarunner.sh.java
+AM_JAVA_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
+JAVA_LOG_COMPILER=$(LOG_COMPILER)
+dist_noinst_JAVA = test/integration/PKCS11JavaTests.java
 
 endif
 # END INTEGRATION

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -24,6 +24,9 @@ Step one is to satisfy the following dependencies:
   - pkcs11-tool (optional for testing)
   - openssl (optional for testing)
   - libp11 (optional for testing)
+  - java (optional for testing)
+  - junit (optional for testing)
+  - hamcrest (optional for testing)
 
 After satisfying the dependencies one invoke the regular autotools build process:
 ```bash

--- a/src/lib/attrs.c
+++ b/src/lib/attrs.c
@@ -565,7 +565,7 @@ error:
     return rv;
 }
 
-static CK_RV attr_common_add_RSA_publickey(attr_list **public_attrs) {
+CK_RV attr_common_add_RSA_publickey(attr_list **public_attrs) {
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
@@ -762,7 +762,7 @@ static CK_RV attr_common_add_EC_privatekey(attr_list **private_attrs) {
     return attr_common_add_privatekey(private_attrs);
 }
 
-static CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs) {
+CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs) {
 
     /* XXX These are hardcoded for now */
     CK_MECHANISM_TYPE t[] = {
@@ -776,13 +776,17 @@ static CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs) 
         CKM_RSA_PKCS_PSS
     };
 
-    bool r = attr_list_add_buf(new_pub_attrs, CKA_ALLOWED_MECHANISMS,
-            (CK_BYTE_PTR)&t, sizeof(t));
-    goto_error_false(r);
+    if (new_pub_attrs) {
+        bool r = attr_list_add_buf(new_pub_attrs, CKA_ALLOWED_MECHANISMS,
+                (CK_BYTE_PTR)&t, sizeof(t));
+        goto_error_false(r);
+    }
 
-    r = attr_list_add_buf(new_priv_attrs, CKA_ALLOWED_MECHANISMS,
+    if (new_priv_attrs) {
+        bool r = attr_list_add_buf(new_priv_attrs, CKA_ALLOWED_MECHANISMS,
             (CK_BYTE_PTR)&t, sizeof(t));
-    goto_error_false(r);
+        goto_error_false(r);
+    }
 
     return CKR_OK;
 
@@ -1114,3 +1118,4 @@ error:
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_ULONG);
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_BBOOL);
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_OBJECT_CLASS);
+UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_KEY_TYPE);

--- a/src/lib/attrs.h
+++ b/src/lib/attrs.h
@@ -234,6 +234,8 @@ CK_RV attr_CK_ULONG(CK_ATTRIBUTE_PTR attr, CK_ULONG *x);
  */
 CK_RV attr_CK_OBJECT_CLASS(CK_ATTRIBUTE_PTR attr, CK_OBJECT_CLASS *x);
 
+CK_RV attr_CK_KEY_TYPE(CK_ATTRIBUTE_PTR attr, CK_KEY_TYPE *x);
+
 /**
  * Searches an attr_list for an attribute specified by type.
  * @param haystack
@@ -258,5 +260,9 @@ CK_ATTRIBUTE_PTR attr_get_attribute_by_type(attr_list *haystack, CK_ATTRIBUTE_TY
  */
 CK_ATTRIBUTE_PTR attr_get_attribute_by_type_raw(CK_ATTRIBUTE_PTR haystack, CK_ULONG haystack_count,
         CK_ATTRIBUTE_TYPE needle);
+
+CK_RV attr_common_add_RSA_publickey(attr_list **public_attrs);
+
+CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs);
 
 #endif /* SRC_LIB_ATTRS_H_ */

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -10,9 +10,18 @@
 
 typedef struct token token;
 
+typedef struct sw_encrypt_data sw_encrypt_data;
 typedef struct encrypt_op_data encrypt_op_data;
-struct encrypt_op_data {
+
+typedef union crypto_op_data crypto_op_data;
+union crypto_op_data{
     tpm_encrypt_data *tpm_enc_data;
+    sw_encrypt_data *sw_enc_data;
+};
+
+struct encrypt_op_data {
+    bool use_sw;
+    crypto_op_data cryptopdata;
 };
 
 encrypt_op_data *encrypt_op_data_new(void);

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -143,4 +143,7 @@ CK_RV tobject_user_increment(tobject *tobj);
 
 CK_RV object_destroy(session_ctx *ctx, CK_OBJECT_HANDLE object);
 
+
+CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *object);
+
 #endif /* SRC_PKCS11_OBJECT_H_ */

--- a/src/lib/openssl_compat.c
+++ b/src/lib/openssl_compat.c
@@ -4,9 +4,6 @@
 
 #include "openssl_compat.h"
 
-#ifndef SRC_LIB_OPENSSL_COMPAT_C_
-#define SRC_LIB_OPENSSL_COMPAT_C_
-
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
 
 /*
@@ -62,5 +59,28 @@ const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x) {
     return ASN1_STRING_data((ASN1_STRING *)x);
 }
 
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d) {
+
+    if ((r->n == NULL && n == NULL) || (r->e == NULL && e == NULL)) {
+        return 0;
+    }
+
+    if (n != NULL) {
+        BN_free(r->n);
+        r->n = n;
+    }
+
+    if (e != NULL) {
+        BN_free(r->e);
+        r->e = e;
+    }
+
+    if (d != NULL) {
+        BN_free(r->d);
+        r->d = d;
+    }
+
+    return 1;
+}
+
 #endif
-#endif /* SRC_LIB_OPENSSL_COMPAT_C_ */

--- a/src/lib/openssl_compat.h
+++ b/src/lib/openssl_compat.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 #include <openssl/bn.h>
 #include <openssl/ec.h>
+#include <openssl/rsa.h>
 
 #ifndef SRC_LIB_OPENSSL_COMPAT_H_
 #define SRC_LIB_OPENSSL_COMPAT_H_
@@ -16,6 +17,8 @@ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
                           unsigned char **pbuf, BN_CTX *ctx);
 
 const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 
 #endif
 

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -564,8 +564,11 @@ CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj)
             return CKR_KEY_HANDLE_INVALID;
         }
 
-        // Already loaded, ignored.
-        if (tobj->handle) {
+        /*
+         * The object may already be loaded by the TPM or may just be
+         * a public key object not-resident in the TPM.
+         */
+        if (tobj->handle || !tobj->pub) {
             *loaded_tobj = tobj;
             return CKR_OK;
         }

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -26,6 +26,7 @@
 #include "attrs.h"
 #include "checks.h"
 #include "digest.h"
+#include "encrypt.h"
 #include "openssl_compat.h"
 #include "pkcs11.h"
 #include "log.h"
@@ -1828,9 +1829,11 @@ out:
 #define ENCRYPT 0
 #define DECRYPT 1
 
-CK_RV tpm_encrypt(tpm_encrypt_data *tpm_enc_data,
+CK_RV tpm_encrypt(crypto_op_data *opdata,
         CK_BYTE_PTR ptext, CK_ULONG ptextlen,
         CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen) {
+
+    tpm_encrypt_data *tpm_enc_data = opdata->tpm_enc_data;
 
     if (tpm_enc_data->is_rsa) {
         return tpm_rsa_encrypt(tpm_enc_data, ptext, ptextlen, ctext, ctextlen);
@@ -1847,9 +1850,11 @@ CK_RV tpm_encrypt(tpm_encrypt_data *tpm_enc_data,
             iv, ptext, ptextlen, ctext, ctextlen);
 }
 
-CK_RV tpm_decrypt(tpm_encrypt_data *tpm_enc_data,
+CK_RV tpm_decrypt(crypto_op_data *opdata,
         CK_BYTE_PTR ctext, CK_ULONG ctextlen,
         CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen) {
+
+    tpm_encrypt_data *tpm_enc_data = opdata->tpm_enc_data;
 
     if (tpm_enc_data->is_rsa) {
         return tpm_rsa_decrypt(tpm_enc_data, ctext, ctextlen, ptext, ptextlen);

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -124,9 +124,12 @@ typedef struct tpm_encrypt_data tpm_encrypt_data;
 CK_RV tpm_encrypt_data_init(tpm_ctx *ctx, uint32_t handle, twist auth, CK_MECHANISM_PTR, tpm_encrypt_data **encdata);
 void tpm_encrypt_data_free(tpm_encrypt_data *encdata);
 
-CK_RV tpm_encrypt(tpm_encrypt_data *tpm_enc_data, CK_BYTE_PTR ptext, CK_ULONG ptextlen, CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen);
+/* forward reference */
+typedef union crypto_op_data crypto_op_data;
 
-CK_RV tpm_decrypt(tpm_encrypt_data *tpm_enc_data, CK_BYTE_PTR ctext, CK_ULONG ctextlen, CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen);
+CK_RV tpm_encrypt(crypto_op_data *opdata, CK_BYTE_PTR ptext, CK_ULONG ptextlen, CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen);
+
+CK_RV tpm_decrypt(crypto_op_data *opdata, CK_BYTE_PTR ctext, CK_ULONG ctextlen, CK_BYTE_PTR ptext, CK_ULONG_PTR ptextlen);
 
 bool tpm_register_handle(tpm_ctx *ctx, uint32_t *handle);
 

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -456,7 +456,7 @@ CK_RV C_Logout (CK_SESSION_HANDLE session) {
 }
 
 CK_RV C_CreateObject (CK_SESSION_HANDLE session, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *object) {
-    TOKEN_UNSUPPORTED;
+    TOKEN_WITH_LOCK_BY_SESSION_PUB_RO(object_create, session, templ, count, object);
 }
 
 CK_RV C_CopyObject (CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *new_object) {

--- a/test/integration/PKCS11JavaTests.java
+++ b/test/integration/PKCS11JavaTests.java
@@ -1,0 +1,98 @@
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.crypto.Cipher;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+public class PKCS11JavaTests {
+
+    static final String PIN = "myuserpin";
+    static final String KEY_ALIAS = "rsa1";
+	
+    static KeyStore KEY_STORE;
+    static Provider PROV;
+    
+    @BeforeClass
+    public static void beforeAllTestMethods() throws Exception {
+    	/*
+    	 * Generate a new provider to use the SUNPKCS11 module
+    	 * 
+    	 */
+    	String cwd = System.getProperty("user.dir");
+    	Path libPath = Paths.get(cwd, "src/.libs/libtpm2_pkcs11.so.0.0.0");
+    	String pkcs11Config = "name = TPM2\nlibrary = " + libPath;
+        ByteArrayInputStream confStream = new ByteArrayInputStream(pkcs11Config.getBytes());
+        PROV = new sun.security.pkcs11.SunPKCS11(confStream);
+
+        /* add the provider */
+        Security.addProvider(PROV);
+        
+        /* Generate a keystore from the provider */
+        KEY_STORE = KeyStore.getInstance("PKCS11-TPM2");
+        KeyStore.PasswordProtection pp = new KeyStore.PasswordProtection(PIN.toCharArray());
+        KEY_STORE.load(null, pp.getPassword());
+    }
+    
+    @Test
+    public void test_rsa_crypto() throws Exception {
+
+        /* Get the key/cert pair */
+        Key rsaKey = KEY_STORE.getKey(KEY_ALIAS, null);
+        Assert.assertEquals("RSA", rsaKey.getAlgorithm());
+
+        X509Certificate certificate = (X509Certificate) KEY_STORE.getCertificate(KEY_ALIAS);
+        
+        /* get the public key from the cert */
+        Key rsaPublicKey = certificate.getPublicKey();
+
+        /* Encrypt public decrypt private */
+        Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding", PROV);
+
+        String plaintext = "mysecretdata";
+        
+        byte[] plainData = plaintext.getBytes("UTF-8");
+       
+    	cipher.init(Cipher.ENCRYPT_MODE, rsaPublicKey);
+    	byte[] encryptedData = cipher.doFinal(plainData);
+
+        cipher.init(Cipher.DECRYPT_MODE, rsaKey);
+        int output = cipher.getOutputSize(encryptedData.length);
+        byte[] decryptedData = cipher.doFinal(encryptedData);
+
+        String decrypted = new String(decryptedData, output - plainData.length, plainData.length);
+        
+        Assert.assertEquals(plaintext, decrypted);
+    }	
+	
+	public static void main(String [] args) {
+		int rc = 1;
+		Result result = JUnitCore.runClasses(PKCS11JavaTests.class);
+		if (result.wasSuccessful()) {
+			rc = 0;
+	    	System.out.println("Success");
+	    } else {
+	    	System.out.println("Failed");
+	    }	
+
+		for (Failure failure : result.getFailures()) {
+	        System.out.println(failure.toString());
+	    }
+
+		System.exit(rc);
+	}
+}

--- a/test/integration/pkcs11-javarunner.sh.java
+++ b/test/integration/pkcs11-javarunner.sh.java
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -e
+
+if [ "$ASAN_ENABLED" = "true" ]; then
+  # Skip this test when ASAN is enabled
+  exit 77
+fi
+
+export CLASSPATH="$CLASSPATH:$TEST_JAVA_ROOT"
+
+echo "CLASSPATH=$CLASSPATH"
+
+#dont use -cp here, it causes env CLASSPATH not to be used
+java PKCS11JavaTests
+
+exit 0

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -134,7 +134,7 @@ echo "Added RSA Keys"
 
 echo "Adding 2 EC p256 keys under token \"label\""
 for i in `seq 0 1`; do
-  tpm2_ptool addkey --algorithm=ecc256 --label="label" --key-label=$i --userpin=myuserpin --path=$TPM2_PKCS11_STORE
+  tpm2_ptool addkey --algorithm=ecc256 --label="label" --key-label="ec$i" --userpin=myuserpin --path=$TPM2_PKCS11_STORE
 done;
 echo "Added EC Keys"
 
@@ -184,14 +184,21 @@ cert="$TPM2_PKCS11_STORE/cert.pem"
 # often silly and leak.
 setup_asan
 TPM2_PKCS11_STORE="$TPM2_PKCS11_STORE" openssl \
-    req -new -x509 -days 365 -subj '/CN=my key/' -sha256 -engine pkcs11 -keyform engine -key slot_1-label_1 -out "$cert"
+    req -new -x509 -days 365 -subj '/CN=my key/' -sha256 -engine pkcs11 -keyform engine -key slot_1-label_ec1 -out "$cert.ec1"
+
+TPM2_PKCS11_STORE="$TPM2_PKCS11_STORE" openssl \
+    req -new -x509 -days 365 -subj '/CN=my key/' -sha256 -engine pkcs11 -keyform engine -key slot_1-label_rsa1 -out "$cert.rsa1"
 clear_asan
 
 #
 # insert cert to token
 #
-tpm2_ptool addcert --label=label --key-label=1 --path=$TPM2_PKCS11_STORE "$cert"
+echo "Adding EC Certificate"
+tpm2_ptool addcert --label=label --key-label=ec1 --path=$TPM2_PKCS11_STORE "$cert.ec1"
+echo "added x509 Certificate"
 
+echo "Adding RSA Certificate"
+tpm2_ptool addcert --label=label --key-label=rsa1 --path=$TPM2_PKCS11_STORE "$cert.rsa1"
 echo "added x509 Certificate"
 
 # add 1 aes key under label "import-keys"


### PR DESCRIPTION
This creates basic support for RSA public key crypto for algorithm
RSA/ECB/RSAPKCS1.5 padding in Java. Other schemes may work, but are
untested. Test machines must have the hamcrest and junit JAR files on
their CLASSPATH.

Fixes: #341

Signed-off-by: William Roberts <william.c.roberts@intel.com>