### PR TITLE
 PKCS11JavaTests: Java >= 9 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,13 @@ AC_ARG_ENABLE(
     [build and execute integration tests])],,
   [enable_integration=no])
 
+# Test for Java compiler and interpreter without throwing fatal errors (since
+# these macros are defined using AC_DEFUN they cannot be called conditionally)
+m4_pushdef([AC_MSG_ERROR], [have_javac=no])
+AX_PROG_JAVAC()
+AX_PROG_JAVA()
+m4_popdef([AC_MSG_ERROR])
+
 AC_DEFUN([integration_test_checks], [
 
   PKG_CHECK_MODULES([CMOCKA],[cmocka])
@@ -113,6 +120,13 @@ AC_DEFUN([integration_test_checks], [
   AC_CHECK_PROG([ss], [ss], [yes], [no])
     AS_IF([test "x$ss" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but ss executable not found.])])
+
+  AS_IF([test "x$have_javac" = "xno"],
+    [AC_MSG_ERROR([Integration tests enabled but no Java compiler was found])])
+  AX_CHECK_CLASS([org.junit.Assert], ,
+    [AC_MSG_ERROR([Integration tests enabled but JUnit not found, try setting CLASSPATH])])
+  AX_CHECK_CLASS([org.hamcrest.SelfDescribing], ,
+    [AC_MSG_ERROR([Integration tests enabled but Hamcrest not found, try setting CLASSPATH])])
 
   AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])
 ]) # end function integration_test_checks


### PR DESCRIPTION
In Java >=9, the PKCS#11 provider needs to be configured as follows:
```
String pkcs11Config = "--name = TPM2\nlibrary = " + libPath;
PROV = Security.getProvider("SunPKCS11");
PROV = PROV.configure(pkcs11Config);
```
The `sun.security.pkcs11.SunPKCS11` class is not user-accessible any more, trying to instantiate it leads to a "package sun.security.pkcs11 is not visible" compilation error.

In Java <= 8, the `Provider.configure()` method does not exist, the configuration needs to be supplied to the class constructor instead.

To support all Java versions, check if `Provider.configure()` is available and fall back to the old code in case it is not. To avoid compile-time "symbol not found" errors due to missing/inaccessible methods and classes, we need to use introspection to do the resolution during runtime.

Additionally check during configure if a Java compiler can be found and whether the JUnit and Hamcrest classes are available.