### PR TITLE
tpm2_ptool: objmod fixes

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -451,10 +451,10 @@ class ObjMod(Command):
                 sys.exit('Unknown key: %d', key)
             keyname = keynames[key]
 
-        if key and not key in obj_attrs:
-            sys.exit("Key not found")
-
         if not value:
+            if key and not key in obj_attrs:
+                sys.exit("Key not found")
+
             print(yaml.safe_dump({keyname : obj_attrs[key]}))
             sys.exit()
 

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -458,7 +458,7 @@ class ObjMod(Command):
             print(yaml.safe_dump({keyname : obj_attrs[key]}))
             sys.exit()
 
-        if not type:
+        if not vtype:
             sys.exit("When specifying a value, type is required")
 
         value = getattr(cls, ObjMod._type_map[vtype])(value)


### PR DESCRIPTION
This PR comprises two changes to tpm2_ptool objmod that fix the type check when setting a new value to an attribute, and also allow to add new attributes to an object, rather than just changing existing values.