### PR TITLE
Improve NSS support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,8 @@ check_SCRIPTS += \
     test/integration/pkcs11-tool.sh \
     test/integration/pkcs11-tool-init.sh.nosetup \
     test/integration/pkcs11-dbup.sh.nosetup \
-    test/integration/tls-tests.sh
+    test/integration/tls-tests.sh \
+    test/integration/nss-tests.sh
 
 LOG_COMPILER = $(srcdir)/test/integration/scripts/int-test-setup.sh
 

--- a/test/integration/fixtures/smimeextensions
+++ b/test/integration/fixtures/smimeextensions
@@ -1,0 +1,7 @@
+[smime]
+basicConstraints = critical,CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+subjectAltName = email:move
+extendedKeyUsage = emailProtection

--- a/test/integration/nss-tests.sh
+++ b/test/integration/nss-tests.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -xo pipefail
+
+CA_PEM="$TEST_FIXTURES/ca.pem"
+CA_KEY="$TEST_FIXTURES/ca.key"
+
+CLIENT_CNF="$TEST_FIXTURES/client.cnf"
+PASSWORD_CA=whatever
+EXT_FILE="$TEST_FIXTURES/smimeextensions"
+
+export NSS_DEFAULT_DB_TYPE=sql
+
+if ! command -v certutil ||
+   ! command -v modutil; then
+  # Skip this test unless certutil/modutil are found
+  exit 77
+fi
+
+function pinentry() {
+  pin="$1"
+  shift
+  cmd="$*"
+  printf 'spawn %s\nexpect "Password or Pin"\nsend -- %s\\r\nexpect eof\n' \
+	  "$cmd" "$pin" | expect
+}
+
+function cleanup() {
+  if [ "$1" != "no-kill" ]; then
+      pkill -P $$ || true
+  fi
+  rm -f index.txt index.txt.attr serial serial.old index.txt.old index.txt.attr.old \
+        03.pem smimeclient.csr smimeclient.crt smimeclient.key smimeclient.pem \
+        pkcs11.txt cert9.db key4.db userpin.txt
+}
+trap cleanup EXIT
+
+onerror() {
+  echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+  exit 1
+}
+trap onerror ERR
+
+cleanup "no-kill"
+
+if [ -z "$modpath" ]; then
+  modpath="$PWD/src/.libs/libtpm2_pkcs11.so"
+fi
+
+echo "modpath=$modpath"
+
+# make the DB
+touch index.txt
+touch index.txt.attr
+echo "03" >> serial
+
+echo "Creating S/MIME certificate for testuser@example.org"
+openssl req -new -newkey rsa:2048 -nodes -keyout smimeclient.key \
+  -out smimeclient.csr \
+  -subj "/C=FR/ST=Radius/L=Somewhere/O=Example Inc./CN=smimetesting/emailAddress=testuser@example.org"
+
+echo "Signing S/MIME certificate with test CA"
+openssl ca -batch -keyfile "$CA_KEY" -cert "$CA_PEM" -in smimeclient.csr \
+  -key "$PASSWORD_CA" -out smimeclient.crt -extensions smime \
+  -extfile "$EXT_FILE" -config "$CLIENT_CNF"
+
+echo "Converting signed S/MIME certificate to PEM format"
+openssl x509 -in smimeclient.crt -out smimeclient.pem -outform pem
+
+echo "Initializing temporary NSS DB"
+certutil -N -d . --empty-password
+
+echo "Adding PKCS11 module in $modpath to NSS configuration"
+echo | modutil -add tpm2 -libfile "$modpath" -dbdir .
+
+echo "Adding S/MIME trust for test CA"
+certutil -A -d . -n testca -t ,C, -a -i "$CA_PEM"
+
+echo "Importing S/MIME key to TPM2 token"
+tpm2_ptool import --userpin anotheruserpin --privkey smimeclient.key \
+  --label import-keys --key-label smimetest --algorithm rsa
+
+echo "Importing S/MIME certificate to TPM2 token"
+tpm2_ptool addcert --label import-keys --key-label smimetest smimeclient.pem
+
+echo "Testing S/MIME certificate lookup in NSS DB via label"
+pinentry anotheruserpin certutil -L -d . -n import-keys:smimetest
+
+echo "Testing S/MIME certificate lookup in NSS DB via mail address"
+pinentry anotheruserpin certutil -L -d . --email testuser@example.org
+
+echo "Testing if S/MIME certificate in NSS DB has user trust"
+pinentry anotheruserpin certutil -L -d . -h import-keys | \
+	 grep import-keys:smimetest | grep -q u,u,u
+
+echo "Testing if S/MIME certificate in NSS DB is valid for mail signing"
+pinentry anotheruserpin certutil -V -d . -n import-keys:smimetest -u S
+
+echo "Testing if S/MIME certificate in NSS DB is valid for mail reception"
+pinentry anotheruserpin certutil -V -d . -n import-keys:smimetest -u R
+
+exit 0

