### PR TITLE
tobject: change field index to handle

### DIFF
--- a/src/lib/encrypt.c
+++ b/src/lib/encrypt.c
@@ -294,7 +294,7 @@ static CK_RV common_init_op (session_ctx *ctx, encrypt_op_data *supplied_opdata,
      * only object and don't go to the TPM.
      */
     if (tobj->pub) {
-       rv = tpm_encrypt_data_init(tok->tctx, tobj->handle, tobj->unsealed_auth, mechanism,
+       rv = tpm_encrypt_data_init(tok->tctx, tobj->tpm_handle, tobj->unsealed_auth, mechanism,
                &opdata->cryptopdata.tpm_enc_data);
     } else {
         opdata->use_sw = true;

--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -322,8 +322,8 @@ CK_RV key_gen (
         goto out;
     }
 
-    *public_key_handle = new_public_tobj->index;
-    *private_key_handle = new_private_tobj->index;
+    *public_key_handle = new_public_tobj->obj_handle;
+    *private_key_handle = new_private_tobj->obj_handle;
 
 out:
     tpm_objdata_free(&objdata);

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -171,7 +171,7 @@ static object_find_data *object_find_data_new(void) {
 
 static CK_RV do_match_set(tobject_match_list *match_cur, tobject *tobj) {
 
-    match_cur->tobj_handle = tobj->index;
+    match_cur->tobj_handle = tobj->obj_handle;
 
     CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_CLASS);
     if (!a) {
@@ -467,7 +467,7 @@ CK_RV tobject_set_auth(tobject *tobj, twist authbin, twist wrappedauthhex) {
 void tobject_set_handle(tobject *tobj, uint32_t handle) {
     assert(tobj);
 
-    tobj->handle = handle;
+    tobj->tpm_handle = handle;
 }
 
 void tobject_set_id(tobject *tobj, unsigned id) {
@@ -759,7 +759,7 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
         return rv;
     }
 
-    *object = new_tobj->index;
+    *object = new_tobj->obj_handle;
 
     return CKR_OK;
 }

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -28,7 +28,7 @@ struct tobject {
 
     unsigned id; /** external handle */
 
-    CK_OBJECT_HANDLE index;
+    CK_OBJECT_HANDLE obj_handle; /** application visible handle */
 
     /*
      * these all exist in the attribute array, but we'll keep some
@@ -44,7 +44,7 @@ struct tobject {
 
     twist unsealed_auth; /** unwrapped auth value */
 
-    uint32_t handle;     /** loaded tpm handle */
+    uint32_t tpm_handle;     /** loaded tpm handle */
 
     bool is_authenticated; /** true if a context specific login has authenticated use of the object */
 };

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -372,11 +372,11 @@ CK_RV session_ctx_logout(session_ctx *ctx) {
         while(cur) {
             tobject *tobj = list_entry(cur, tobject, l);
             cur = cur->next;
-            if (tobj->handle) {
-                bool result = tpm_flushcontext(tpm, tobj->handle);
+            if (tobj->tpm_handle) {
+                bool result = tpm_flushcontext(tpm, tobj->tpm_handle);
                 assert(result);
                 UNUSED(result);
-                tobj->handle = 0;
+                tobj->tpm_handle = 0;
 
                 /* Clear the unwrapped auth value for tertiary objects */
                 twist_free(tobj->unsealed_auth);

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -482,7 +482,7 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
         };
 
         /* RSA Decrypt is the RSA operation with the private key, which is what we want */
-        rv = decrypt_init_op(ctx, encrypt_opdata, &mechanism, tobj->index);
+        rv = decrypt_init_op(ctx, encrypt_opdata, &mechanism, tobj->obj_handle);
         if (rv != CKR_OK) {
             free(padded);
             encrypt_op_data_free(&encrypt_opdata);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -1215,7 +1215,7 @@ static CK_RV sig_flatten(TPMT_SIGNATURE *signature, TPMT_SIG_SCHEME *scheme, CK_
 CK_RV tpm_sign(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_PTR mech, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG_PTR siglen) {
 
     twist auth = tobj->unsealed_auth;
-    TPMI_DH_OBJECT handle = tobj->handle;
+    TPMI_DH_OBJECT handle = tobj->tpm_handle;
 
     TPM2B_DIGEST tdigest;
     if (sizeof(tdigest.buffer) < datalen) {
@@ -1339,7 +1339,7 @@ static CK_RV init_sig_from_mech(CK_MECHANISM_TYPE mech, CK_ULONG datalen, CK_BYT
 
 CK_RV tpm_verify(tpm_ctx *ctx, tobject *tobj, CK_MECHANISM_PTR mech, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG siglen) {
 
-    TPMI_DH_OBJECT handle = tobj->handle;
+    TPMI_DH_OBJECT handle = tobj->tpm_handle;
 
     // Copy the data into the digest block
     TPM2B_DIGEST msgdigest;


### PR DESCRIPTION
The index field implies that it's an index into a list, which in some
cases it is. However, the value may not always be in the index, as the
list can contain holes, for instance if obect at list index 2 is
deleted, the list would have a hole.

The index is really the object handle, so call it that. And while the
internal list is kept in order so holes can be filled in, and the handle
assigned an index in the hole, it's still just a handle.

The spec does discuss that the handle will be valid under three
conditions:
1. The session continues to exist that the object was discovered on.
2. The object continues to exist.
3. The object is still accessible.

The current logic does have some issues in that:
1. The handle is not invalidated if the session is closed.
2. A logout will cause the object to be unuseable, but will not
   actually cause the handle to be invalidated.

One would have to consider, to support this, things like object deletes
get very complicated. For instace, when a C_Destory() call is made, you
need to go through every session and delete the object from a per
session handle table and 2 then destroy the object.

Signed-off-by: William Roberts <william.c.roberts@intel.com>