### PR TITLE
tpm: support raw RSA crypto in C_Sign

### DIFF
--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -139,6 +139,9 @@ static CK_RV common_init(operation op, session_ctx *ctx, CK_MECHANISM_PTR mechan
 
     check_pointer(mechanism);
 
+    LOGV("mechanism: 0x%x\n\thas_params: %s\n\tlen: %lu", mechanism->mechanism,
+            mechanism->pParameter ? "yes" : "no", mechanism->ulParameterLen);
+
     CK_RV rv = CKR_GENERAL_ERROR;
 
     bool is_active = session_ctx_opdata_is_active(ctx);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -3165,7 +3165,7 @@ CK_RV tpm2_getmechanisms(tpm_ctx *ctx, CK_MECHANISM_TYPE *mechanism_list, CK_ULO
         add_mech(CKM_SHA1_RSA_PKCS);
         add_mech(CKM_SHA256_RSA_PKCS);
         add_mech(CKM_SHA384_RSA_PKCS);
-        add_mech(CKM_SHA512_RSA_PKCS_PSS);
+        add_mech(CKM_SHA512_RSA_PKCS);
 
         /*
          * PSS cannot be synthesized, so always check for support before

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -1062,6 +1062,9 @@ CK_RV get_signature_scheme(CK_MECHANISM_PTR mech, CK_ULONG datalen, TPMT_SIG_SCH
 
             p = mech->pParameter;
 
+            LOGV("PSS PARAMS\n\thashAlg:0x%x\n\tmgf: 0x%x\n\tsLen: %d",
+                    p->hashAlg, p->mgf, p->sLen);
+
             halg = mech_to_hash_alg_ex(p->hashAlg, datalen);
         }
 

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -349,6 +349,8 @@ bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech) {
 
     switch(mech) {
     case CKM_RSA_PKCS:
+        /* falls-thru */
+    case CKM_RSA_X_509:
         return true;
     default:
         return false;


### PR DESCRIPTION
**Update**

Just support CKM_RSA_X509 via C_Sign()

**Old outdated, dumb idea below**

Assymetric keypairs are represented by PKCS11/TPM internals as 2
objects. The private key handle contains the public and private portion
of the RSA object and the public handle contains only the public
portion. The TPM cannot distinguish the private key case for calls
performing RSA Encrypt or Decrypt, and thus default to their proper
keys. RSA Decrypt uses the private key, and RSA Encrypt uses the public
key. This can cause issues where a call is made to C_Encrypt with a
private key object. The code was calling TPM2_RSA_Encrypt, which
performs the RSA operation using the public key, thus calls using public
keys loaded into OSSL to decrypt with the public key (perform RSA
Encrypt) will fail. Below is mapping of class and interface to proper
RSA calls, update the TPM to use it.

| Key Class | Interface | Operation |
|---------------|--------------|--------------|
| CKO_PRIVATE | C_Decrypt | tpm_decrypt |
| CKO_PUBLIC   | C_Decrypt | tpm_encrypt |
| CKO_PRIVATE | C_Encrypt | tpm_decrypt |
| CKO_PUBLIC   | C_Encrypt | tpm_encrypt |

Signed-off-by: William Roberts <william.c.roberts@intel.com>