--- a/test/integration/pkcs-get-attribute-value.int.c
+++ b/test/integration/pkcs-get-attribute-value.int.c
@@ -396,6 +396,8 @@ static void verify_cert_attrs(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE h) {
     CK_ATTRIBUTE_PTR value = NULL;
     CK_ATTRIBUTE_PTR checkvalue = NULL;
     CK_ATTRIBUTE_PTR subject = NULL;
+    CK_ATTRIBUTE_PTR issuer = NULL;
+    CK_ATTRIBUTE_PTR serial_number = NULL;
 
     CK_ULONG i = 0;
     for (i=0; i < ARRAY_LEN(attrs); i++) {
@@ -430,6 +432,12 @@ static void verify_cert_attrs(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE h) {
             case CKA_SUBJECT:
                 subject = a;
                 break;
+            case CKA_ISSUER:
+                issuer = a;
+		break;
+            case CKA_SERIAL_NUMBER:
+                serial_number = a;
+		break;
             case CKA_LABEL:
                 /* a label should be set ? */
                 assert_true(a->ulValueLen > 0);
@@ -456,10 +464,6 @@ static void verify_cert_attrs(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE h) {
                 // falls-thru
             case CKA_PUBLIC_KEY_INFO:
                 // falls-thru
-            case CKA_ISSUER:
-                // falls-thru
-            case CKA_SERIAL_NUMBER:
-                // falls-thru
             case CKA_START_DATE:
                 // falls-thru
             case CKA_END_DATE:
@@ -471,6 +475,8 @@ static void verify_cert_attrs(CK_SESSION_HANDLE s, CK_OBJECT_HANDLE h) {
     }
 
     assert_non_null(subject);
+    assert_non_null(issuer);
+    assert_non_null(serial_number);
 
     assert_non_null(value);
     assert_non_null(checkvalue);

--- a/tools/tpm2_pkcs11/utils.py
+++ b/tools/tpm2_pkcs11/utils.py
@@ -270,7 +270,13 @@ def pemcert_to_attrs(certpath):
         hexbercertchecksum = h(bercertchecksum).decode()
 
         subj = c['subject']
-        hexsubj=h(d(str2bytes(subj))).decode()
+        hexsubj = h(d(str2bytes(subj))).decode()
+
+        issuer = c['issuer']
+        hexissuer = h(d(str2bytes(issuer))).decode()
+
+        serial = c['serialNumber']
+        hexserial = h(d(str2bytes(serial))).decode()
 
         return {
             # The attrs of this attribute is derived by taking the first 3 bytes of the CKA_VALUE
@@ -285,10 +291,10 @@ def pemcert_to_attrs(certpath):
             CKA_PUBLIC_KEY_INFO : "",
             # DER encoded subject
             CKA_SUBJECT : hexsubj,
-            # der encoding of issuer, default empty
-            CKA_ISSUER : '',
-            # der encoding of the cert serial, default empty
-            CKA_SERIAL_NUMBER : '',
+            # DER encoding of issuer
+            CKA_ISSUER : hexissuer,
+            # DER encoding of the cert serial
+            CKA_SERIAL_NUMBER : hexserial,
             # BER encoding of the certificate
             CKA_VALUE : hexbercert,
             # RFC2279 string to URL where cert can be found, default empty


### PR DESCRIPTION
Initialize required PKCS11 attributes to make NSS recognize certificates from `tpm2_pkcs11` by default. This is useful eg. for web browsers or S/MIME certificates in mail clients that are based on `libnss` and `libsmime`. Add a new integration test for the S/MIME use case.