### PR TITLE
Drop unused variable which is causing the build to fail with current gcc10

### DIFF
--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -14,7 +14,7 @@ typedef struct token_config token_config;
 struct token_config {
     bool is_initialized;  /* token initialization state */
     char *tcti;           /* token specific tcti config */
-} config;
+};
 
 typedef struct session_table session_table;
 typedef struct session_ctx session_ctx;


### PR DESCRIPTION
The package build started failing with current gcc10 because of multiple definition of `config`. In the end, it turned out that this global variable is not used in the code at all so I think the correct approach will be to remove it altogether as in the attached commit.

https://bugzilla.redhat.com/show_bug.cgi?id=1796383