### PR TITLE
test: verify C_CloseAllSessions implicitly logs out

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -300,7 +300,7 @@ CK_RV object_find(session_ctx *ctx, CK_OBJECT_HANDLE *object, CK_ULONG max_objec
         CK_OBJECT_HANDLE handle = opdata->cur->tobj_handle;
 
         // filter out CKO_PRIVATE and CKO_SECRET if not logged in
-        if (token_is_user_logged_in(tok) && is_not_public(opdata->cur)) {
+        if (!token_is_user_logged_in(tok) && is_not_public(opdata->cur)) {
             opdata->cur = opdata->cur->next;
             continue;
         }

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -282,7 +282,6 @@ CK_RV session_ctx_login(session_ctx *ctx, CK_USER_TYPE user, CK_BYTE_PTR pin, CK
     uint32_t pobj_handle = tok->pobject.handle;
     twist pobjauth = tok->pobject.objauth;
 
-    // TODO evict sealobjhandle
     bool res = tpm_loadobj(tpm, pobj_handle, pobjauth, sealpub, sealpriv, &sealobj->handle);
     if (!res) {
         goto error;
@@ -385,6 +384,14 @@ CK_RV session_ctx_logout(session_ctx *ctx) {
             }
         }
     }
+
+    /* evict the seal object */
+    bool result = tpm_flushcontext(tpm, tok->sealobject.handle);
+    if (!result) {
+        LOGW("Could not evict the seal object");
+        assert(0);
+    }
+    tok->sealobject.handle = 0;
 
     /*
      * State transition all sessions in the table

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -410,7 +410,7 @@ bool token_is_any_user_logged_in(token *tok) {
 
 bool token_is_user_logged_in(token *tok) {
 
-    return tok->login_state != token_user_logged_in;
+    return tok->login_state & token_user_logged_in;
 }
 
 void token_lock(token *t) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -118,6 +118,8 @@ bool token_is_any_user_logged_in(token *tok);
 
 bool token_is_user_logged_in(token *tok);
 
+bool token_is_so_logged_in(token *tok);
+
 /**
  * TODO
  * @param tok


### PR DESCRIPTION
Verify that C_CloseAllSessions() causes a logout of the token to
occur.

Fixes: #127

Signed-off-by: William Roberts <william.c.roberts@intel.com>