### PR TITLE
mechanism refactor

### DIFF
--- a/src/lib/attrs.c
+++ b/src/lib/attrs.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 

--- a/src/lib/digest.h
+++ b/src/lib/digest.h
@@ -19,8 +19,6 @@ struct digest_op_data {
     EVP_MD_CTX *mdctx;
 };
 
-bool digest_is_supported(CK_MECHANISM_TYPE type);
-
 digest_op_data *digest_op_data_new(void);
 void digest_op_data_free(digest_op_data **opdata);
 

--- a/src/lib/emitter.c
+++ b/src/lib/emitter.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 
@@ -332,3 +333,4 @@ doc_delete:
     return yaml_return;
 
 }
+

--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -15,7 +15,7 @@ typedef struct encrypt_op_data encrypt_op_data;
 
 typedef union crypto_op_data crypto_op_data;
 union crypto_op_data{
-    tpm_encrypt_data *tpm_enc_data;
+    tpm_op_data *tpm_opdata;
     sw_encrypt_data *sw_enc_data;
 };
 

--- a/src/lib/mech.c
+++ b/src/lib/mech.c
@@ -1,0 +1,1191 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#include "config.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <openssl/obj_mac.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+
+#include "attrs.h"
+#include "checks.h"
+#include "log.h"
+#include "mech.h"
+#include "object.h"
+#include "pkcs11.h"
+#include "tpm.h"
+#include "utils.h"
+
+#define MAX_MECHS 128
+
+typedef enum mechanism_flags mechanism_flags;
+enum mechanism_flags {
+    mf_tpm_supported = 1 << 0,
+    mf_is_keygen     = 1 << 1,
+    mf_is_synthetic  = 1 << 3,
+    mf_is_digester   = 1 << 4,
+    mf_sign          = 1 << 5,
+    mf_verify        = 1 << 6,
+    mf_encrypt       = 1 << 7,
+    mf_decrypt       = 1 << 8,
+    mf_rsa           = 1 << 9,
+    mf_ecc           = 1 << 10,
+    mf_aes           = 1 << 11,
+    mf_force_synthetic     = 1 << 11,
+};
+
+/*
+ * Validates that the mechanism parameters are sane and supported
+ */
+typedef CK_RV (*fn_validator)(CK_MECHANISM_PTR mech, attr_list *attrs);
+
+/*
+ * Some crypto operations can be synthesized (padding done off hw and raw crypto performed)
+ * This routine would do all those steps.
+ */
+typedef CK_RV (*fn_synthesizer)(CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
+
+typedef CK_RV (*fn_get_halg)(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE *halg);
+
+typedef CK_RV (*fn_get_digester)(CK_MECHANISM_PTR mech, const EVP_MD **md);
+
+typedef CK_RV (*fn_get_tpm_opdata)(tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **encdata);
+
+typedef struct mdetail mdetail;
+struct mdetail {
+    CK_MECHANISM_TYPE type;
+
+    fn_validator validator;
+    fn_synthesizer synthesizer;
+    fn_get_tpm_opdata get_tpm_opdata;
+    fn_get_halg get_halg;
+    fn_get_digester get_digester;
+
+    mechanism_flags flags;
+};
+
+#define DO_INIT(tctx) \
+do { \
+    CK_RV rv = mech_init(tctx); \
+    if (rv != CKR_OK) { \
+        return rv; \
+    } \
+} while (0)
+
+static CK_RV rsa_keygen_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_pkcs_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_pss_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_oaep_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_pkcs_hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_pss_hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV ecc_keygen_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV ecdsa_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV rsa_pkcs_synthesizer(CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
+static CK_RV rsa_pkcs_hash_synthesizer(CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
+static CK_RV rsa_pss_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+static CK_RV rsa_oaep_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+static CK_RV sha1_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+static CK_RV sha256_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+static CK_RV sha384_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+static CK_RV sha512_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg);
+
+static CK_RV rsa_pss_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+static CK_RV rsa_oaep_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+static CK_RV sha1_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+static CK_RV sha256_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+static CK_RV sha384_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+static CK_RV sha512_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md);
+
+static CK_RV tpm_rsa_pss_get_opdata(tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata);
+
+static bool _g_is_initialized = false;
+
+static mdetail _g_mechs[MAX_MECHS] = {
+
+    /* RSA */
+    { .type = CKM_RSA_PKCS_KEY_PAIR_GEN, .validator = rsa_keygen_validator, .flags = mf_is_keygen|mf_rsa },
+
+    { .type = CKM_RSA_X_509, .flags = mf_is_synthetic|mf_sign|mf_verify|mf_encrypt|mf_decrypt|mf_rsa, .get_tpm_opdata = tpm_rsa_pkcs_get_opdata },
+
+    { .type = CKM_RSA_PKCS,      .flags = mf_force_synthetic|mf_sign|mf_verify|mf_encrypt|mf_decrypt|mf_rsa, .validator = rsa_pkcs_validator, .synthesizer = rsa_pkcs_synthesizer, .get_tpm_opdata = tpm_rsa_pkcs_get_opdata },
+
+    { .type = CKM_RSA_PKCS_PSS,  .flags = mf_sign|mf_verify|mf_rsa,       .validator = rsa_pss_validator,  .get_halg = rsa_pss_get_halg,  .get_digester = rsa_pss_get_digester,  .get_tpm_opdata = tpm_rsa_pss_get_opdata },
+    { .type = CKM_RSA_PKCS_OAEP, . flags = mf_encrypt|mf_decrypt|mf_rsa,  .validator = rsa_oaep_validator, .get_halg = rsa_oaep_get_halg, .get_digester = rsa_oaep_get_digester, .get_tpm_opdata = tpm_rsa_oaep_get_opdata },
+
+    { .type = CKM_SHA1_RSA_PKCS,   .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pkcs_hash_validator, .synthesizer = rsa_pkcs_hash_synthesizer, .get_halg = sha1_get_halg, .get_digester = sha1_get_digester,     .get_tpm_opdata = tpm_rsa_pkcs_sha1_get_opdata  },
+    { .type = CKM_SHA256_RSA_PKCS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pkcs_hash_validator, .synthesizer = rsa_pkcs_hash_synthesizer, .get_halg = sha256_get_halg, .get_digester = sha256_get_digester, .get_tpm_opdata = tpm_rsa_pkcs_sha256_get_opdata },
+    { .type = CKM_SHA384_RSA_PKCS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pkcs_hash_validator, .synthesizer = rsa_pkcs_hash_synthesizer, .get_halg = sha384_get_halg, .get_digester = sha384_get_digester, .get_tpm_opdata = tpm_rsa_pkcs_sha384_get_opdata },
+    { .type = CKM_SHA512_RSA_PKCS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pkcs_hash_validator, .synthesizer = rsa_pkcs_hash_synthesizer, .get_halg = sha512_get_halg, .get_digester = sha512_get_digester, .get_tpm_opdata = tpm_rsa_pkcs_sha512_get_opdata },
+
+    { .type = CKM_SHA1_RSA_PKCS_PSS,   .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pss_hash_validator, .get_halg = sha1_get_halg, .get_digester = sha1_get_digester,     .get_tpm_opdata = tpm_rsa_pss_sha1_get_opdata },
+    { .type = CKM_SHA256_RSA_PKCS_PSS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pss_hash_validator, .get_halg = sha256_get_halg, .get_digester = sha256_get_digester, .get_tpm_opdata = tpm_rsa_pss_sha256_get_opdata },
+    { .type = CKM_SHA384_RSA_PKCS_PSS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pss_hash_validator, .get_halg = sha384_get_halg, .get_digester = sha384_get_digester, .get_tpm_opdata = tpm_rsa_pss_sha384_get_opdata },
+    { .type = CKM_SHA512_RSA_PKCS_PSS, .flags = mf_sign|mf_verify|mf_rsa, .validator = rsa_pss_hash_validator, .get_halg = sha512_get_halg, .get_digester = sha512_get_digester, .get_tpm_opdata = tpm_rsa_pss_sha512_get_opdata },
+
+    /* EC */
+    { .type = CKM_EC_KEY_PAIR_GEN, .flags = mf_is_keygen|mf_ecc,      .validator = ecc_keygen_validator },
+
+    { .type = CKM_ECDSA,           .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_tpm_opdata = tpm_ec_ecdsa_get_opdata },
+
+    { .type = CKM_ECDSA_SHA1,      .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha1_get_halg, .get_digester = sha1_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha1_get_opdata },
+
+    /* AES */
+    { .type = CKM_AES_KEY_GEN, .flags = mf_is_keygen|mf_aes },
+
+    { .type = CKM_AES_CBC,    .flags = mf_encrypt|mf_decrypt|mf_aes, .get_tpm_opdata = tpm_aes_cbc_get_opdata },
+    { .type = CKM_AES_CFB128, .flags = mf_encrypt|mf_decrypt|mf_aes, .get_tpm_opdata = tpm_aes_cfb_get_opdata },
+    { .type = CKM_AES_ECB,    .flags = mf_encrypt|mf_decrypt|mf_aes, .get_tpm_opdata = tpm_aes_ecb_get_opdata },
+
+    /* hashing */
+    { .type = CKM_SHA_1,  .flags = mf_is_digester|mf_aes, .validator = hash_validator, .get_digester = sha1_get_digester },
+    { .type = CKM_SHA256, .flags = mf_is_digester|mf_aes, .validator = hash_validator, .get_digester = sha256_get_digester },
+    { .type = CKM_SHA384, .flags = mf_is_digester|mf_aes, .validator = hash_validator, .get_digester = sha384_get_digester },
+    { .type = CKM_SHA512, .flags = mf_is_digester|mf_aes, .validator = hash_validator, .get_digester = sha512_get_digester },
+};
+
+static struct {
+    CK_ULONG bits;
+    bool supported;
+} _g_rsa_keysizes [] = {
+    { .bits = 1024 },
+    { .bits = 2048 },
+    { .bits = 3072 },
+    { .bits = 4096 },
+};
+
+static struct {
+    int nid;
+    bool supported;
+} _g_ecc_curve_nids [] = {
+    { .nid = NID_X9_62_prime192v1 },
+    { .nid = NID_secp224r1        },
+    { .nid = NID_X9_62_prime256v1 },
+    { .nid = NID_secp384r1,       },
+    { .nid = NID_secp521r1,       },
+};
+
+#define _L(a) (a->ulValueLen/sizeof(CK_MECHANISM_TYPE))
+#define _P(a) ((CK_MECHANISM_TYPE_PTR)a->pValue)
+
+static mdetail *mlookup(CK_MECHANISM_TYPE t) {
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(_g_mechs); i++) {
+        mdetail *m = &_g_mechs[i];
+        if (m->type == t) {
+            return m;
+        }
+    }
+
+    return NULL;
+}
+
+static CK_RV has_raw_rsa(attr_list *attrs) {
+
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_ALLOWED_MECHANISMS);
+    if (!a) {
+        LOGE("Expected CKA_ALLOWED_MECHANISMS");
+        return CKR_GENERAL_ERROR;
+    }
+
+    /* If the TPM doesn't support it, it needs to support raw sign */
+    bool supported = false;
+    CK_ULONG i;
+    for (i=0; i < _L(a); i++) {
+        CK_MECHANISM_TYPE t = _P(a)[i];
+        if (t == CKM_RSA_X_509) {
+            supported = true;
+            break;
+        }
+    }
+
+    return supported ? CKR_OK : CKR_MECHANISM_INVALID;
+}
+
+CK_RV hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+    UNUSED(attrs);
+
+    /* hashers don't take params */
+    if (mech->pParameter || mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /* all known hashing digests are supported in software */
+
+    return CKR_OK;
+}
+
+CK_RV rsa_pkcs_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    /*
+     * CKM_RSA_PKCS has the PKCS v1.5 signing structure computed by the client
+     * and requires only padding, so no parameters should be set
+     */
+    if (mech->pParameter || mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    return has_raw_rsa(attrs);
+}
+
+CK_RV rsa_pkcs_hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    /* CKM_<HASH>_RSA_PKCS takes no params */
+    if (mech->pParameter || mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* if the TPM supports it natively, we're done */
+    if (m->flags & mf_tpm_supported) {
+        return CKR_OK;
+    }
+
+    return has_raw_rsa(attrs);
+}
+
+CK_RV rsa_pss_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+    UNUSED(attrs);
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    CK_RSA_PKCS_PSS_PARAMS_PTR params;
+    SAFE_CAST(mech, params);
+
+    /* no SHA224 support AFAIK */
+    if (params->mgf == CKG_MGF1_SHA224) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    CK_MECHANISM_TYPE halg = 0;
+    CK_RV rv = m->get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    if (halg != params->hashAlg) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /*
+     * The TPM fixes the MGF to the hash algorithm and the salt to the hashlen.
+     */
+    if (params->hashAlg == CKM_SHA_1
+            && ((params->mgf != CKG_MGF1_SHA1) ||(params->sLen != 20)) ) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    if (params->hashAlg == CKM_SHA256
+            && ((params->mgf != CKG_MGF1_SHA256) ||(params->sLen != 32)) ) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    if (params->hashAlg == CKM_SHA384
+            && ((params->mgf != CKG_MGF1_SHA384) ||(params->sLen != 48)) ) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    if (params->hashAlg == CKM_SHA512
+            && ((params->mgf != CKG_MGF1_SHA512) ||(params->sLen != 64)) ) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /*
+     * now that the PSS portion IS supported AND the mechanism params check out,
+     * is supported natively?
+     */
+    if (m->flags & mf_tpm_supported) {
+        return CKR_OK;
+    }
+
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV rsa_oaep_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+    UNUSED(attrs);
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    CK_RSA_PKCS_OAEP_PARAMS_PTR params;
+    SAFE_CAST(mech, params);
+
+    /* no SHA224 support AFAIK */
+    if (params->mgf == CKG_MGF1_SHA224) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    CK_MECHANISM_TYPE halg = 0;
+    CK_RV rv = m->get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    if (halg != params->hashAlg) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    if (!params->source) {
+
+        if (params->pSourceData || params->ulSourceDataLen) {
+            return CKR_MECHANISM_PARAM_INVALID;
+        }
+
+        return CKR_OK;
+    }
+
+    if (params->source != CKZ_DATA_SPECIFIED) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /*
+     * now that the OAEP portion IS supported AND the mechanism params check out,
+     * is supported natively?
+     */
+    if (m->flags & mf_tpm_supported) {
+        return CKR_OK;
+    }
+
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV rsa_pss_hash_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* this may have an argument */
+    if (mech->pParameter || mech->ulParameterLen) {
+        return rsa_pss_validator(mech, attrs);
+    }
+
+    if (m->flags & mf_tpm_supported) {
+        return CKR_OK;
+    }
+
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV rsa_keygen_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* this requires no argument */
+    if (!mech->pParameter || !mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_MODULUS);
+    if (!a) {
+        return CKR_TEMPLATE_INCOMPLETE;
+    }
+
+    CK_ULONG bits = a->ulValueLen * 8;
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(_g_rsa_keysizes); i++) {
+        if (_g_rsa_keysizes[i].bits == bits) {
+            return _g_rsa_keysizes[i].supported ?
+                    CKR_OK : CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+    }
+
+    return CKR_ATTRIBUTE_VALUE_INVALID;
+}
+
+CK_RV ecc_keygen_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* this requires no argument */
+    if (!mech->pParameter || !mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_EC_PARAMS);
+    if (!a) {
+        return CKR_TEMPLATE_INCOMPLETE;
+    }
+
+    int nid = 0;
+    CK_RV rv = ec_params_to_nid(a, &nid);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(_g_rsa_keysizes); i++) {
+        if (_g_ecc_curve_nids[i].nid == nid) {
+            return _g_ecc_curve_nids[i].supported ?
+                    CKR_OK : CKR_MECHANISM_INVALID;
+        }
+    }
+
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV ecdsa_validator(CK_MECHANISM_PTR mech, attr_list *attrs) {
+    UNUSED(attrs);
+
+    /* ECDSA and ECDSA SHA1 are always supported */
+
+    /* it needs to be supported */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* this does not require an argument */
+    if (mech->pParameter || mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    return CKR_OK;
+}
+
+CK_RV sha1_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+    UNUSED(mech);
+    *halg = CKM_SHA_1;
+    return CKR_OK;
+}
+
+CK_RV sha256_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+    UNUSED(mech);
+    *halg = CKM_SHA256;
+    return CKR_OK;
+}
+
+CK_RV sha384_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+    UNUSED(mech);
+    *halg = CKM_SHA384;
+    return CKR_OK;
+}
+
+CK_RV sha512_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+    UNUSED(mech);
+    *halg = CKM_SHA512;
+    return CKR_OK;
+}
+
+static CK_RV rsa_pss_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+
+    /* this should never fail on the look up */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_GENERAL_ERROR;
+    }
+
+    CK_RSA_PKCS_PSS_PARAMS_PTR params;
+    SAFE_CAST(mech, params);
+
+    *halg = params->hashAlg;
+
+    return CKR_OK;
+}
+
+static CK_RV rsa_oaep_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+
+    /* this should never fail on the look up */
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        return CKR_GENERAL_ERROR;
+    }
+
+    CK_RSA_PKCS_PSS_PARAMS_PTR params;
+    SAFE_CAST(mech, params);
+
+    *halg = params->hashAlg;
+
+    return CKR_OK;
+}
+
+CK_RV rsa_pss_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+
+    CK_MECHANISM_TYPE halg = 0;
+    CK_RV rv = rsa_pss_get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    mdetail *m = mlookup(halg);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_digester(mech, md);
+}
+
+CK_RV rsa_oaep_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+
+    CK_MECHANISM_TYPE halg = 0;
+    CK_RV rv = rsa_oaep_get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    mdetail *m = mlookup(halg);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_digester(mech, md);
+}
+
+CK_RV sha1_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+    UNUSED(mech);
+    *md = EVP_sha1();
+    return CKR_OK;
+}
+
+CK_RV sha256_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+    UNUSED(mech);
+    *md = EVP_sha256();
+    return CKR_OK;
+}
+
+CK_RV sha384_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+    UNUSED(mech);
+    *md = EVP_sha384();
+    return CKR_OK;
+}
+
+CK_RV sha512_get_digester(CK_MECHANISM_PTR mech, const EVP_MD **md) {
+    UNUSED(mech);
+    *md = EVP_sha512();
+    return CKR_OK;
+}
+
+static CK_RV mech_init(tpm_ctx *tctx) {
+
+    if (_g_is_initialized) {
+        return CKR_OK;
+    }
+
+    /*
+     * Get the mechanisms
+     */
+    CK_MECHANISM_TYPE tpm_mechs[MAX_MECHS];
+    CK_ULONG tpm_mechs_len = ARRAY_LEN(tpm_mechs);
+    CK_RV rv = tpm2_getmechanisms(tctx, tpm_mechs, &tpm_mechs_len);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    assert(tpm_mechs_len <= ARRAY_LEN(_g_mechs));
+
+    /*
+     * Update whether or not the TPM supports it ot not
+     * and any other metadata
+     */
+    CK_ULONG i;
+    for (i=0; i < tpm_mechs_len; i++) {
+        CK_MECHANISM_TYPE t = tpm_mechs[i];
+        mdetail *m = NULL;
+        CK_ULONG j;
+        for (j=0; j < ARRAY_LEN(_g_mechs); j++) {
+            m = &_g_mechs[j];
+            if (m->type == t) {
+                m->flags |= mf_tpm_supported;
+                break;
+            }
+        }
+    }
+
+    mdetail *m = mlookup(CKM_RSA_PKCS_KEY_PAIR_GEN);
+    if (m) {
+        /* get supported RSA key bit sizes */
+        for (i=0; i < ARRAY_LEN(_g_rsa_keysizes); i++) {
+            rv = tpm_is_rsa_keysize_supported(tctx, _g_rsa_keysizes[i].bits);
+            if (rv == CKR_MECHANISM_INVALID) {
+                continue;
+            }
+
+            if(rv == CKR_OK) {
+                _g_rsa_keysizes[i].supported = true;
+                continue;
+            }
+
+            return rv;
+        }
+    } else {
+        LOGV("RSA Keygen not detected");
+    }
+
+    m = mlookup(CKM_EC_KEY_PAIR_GEN);
+    if (m) {
+        /* get supported ECC curves */
+        for (i=0; i < ARRAY_LEN(_g_ecc_curve_nids); i++) {
+            rv = tpm_is_ecc_curve_supported(tctx, _g_ecc_curve_nids[i].nid);
+            if (rv == CKR_MECHANISM_INVALID) {
+                continue;
+            }
+
+            if(rv == CKR_OK) {
+                _g_ecc_curve_nids[i].supported = true;
+                continue;
+            }
+
+            return rv;
+        }
+    } else {
+        LOGV("EC Keygen not detected");
+    }
+
+    _g_is_initialized = true;
+
+    return CKR_OK;
+}
+
+CK_RV rsa_pkcs_synthesizer(CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen) {
+    UNUSED(mech);
+
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_MODULUS_BITS);
+    if (!a) {
+        LOGE("Signing key has no CKA_MODULUS_BITS");
+        return CKR_GENERAL_ERROR;
+    }
+
+    if (a->ulValueLen != sizeof(CK_ULONG)) {
+        LOGE("Modulus bit pointer data not size of CK_ULONG, got %lu, expected %zu",
+                a->ulValueLen, sizeof(CK_ULONG));
+        return CKR_GENERAL_ERROR;
+    }
+
+    CK_ULONG_PTR keybits = (CK_ULONG_PTR)a->pValue;
+
+    size_t padded_len = *keybits / 8;
+
+    if (*outlen < padded_len) {
+        LOGE("Internal buffer is too small, got: %lu, required %lu",
+                *outlen, padded_len);
+        return CKR_GENERAL_ERROR;
+    }
+
+    /* Apply the PKCS1.5 padding */
+    int rc = RSA_padding_add_PKCS1_type_1(outbuf, padded_len,
+            inbuf, inlen);
+    if (!rc) {
+        LOGE("Applying RSA padding failed");
+        return CKR_GENERAL_ERROR;
+    }
+
+    *outlen = padded_len;
+
+    return CKR_OK;
+}
+
+CK_RV rsa_pkcs_hash_synthesizer(CK_MECHANISM_PTR mech, attr_list *attrs, CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen) {
+
+    assert(mech);
+    assert(outlen);
+
+    /* These headers are defined in the following RFC
+     *   - https://www.ietf.org/rfc/rfc3447.txt
+     *     - Page 42
+     */
+    static const CK_BYTE pkcs1_5_hdr_sha1[15] = {
+        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a,
+        0x05, 0x00, 0x04, 0x14,
+    };
+
+    static const CK_BYTE pkcs1_5_hdr_sha256[19] = {
+        0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+        0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
+    };
+
+    static const CK_BYTE pkcs1_5_hdr_sha384[19] = {
+        0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+        0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30,
+    };
+
+    static const CK_BYTE pkcs1_5_hdr_sha512[19] = {
+        0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+        0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40,
+    };
+
+    const CK_BYTE *hdr;
+    size_t hdr_size;
+
+    switch(mech->mechanism) {
+    case CKM_SHA1_RSA_PKCS:
+        hdr = pkcs1_5_hdr_sha1;
+        hdr_size = sizeof(pkcs1_5_hdr_sha1);
+        break;
+    case CKM_SHA256_RSA_PKCS:
+        hdr = pkcs1_5_hdr_sha256;
+        hdr_size = sizeof(pkcs1_5_hdr_sha256);
+        break;
+    case CKM_SHA384_RSA_PKCS:
+        hdr = pkcs1_5_hdr_sha384;
+        hdr_size = sizeof(pkcs1_5_hdr_sha384);
+        break;
+    case CKM_SHA512_RSA_PKCS:
+        hdr = pkcs1_5_hdr_sha512;
+        hdr_size = sizeof(pkcs1_5_hdr_sha512);
+        break;
+    default:
+        return CKR_MECHANISM_INVALID;
+    }
+
+    size_t hash_len = utils_get_halg_size(mech->mechanism);
+    if (!hash_len) {
+        LOGE("Unknown hash size, got 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (inlen != hash_len) {
+        LOGE("Expected input hash length to match expected hash length,"
+                "got: %lu, expected: %lu", inlen, hash_len);
+    }
+
+    size_t total_size = hdr_size + hash_len;
+
+    CK_BYTE hdr_buf[4096];
+    if (total_size > sizeof(hdr_buf)) {
+        LOGE("Internal buffer is too small, got: %lu, required %lu",
+                total_size, sizeof(hdr_buf));
+        return CKR_GENERAL_ERROR;
+    }
+
+    /*
+     * Build and populate a buffer with hdr + hash
+     */
+    memcpy(hdr_buf, hdr, hdr_size);
+    memcpy(&hdr_buf[hdr_size], inbuf, hash_len);
+
+    return rsa_pkcs_synthesizer(mech, attrs, hdr_buf, total_size, outbuf, outlen);
+}
+
+CK_RV tpm_rsa_pss_get_opdata(tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata) {
+
+    check_pointer(mech);
+    check_pointer(outdata);
+
+    CK_MECHANISM_TYPE halg = 0;
+    CK_RV rv = rsa_pss_get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    mdetail *m = mlookup(halg);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    CK_MECHANISM flat = { 0 };
+    switch (halg) {
+    case CKM_SHA_1:
+        flat.mechanism = CKM_SHA1_RSA_PKCS_PSS;
+        break;
+    case CKM_SHA256:
+        flat.mechanism = CKM_SHA256_RSA_PKCS_PSS;
+        break;
+    case CKM_SHA384:
+        flat.mechanism = CKM_SHA384_RSA_PKCS_PSS;
+        break;
+    case CKM_SHA512:
+        flat.mechanism = CKM_SHA512_RSA_PKCS_PSS;
+        break;
+    default:
+        return CKR_MECHANISM_INVALID;
+    }
+
+    m = mlookup(flat.mechanism);
+    if (!m) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_tpm_opdata(tctx, mech, tobj, outdata);
+}
+
+static CK_RV get_rsa_mechinfo(tpm_ctx *tctx, CK_MECHANISM_INFO_PTR info) {
+
+    CK_ULONG min = 0;
+    CK_ULONG max = 0;
+    CK_RV rv = tpm_find_max_rsa_keysize(tctx, &min, &max);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    info->ulMinKeySize = min;
+    info->ulMaxKeySize = max;
+
+    return CKR_OK;
+}
+
+static CK_RV get_ecc_mechinfo(tpm_ctx *tctx, CK_MECHANISM_INFO_PTR info) {
+
+    CK_ULONG max = 0;
+    CK_ULONG min = 0;
+    CK_RV rv = tpm_find_ecc_keysizes(tctx, &min, &max);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    info->ulMinKeySize = min;
+    info->ulMaxKeySize = max;
+
+    return CKR_OK;
+}
+
+static CK_RV get_aes_mechinfo(tpm_ctx *tctx, CK_MECHANISM_INFO_PTR info) {
+
+    CK_ULONG max = 0;
+    CK_ULONG min = 0;
+    CK_RV rv = tpm_find_aes_keysizes(tctx, &min, &max);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    info->ulMinKeySize = min;
+    info->ulMaxKeySize = max;
+
+    return CKR_OK;
+}
+
+static bool is_mech_supported(mdetail *m) {
+
+    mechanism_flags f = m->flags;
+
+    return (f & mf_tpm_supported) ||
+           (f & mf_is_keygen)     ||
+           (f & mf_is_digester)   ||
+           (m->synthesizer);
+
+}
+
+CK_RV mech_get_supported(tpm_ctx *tctx, CK_MECHANISM_TYPE_PTR mechlist, CK_ULONG_PTR count) {
+
+    CK_RV rv = CKR_GENERAL_ERROR;
+
+    DO_INIT(tctx);
+
+    check_pointer(count);
+
+    CK_ULONG supported = 0;
+
+    CK_MECHANISM_TYPE tmp[MAX_MECHS];
+
+    CK_ULONG i;
+    for (i=0; i < ARRAY_LEN(_g_mechs); i++) {
+        mdetail *m = &_g_mechs[i];
+
+        /* is it supported ? */
+        bool is_supported = is_mech_supported(m);
+        if (!is_supported) {
+            continue;
+        }
+
+        supported++;
+
+        assert(supported <= ARRAY_LEN(tmp));
+
+        tmp[supported] = m->type;
+    }
+
+    if (mechlist) {
+        if (supported > *count) {
+            rv = CKR_BUFFER_TOO_SMALL;
+            goto out;
+        }
+        memcpy(mechlist, tmp, supported * sizeof(mechlist[0]));
+    }
+
+    rv = CKR_OK;
+
+out:
+    *count = supported;
+
+    return rv;
+}
+
+CK_RV mech_validate(tpm_ctx *tctx, CK_MECHANISM_PTR mech, attr_list *attrs) {
+
+    check_pointer(mech);
+
+    DO_INIT(tctx);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* if their is no validator, don't do anything but a look up */
+    if (!m->validator) {
+        return CKR_OK;
+    }
+
+    /* if it's not a keygen template, make sure the object supports it */
+    if (!(m->flags & mf_is_keygen)) {
+        CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_ALLOWED_MECHANISMS);
+        if (!a) {
+            LOGE("Expected object to have: CKA_ALLOWED_MECHANISMS");
+            return CKR_GENERAL_ERROR;
+        }
+
+        CK_ULONG count = a->ulValueLen/sizeof(CK_MECHANISM_TYPE);
+        CK_MECHANISM_TYPE_PTR mt = (CK_MECHANISM_TYPE_PTR)a->pValue;
+
+        bool found = true;
+
+        CK_ULONG i;
+        for(i=0; i < count; i++) {
+            CK_MECHANISM_TYPE t = mt[i];
+            if (t == mech->mechanism) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            return CKR_MECHANISM_INVALID;
+        }
+    }
+
+    return m->validator(mech, attrs);
+}
+
+CK_RV mech_synthesize(tpm_ctx *tctx,
+        CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen) {
+
+    check_pointer(mech);
+
+    DO_INIT(tctx);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    /* if it's supported by the tpm we don't need to call
+     * the synthesizer, just memcpy in to out.
+     */
+    if ((m->flags & mf_tpm_supported)
+            && !(m->flags & mf_force_synthetic)) {
+        if (outbuf) {
+            if (*outlen < inlen) {
+                return CKR_BUFFER_TOO_SMALL;
+            }
+            memcpy(outbuf, inbuf, inlen);
+        }
+        *outlen = inlen;
+        return CKR_OK;
+    }
+
+    if (!m->synthesizer) {
+        LOGE("Cannot synthesize mechanism: 0x%lx", m->type);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->synthesizer(mech, attrs, inbuf, inlen, outbuf, outlen);
+}
+
+CK_RV mech_is_synthetic(tpm_ctx *tctx, CK_MECHANISM_PTR mech,
+        bool *is_synthetic) {
+
+    check_pointer(mech);
+
+    DO_INIT(tctx);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    *is_synthetic = (!(m->flags & mf_tpm_supported))
+            || (m->flags & mf_is_synthetic)
+            || (m->flags & mf_force_synthetic);
+
+    return CKR_OK;
+}
+
+CK_RV mech_is_hashing_needed(CK_MECHANISM_PTR mech,
+        bool *is_hashing_needed) {
+
+    check_pointer(mech);
+    check_pointer(is_hashing_needed);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (!m->get_halg) {
+        *is_hashing_needed = false;
+        return CKR_OK;
+    }
+
+    CK_MECHANISM_TYPE halg;
+    CK_RV rv = m->get_halg(mech, &halg);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    *is_hashing_needed = halg != 0;
+
+    return CKR_OK;
+}
+
+CK_RV mech_get_digest_alg(CK_MECHANISM_PTR mech,
+        CK_MECHANISM_TYPE *mech_type) {
+
+    check_pointer(mech);
+    check_pointer(mech_type);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (!m->get_halg) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_halg(mech, mech_type);
+}
+
+CK_RV mech_get_digester(CK_MECHANISM_PTR mech,
+        const EVP_MD **md) {
+
+    check_pointer(mech);
+    check_pointer(md);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (!m->get_digester) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_digester(mech, md);
+}
+
+CK_RV mech_get_tpm_opdata(tpm_ctx *tctx, CK_MECHANISM_PTR mech,
+        tobject *tobj, tpm_op_data **opdata) {
+
+    check_pointer(tctx);
+    check_pointer(opdata);
+
+    DO_INIT(tctx);
+
+    mdetail *m = mlookup(mech->mechanism);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech->mechanism);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (!m->get_tpm_opdata) {
+        return CKR_MECHANISM_INVALID;
+    }
+
+    return m->get_tpm_opdata(tctx, mech, tobj, opdata);
+}
+
+CK_RV mech_get_info(tpm_ctx *tctx, CK_MECHANISM_TYPE mech_type, CK_MECHANISM_INFO_PTR info) {
+
+    check_pointer(tctx);
+    check_pointer(info);
+
+    memset(info, 0, sizeof(*info));
+
+    DO_INIT(tctx);
+
+    mdetail *m = mlookup(mech_type);
+    if (!m) {
+        LOGE("Mechanism not supported, got: 0x%x", mech_type);
+        return CKR_MECHANISM_INVALID;
+    }
+
+    if (m->flags & mf_is_keygen) {
+        info->flags |= (m->flags & mf_aes) ?
+                CKF_GENERATE :
+                CKF_GENERATE_KEY_PAIR;
+    }
+
+    if (m->flags & mf_tpm_supported) {
+        info->flags |= CKF_HW;
+    }
+
+    if (m->flags & mf_sign) {
+        info->flags |= CKF_SIGN;
+    }
+
+    if (m->flags & mf_verify) {
+        info->flags |= CKF_VERIFY;
+    }
+
+    if (m->flags & mf_encrypt) {
+        info->flags |= CKF_ENCRYPT;
+    }
+
+    if (m->flags & mf_decrypt) {
+        info->flags |= CKF_DECRYPT;
+    }
+
+    /* functions below here return */
+    if (m->flags & mf_is_digester) {
+        info->flags |= CKF_DIGEST;
+        return CKR_OK;
+    }
+
+    if (m->flags & mf_rsa) {
+        return get_rsa_mechinfo(tctx, info);
+    }
+
+    if (m->flags & mf_aes) {
+        return get_aes_mechinfo(tctx, info);
+    }
+
+    if (m->flags & mf_ecc) {
+        return get_ecc_mechinfo(tctx, info);
+    }
+
+    LOGE("Unknown mechanism, got: 0x%lx", mech_type);
+
+    return CKR_MECHANISM_INVALID;
+}

--- a/src/lib/mech.h
+++ b/src/lib/mech.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <openssl/evp.h>
+
+#include "attrs.h"
+#include "object.h"
+#include "pkcs11.h"
+#include "tpm.h"
+
+#ifndef SRC_LIB_MECH_H_
+#define SRC_LIB_MECH_H_
+
+/**
+ * Validate that a mechanism is supported by the object/tpm.
+ *
+ * @param ctx
+ *  A context to the tpm.
+ * @param mech
+ *  The mechanism parameter the application is requesting.
+ * @param attrs
+ *  The attributes list / template of the object being used for the operation.
+ * @return
+ */
+CK_RV mech_validate(tpm_ctx *ctx, CK_MECHANISM_PTR mech, attr_list *attrs);
+
+CK_RV mech_synthesize(tpm_ctx *tctx,
+        CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
+
+CK_RV mech_is_synthetic(tpm_ctx *tctx, CK_MECHANISM_PTR mech,
+        bool *is_synthetic);
+
+CK_RV mech_get_supported(tpm_ctx *tctx, CK_MECHANISM_TYPE_PTR mechlist, CK_ULONG_PTR count);
+
+CK_RV mech_is_hashing_needed(CK_MECHANISM_PTR mech,
+        bool *is_hashing_needed);
+
+CK_RV mech_get_digest_alg(CK_MECHANISM_PTR mech,
+        CK_MECHANISM_TYPE *mech_type);
+
+CK_RV mech_get_digester(CK_MECHANISM_PTR mech,
+        const EVP_MD **md);
+
+CK_RV mech_get_tpm_opdata(tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+
+CK_RV mech_get_info(tpm_ctx *tctx, CK_MECHANISM_TYPE mech_type, CK_MECHANISM_INFO_PTR info);
+
+#endif /* SRC_LIB_MECH_H_ */

--- a/src/lib/mutex.h
+++ b/src/lib/mutex.h
@@ -2,7 +2,7 @@
 
 #ifndef SRC_PKCS11_MUTEX_H_
 #define SRC_PKCS11_MUTEX_H_
-
+#include "config.h"
 #include <assert.h>
 
 #include "log.h"

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -110,6 +110,8 @@ CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
 
 CK_ATTRIBUTE_PTR tobject_get_attribute_full(tobject *tobj, CK_ATTRIBUTE_PTR attr);
 
+CK_RV tobject_get_max_buf_size(tobject *tobj, size_t *maxsize);
+
 CK_RV object_mech_is_supported(tobject *tobj, CK_MECHANISM_PTR mech);
 
 /**

--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -4,14 +4,12 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include <openssl/rand.h>
-#include <openssl/rsa.h>
-
 #include "attrs.h"
 #include "checks.h"
 #include "digest.h"
 #include "encrypt.h"
 #include "log.h"
+#include "mech.h"
 #include "session.h"
 #include "session_ctx.h"
 #include "sign.h"
@@ -24,7 +22,7 @@ struct sign_opdata {
     bool do_hash;
     twist buffer;
     digest_op_data *digest_opdata;
-    encrypt_op_data *encrypt_opdata;
+    encrypt_op_data *crypto_opdata;
 };
 
 static sign_opdata *sign_opdata_new(void) {
@@ -38,102 +36,13 @@ static void sign_opdata_free(sign_opdata **opdata) {
         twist_free((*opdata)->buffer);
     }
 
+    if ((*opdata)->crypto_opdata) {
+        encrypt_op_data_free(&(*opdata)->crypto_opdata);
+    }
+
     free(*opdata);
 
     *opdata = NULL;
-}
-
-static CK_RV ec_fixup_size(CK_MECHANISM_TYPE mech, tobject *tobj, CK_ULONG_PTR signature_len) {
-
-    if (mech != CKM_ECDSA &&
-        mech != CKM_ECDSA_SHA1) {
-        /* nothing to fix up */
-        return CKR_OK;
-    }
-
-    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_EC_PARAMS);
-    assert(a);
-
-    int nid = 0;
-    CK_RV rv = ec_params_to_nid(a, &nid);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    /*
-     * Math below is based off of ECDSA signature:
-     * SEQUENCE (2 elem)
-     *  INTEGER R
-     *  INTEGER S
-     *
-     *  Integers R and S are bounded by keysize in bytes, followed by their
-     *  respective headers(2bytes) followed by the SEQUENCE header(2 bytes)
-     */
-    unsigned keysize;
-
-    switch (nid) {
-    case NID_X9_62_prime192v1:
-        keysize = 24;
-    break;
-    case NID_secp224r1:
-        keysize = 28;
-    break;
-    case NID_X9_62_prime256v1:
-        keysize = 32;
-    break;
-    case NID_secp384r1:
-        keysize = 48;
-    break;
-    case NID_secp521r1:
-        keysize = 66; /* round up */
-    break;
-    default:
-        LOGE("Unsupported nid to tpm signature size maaping: %d", nid);
-        return CKR_CURVE_NOT_SUPPORTED;
-    }
-
-    /* R and S are INTEGER objects with a header and len byte */
-    static const unsigned INT_HDR = 2U;
-    /* R and S are combined in a SEQUENCE object with a header and len byte */
-    static const unsigned SEQ_HDR = 2U;
-    /* an R or S with a high bit set needs an extra nul byte so it's not negative (twos comp)*/
-    static const unsigned EXTRA = 1U;
-
-    unsigned tmp = ((keysize + INT_HDR + EXTRA) * 2); /* x2 1 for R and 1 for S */
-
-    tmp += SEQ_HDR;
-
-    *signature_len = tmp;
-
-    return CKR_OK;
-}
-
-/*XXX Perhaps create a mechanism checking interface so we can get all
- * this scattered mechanism logic to a single spot.
- */
-static bool is_hashing_needed(CK_MECHANISM_TYPE mech) {
-
-   switch(mech) {
-     case CKM_SHA1_RSA_PKCS:
-     case CKM_SHA256_RSA_PKCS:
-     case CKM_SHA384_RSA_PKCS:
-     case CKM_SHA512_RSA_PKCS:
-     case CKM_SHA1_RSA_PKCS_PSS:
-     case CKM_SHA256_RSA_PKCS_PSS:
-     case CKM_SHA384_RSA_PKCS_PSS:
-     case CKM_SHA512_RSA_PKCS_PSS:
-     case CKM_ECDSA_SHA1:
-         return true;
-     case CKM_ECDSA:
-     case CKM_RSA_X_509:
-     case CKM_RSA_PKCS:
-     case CKM_RSA_PKCS_PSS:
-         return false;
-    default:
-        LOGW("Unknown mech: %lu", mech);
-    }
-
-    return false;
 }
 
 static CK_RV common_init(operation op, session_ctx *ctx, CK_MECHANISM_PTR mechanism, CK_OBJECT_HANDLE key) {
@@ -159,15 +68,19 @@ static CK_RV common_init(operation op, session_ctx *ctx, CK_MECHANISM_PTR mechan
         return rv;
     }
 
-    rv = object_mech_is_supported(tobj, mechanism);
+    rv = mech_validate(tok->tctx, mechanism, tobj->attrs);
     if (rv != CKR_OK) {
         return rv;
     }
 
     digest_op_data *digest_opdata = NULL;
-    bool do_hash = is_hashing_needed(mechanism->mechanism);
+    bool is_hashing_needed = false;
+    rv = mech_is_hashing_needed(mechanism, &is_hashing_needed);
+    if (rv != CKR_OK) {
+        return rv;
+    }
 
-    if (do_hash) {
+    if (is_hashing_needed) {
 
         digest_opdata = digest_op_data_new();
         if (!digest_opdata) {
@@ -181,14 +94,29 @@ static CK_RV common_init(operation op, session_ctx *ctx, CK_MECHANISM_PTR mechan
         }
     }
 
+    tpm_op_data *tpm_opdata;
+    rv = mech_get_tpm_opdata(tok->tctx, mechanism, tobj, &tpm_opdata);
+    if (rv != CKR_OK) {
+        tpm_opdata_free(&tpm_opdata);
+        return rv;
+    }
+
     sign_opdata *opdata = sign_opdata_new();
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
 
-    opdata->do_hash = do_hash;
+    opdata->do_hash = is_hashing_needed;
     memcpy(&opdata->mech, mechanism, sizeof(opdata->mech));
     opdata->digest_opdata = digest_opdata;
+
+    opdata->crypto_opdata = encrypt_op_data_new(tobj);
+    if (!opdata->crypto_opdata) {
+        sign_opdata_free(&opdata);
+        return CKR_HOST_MEMORY;
+    }
+
+    opdata->crypto_opdata->cryptopdata.tpm_opdata = tpm_opdata;
 
     /*
      * Store everything for later
@@ -241,112 +169,6 @@ CK_RV sign_update(session_ctx *ctx, CK_BYTE_PTR part, CK_ULONG part_len) {
     return common_update(operation_sign, ctx, part, part_len);
 }
 
-static CK_RV pkcs1_5_build_struct(CK_MECHANISM_TYPE mech,
-        CK_BYTE_PTR hash, CK_ULONG hash_len,
-        char **built, size_t *built_len) {
-
-    /* These headers are defined in the following RFC
-     *   - https://www.ietf.org/rfc/rfc3447.txt
-     *     - Page 42
-     */
-    static const CK_BYTE pkcs1_5_hdr_sha1[15] = {
-        0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a,
-        0x05, 0x00, 0x04, 0x14,
-    };
-
-    static const CK_BYTE pkcs1_5_hdr_sha256[19] = {
-        0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
-        0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
-    };
-
-    static const CK_BYTE pkcs1_5_hdr_sha384[19] = {
-        0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
-        0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30,
-    };
-
-    static const CK_BYTE pkcs1_5_hdr_sha512[19] = {
-        0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
-        0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40,
-    };
-
-    const CK_BYTE *hdr;
-    size_t hdr_size;
-
-    switch(mech) {
-    case CKM_SHA1_RSA_PKCS:
-        hdr = pkcs1_5_hdr_sha1;
-        hdr_size = sizeof(pkcs1_5_hdr_sha1);
-        break;
-    case CKM_SHA256_RSA_PKCS:
-        hdr = pkcs1_5_hdr_sha256;
-        hdr_size = sizeof(pkcs1_5_hdr_sha256);
-        break;
-    case CKM_SHA384_RSA_PKCS:
-        hdr = pkcs1_5_hdr_sha384;
-        hdr_size = sizeof(pkcs1_5_hdr_sha384);
-        break;
-    case CKM_SHA512_RSA_PKCS:
-        hdr = pkcs1_5_hdr_sha512;
-        hdr_size = sizeof(pkcs1_5_hdr_sha512);
-        break;
-    default:
-        return CKR_MECHANISM_INVALID;
-    }
-
-    /*
-     * Build and populate a buffer with hdr + hash
-     */
-    char *b = calloc(1, hdr_size + hash_len);
-    if (!b) {
-        return CKR_HOST_MEMORY;
-    }
-
-    memcpy(b, hdr, hdr_size);
-    memcpy(&b[hdr_size], hash, hash_len);
-
-    *built_len = hdr_size + hash_len;
-    *built = b;
-
-    return CKR_OK;
-}
-
-static CK_RV apply_pkcs_1_5_pad(tobject *tobj, char *built, size_t built_len, char **padded, size_t *padded_len) {
-
-    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_MODULUS_BITS);
-    if (!a) {
-        LOGE("Signing key has no CKA_MODULUS_BITS");
-        return CKR_GENERAL_ERROR;
-    }
-
-    if (a->ulValueLen != sizeof(CK_ULONG)) {
-        LOGE("Modulus bit pointer data not size of CK_ULONG, got %lu, expected %zu",
-                a->ulValueLen, sizeof(CK_ULONG));
-        return CKR_GENERAL_ERROR;
-    }
-
-    CK_ULONG_PTR keybits = (CK_ULONG_PTR)a->pValue;
-
-    size_t out_len = *keybits / 8;
-
-    char *out = malloc(out_len);
-    if (!out) {
-        LOGE("oom");
-        return CKR_HOST_MEMORY;
-    }
-
-    /* Apply the PKCS1.5 padding */
-    int rc = RSA_padding_add_PKCS1_type_1((CK_BYTE_PTR )out, out_len,
-            (const CK_BYTE_PTR )built, built_len);
-    if (!rc) {
-        LOGE("Applying RSA padding failed");
-    }
-
-    *padded = out;
-    *padded_len = out_len;
-
-    return CKR_OK;
-}
-
 CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signature_len, bool is_oneshot) {
 
     check_pointer(signature_len);
@@ -354,9 +176,6 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
     bool reset_ctx = false;
 
     CK_RV rv = CKR_GENERAL_ERROR;
-
-    CK_BYTE_PTR hash = NULL;
-    CK_ULONG hash_len = 0;
 
     sign_opdata *opdata = NULL;
     rv = session_ctx_opdata_get(ctx, operation_sign, &opdata);
@@ -373,105 +192,76 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
     token *tok = session_ctx_get_token(ctx);
     assert(tok);
 
-    tpm_ctx *tpm = tok->tctx;
-
     tobject *tobj = session_ctx_opdata_get_tobject(ctx);
     assert(tobj);
 
+    twist digest_buf = NULL;
+
+    size_t tmp_len = 0;
+    rv = tobject_get_max_buf_size(tobj, &tmp_len);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    if (!signature) {
+        *signature_len = tmp_len;
+        goto out;
+    }
+
+    if (*signature_len < tmp_len) {
+        *signature_len = tmp_len;
+        rv = CKR_BUFFER_TOO_SMALL;
+        goto out;
+    }
+
     if (opdata->do_hash) {
 
-        hash_len = utils_get_halg_size(opdata->mech.mechanism);
+        size_t hash_len = utils_get_halg_size(opdata->mech.mechanism);
         if (!hash_len) {
             LOGE("Hash algorithm cannot have 0 size");
             return CKR_GENERAL_ERROR;
         }
-        hash = malloc(hash_len);
-        if (!hash) {
+        digest_buf = twist_calloc(hash_len);
+        if (!digest_buf) {
             LOGE("oom");
             rv = CKR_HOST_MEMORY;
             goto session_out;
         }
 
-        rv = digest_final_op(ctx, opdata->digest_opdata, hash, &hash_len);
+        rv = digest_final_op(ctx, opdata->digest_opdata, (CK_BYTE_PTR)digest_buf, &hash_len);
         if (rv != CKR_OK) {
             goto session_out;
         }
+    } else {
+        digest_buf = opdata->buffer;
+        /* we take ownership of this buffer */
+        opdata->buffer = NULL;
     }
 
-    /*
-     * Their are two cases when we need to use the raw RSA Decrypt to sign the signature:
-     *
-     * CASE 1
-     * In the case of CKM_RSA_PKCS the raw DigestInfo structure has been done off-card, just perform
-     * a an RSA PKCS1.5 padded private-key encryption formally known as RSA decrypt.
-     *
-     * CASE 2
-     * This method should also be used if the TPM doesn't support the hash algorithm, ie hash off card,
-     * build digest info ASN1 structure, apply padding and RSA_Decrypt() AND the signing structure
-     * is PKCS1.5
-     */
+    CK_BYTE syn_buf[4096];
+    CK_ULONG syn_buf_len = sizeof(syn_buf);
+    CK_ULONG digest_buf_len = twist_len(digest_buf);
 
-    bool is_raw_sign = utils_mech_is_raw_sign(opdata->mech.mechanism);
-    bool is_pkcs1_5 = utils_mech_is_rsa_pkcs(opdata->mech.mechanism);
+    rv = mech_synthesize(tok->tctx,
+            &opdata->mech, tobj->attrs,
+            (CK_BYTE_PTR)digest_buf, digest_buf_len,
+            syn_buf, &syn_buf_len);
+    if (rv != CKR_OK) {
+        goto session_out;
+    }
 
-    if (is_raw_sign || (is_pkcs1_5 && opdata->do_hash)) {
+    bool is_synthetic = false;
+    rv = mech_is_synthetic(tok->tctx, &opdata->mech,
+            &is_synthetic);
+    if (rv != CKR_OK) {
+        goto session_out;
+    }
 
-        char *built = NULL;
-        size_t built_len = 0;
-
-        if(opdata->do_hash) {
-            /*
-             * Ok we did the hash, AND because of the entry condition, it's a SW hash, as is_raw_sign
-             * means we didn't do the hashing. In this case, hash and hash_len should be set with
-             * the digest.
-             */
-            assert(hash);
-            assert(hash_len);
-            assert(!opdata->buffer);
-
-            rv = pkcs1_5_build_struct(opdata->mech.mechanism, hash, hash_len, &built, &built_len);
-            if (rv != CKR_OK) {
-                goto session_out;
-            }
-
-        } else {
-
-            /*
-             * We just use the appended buffer, but make a copy to make the free logic easier.
-             */
-            assert(!hash);
-            assert(!hash_len);
-            assert(opdata->buffer);
-
-            built = malloc(twist_len(opdata->buffer));
-            if (!built) {
-                goto session_out;
-            }
-            built_len = twist_len(opdata->buffer);
-            memcpy(built, opdata->buffer, built_len);
-        }
-
-        char *padded = NULL;
-        size_t padded_len = 0;
-
-        if (is_pkcs1_5) {
-            /* apply padding */
-            rv = apply_pkcs_1_5_pad(tobj, built, built_len, &padded, &padded_len);
-            free(built);
-            if (rv != CKR_OK) {
-                goto session_out;
-            }
-        } else {
-            padded = built;
-            padded_len = built_len;
-            built = NULL;
-            built_len = 0;
-        }
+    if (is_synthetic) {
 
         /* sign padded pkcs 1.5 structure */
         encrypt_op_data *encrypt_opdata = encrypt_op_data_new(tobj);
         if (!encrypt_opdata) {
-            free(padded);
             rv = CKR_HOST_MEMORY;
             goto session_out;
         }
@@ -484,13 +274,11 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
         /* RSA Decrypt is the RSA operation with the private key, which is what we want */
         rv = decrypt_init_op(ctx, encrypt_opdata, &mechanism, tobj->obj_handle);
         if (rv != CKR_OK) {
-            free(padded);
             encrypt_op_data_free(&encrypt_opdata);
             goto session_out;
         }
 
-        rv = decrypt_oneshot_op(ctx, encrypt_opdata, (CK_BYTE_PTR)padded, padded_len, signature, signature_len);
-        free(padded);
+        rv = decrypt_oneshot_op(ctx, encrypt_opdata, syn_buf, syn_buf_len, signature, signature_len);
         encrypt_op_data_free(&encrypt_opdata);
         if (rv != CKR_OK && rv != CKR_BUFFER_TOO_SMALL) {
             goto session_out;
@@ -509,39 +297,16 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
             goto session_out;
         }
     } else {
-
-        /*
-         * CKM_ECDSA is never considered a "raw sign" since the TPM natively supports it
-         * by setting the hashalg to TPM2_ALG_NULL. So just make sure that we propagate
-         * the raw data provided (hash) into the hash variable and perform a sign.
-         */
-        if (opdata->mech.mechanism == CKM_ECDSA ||
-                opdata->mech.mechanism == CKM_RSA_PKCS_PSS){
-            assert(!hash);
-            assert(!hash_len);
-            assert(opdata->buffer);
-            hash_len = twist_len(opdata->buffer);
-            assert(hash_len >= 20); /* Minimum for SHA1 */
-            hash = malloc(hash_len);
-            if (!hash) {
-                LOGE("oom");
-                rv = CKR_HOST_MEMORY;
-                goto session_out;
-            }
-
-            memcpy(hash, opdata->buffer, hash_len);
-        }
-
-        assert(hash);
-        assert(hash_len);
-        rv = tpm_sign(tpm, tobj, &opdata->mech, hash, hash_len, signature, signature_len);
+        rv = tpm_sign(opdata->crypto_opdata->cryptopdata.tpm_opdata,
+                syn_buf, syn_buf_len, signature, signature_len);
         if (rv != CKR_OK && rv != CKR_BUFFER_TOO_SMALL) {
             goto session_out;
         }
     }
 
+out:
     /*
-     * Detect 1 of 3 states:
+     * Detect 1 of 2 states:
      *   - 1 - everything is ok from enc/sign and sig is set (continue normally)
      *   - 2 - buffer too small from enc/sign and sig is set (reset hashing state and keep sign operation alive)
      *   - 3 - everything is ok but sig is NULL, handle like state 2.
@@ -550,14 +315,6 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
      */
     reset_ctx = (rv == CKR_BUFFER_TOO_SMALL || !signature);
     if (reset_ctx) {
-        /* ec signature size is not stable between calls, fix it up */
-        CK_RV tmp; /* we must not overwrite rv */
-        tmp = ec_fixup_size(opdata->mech.mechanism, tobj, signature_len);
-        if (tmp != CKR_OK) {
-            reset_ctx = false;
-            goto session_out;
-        }
-
         if (opdata->do_hash) {
             /* reset the hashing state */
             digest_op_data *new_digest_state = digest_op_data_new();
@@ -569,7 +326,7 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
 
             assert(opdata->digest_opdata);
 
-            tmp = digest_init_op(ctx, new_digest_state, opdata->digest_opdata->mechanism);
+            CK_RV tmp = digest_init_op(ctx, new_digest_state, opdata->digest_opdata->mechanism);
             if (tmp != CKR_OK) {
                 digest_op_data_free(&new_digest_state);
                 reset_ctx = false;
@@ -589,7 +346,7 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
     }
 
 session_out:
-
+    twist_free(digest_buf);
     assert(tobj);
     if (!reset_ctx) {
         tobj->is_authenticated = false;
@@ -597,13 +354,10 @@ session_out:
         if (tmp_rv != CKR_OK && rv == CKR_OK) {
             rv = tmp_rv;
         }
-    }
 
-    if (!reset_ctx) {
+        encrypt_op_data_free(&opdata->crypto_opdata);
         session_ctx_opdata_clear(ctx);
     }
-
-    free(hash);
 
     return rv;
 }
@@ -648,11 +402,6 @@ CK_RV verify_final (session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG signature_
     tobject *tobj = session_ctx_opdata_get_tobject(ctx);
     assert(tobj);
 
-    token *tok = session_ctx_get_token(ctx);
-    assert(tok);
-
-    tpm_ctx *tpm = tok->tctx;
-
     // TODO mode to buffer size
     CK_BYTE hash[1024];
     CK_ULONG hash_len = sizeof(hash);
@@ -674,7 +423,8 @@ CK_RV verify_final (session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG signature_
         memcpy(hash, opdata->buffer, datalen);
     }
 
-    rv = tpm_verify(tpm, tobj, &opdata->mech, hash, hash_len, signature, signature_len);
+    rv = tpm_verify(opdata->crypto_opdata->cryptopdata.tpm_opdata,
+            hash, hash_len, signature, signature_len);
 
 out:
     assert(tobj);
@@ -683,6 +433,8 @@ out:
     if (tmp_rv != CKR_OK && rv == CKR_OK) {
         rv = tmp_rv;
     }
+
+    encrypt_op_data_free(&opdata->crypto_opdata);
 
     session_ctx_opdata_clear(ctx);
 

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -5,6 +5,7 @@
 
 #include "checks.h"
 #include "db.h"
+#include "mech.h"
 #include "pkcs11.h"
 #include "slot.h"
 #include "token.h"
@@ -139,7 +140,7 @@ CK_RV slot_mechanism_list_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE *mechanism_
     }
 
     token_lock(t);
-    CK_RV rv = token_get_mechanism_list(t, mechanism_list, count);
+    CK_RV rv = mech_get_supported(t->tctx, mechanism_list, count);
     token_unlock(t);
     return rv;
 }
@@ -156,7 +157,7 @@ CK_RV slot_mechanism_info_get (CK_SLOT_ID slot_id, CK_MECHANISM_TYPE type, CK_ME
     token_lock(t);
 
     /* tpm builds and maintains cache */
-    CK_RV rv = tpm_get_mech_info(t->tctx, type, info);
+    CK_RV rv = mech_get_info(t->tctx, type, info);
     if (rv != CKR_OK) {
         token_unlock(t);
         return rv;

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -7,10 +7,6 @@
 #include <string.h>
 #include <time.h>
 
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <openssl/sha.h>
-
 #include "attrs.h"
 #include "checks.h"
 #include "db.h"
@@ -773,37 +769,4 @@ CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj)
 
     *loaded_tobj = tobj;
     return CKR_OK;
-}
-
-CK_RV token_get_mechanism_list(token *t, CK_MECHANISM_TYPE_PTR mechanism_list, CK_ULONG_PTR count) {
-
-    check_pointer(count);
-
-    /* build a cache of mechanisms */
-    static bool is_mech_list_initialized = false;
-    static CK_MECHANISM_TYPE mech_list_cache[64];
-    static CK_ULONG mech_cache_len = ARRAY_LEN(mech_list_cache);
-    if (!is_mech_list_initialized) {
-        CK_RV rv = tpm2_getmechanisms(t->tctx, mech_list_cache, &mech_cache_len);
-        if (rv != CKR_OK) {
-            return rv;
-        }
-        is_mech_list_initialized = true;
-    }
-
-    if (mechanism_list) {
-
-        if (*count < mech_cache_len) {
-            *count = mech_cache_len;
-            return CKR_BUFFER_TOO_SMALL;
-        }
-
-        memcpy(mechanism_list, mech_list_cache,
-                ARRAY_BYTES(mech_cache_len, mech_list_cache));
-    }
-
-    *count = mech_cache_len;
-
-    return CKR_OK;
-
 }

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -152,19 +152,6 @@ void token_unlock(token *t);
  */
 CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 
-/**
- * Retrieves the supported mechanism list for the token.
- * @param t
- *  The token to query.
- * @param mechanism_list
- *  The mechanism list to populate.
- * @param count
- *  The length of the mechanism_list, which is set to the actual length on return.
- * @return
- *  CKR_* status codes.
- */
-CK_RV token_get_mechanism_list(token *t, CK_MECHANISM_TYPE_PTR mechanism_list, CK_ULONG_PTR count);
-
 CK_RV token_min_init(token *t);
 
 CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label);

--- a/src/lib/typed_memory.c
+++ b/src/lib/typed_memory.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+#include "config.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -70,9 +71,10 @@ CK_RV type_mem_dup(void *in, size_t len, void **dup) {
 
     *dup = buf;
 
+#ifndef NDEBUG
     CK_BYTE check = type_from_ptr(buf, len);
     assert(check == type);
-
+#endif
     return CKR_OK;
 }
 
@@ -81,7 +83,9 @@ void type_mem_cpy(void *dest, void *in, size_t size) {
     assert(dest);
     assert(size);
     memcpy(dest, in, size + 1);
+#ifndef NDEBUG
     CK_BYTE check = type_from_ptr(in, size);
     CK_BYTE got = type_from_ptr(dest, size);
     assert(check == got);
+#endif
 }

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -353,36 +353,6 @@ size_t utils_get_halg_size(CK_MECHANISM_TYPE mttype) {
     return 0;
 }
 
-bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech) {
-
-    switch(mech) {
-    case CKM_RSA_PKCS:
-        /* falls-thru */
-    case CKM_RSA_X_509:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool utils_mech_is_rsa_pkcs(CK_MECHANISM_TYPE mech) {
-
-    switch(mech) {
-    case CKM_RSA_PKCS:
-        /* falls-thru*/
-    case CKM_SHA1_RSA_PKCS:
-        /* falls-thru*/
-    case CKM_SHA256_RSA_PKCS:
-        /* falls-thru*/
-    case CKM_SHA384_RSA_PKCS:
-        /* falls-thru*/
-    case CKM_SHA512_RSA_PKCS:
-        return true;
-    default:
-        return false;
-    }
-}
-
 twist utils_get_rand_hex_str(size_t size) {
 
     if (size == 0) {
@@ -439,70 +409,6 @@ CK_RV utils_ctx_wrap_objauth(token *tok, twist data, twist *wrapped_auth) {
     }
 
     *wrapped_auth = wrapped;
-
-    return CKR_OK;
-}
-
-CK_RV generic_attr_copy(CK_ATTRIBUTE_PTR in, CK_ULONG count, void *udata) {
-    CK_ATTRIBUTE_PTR out = &((CK_ATTRIBUTE_PTR)udata)[count];
-
-
-    void *newval = NULL;
-
-    if (in->pValue) {
-        newval = calloc(1, in->ulValueLen);
-        if (!newval) {
-            return CKR_HOST_MEMORY;
-        }
-        memcpy(newval, in->pValue, in->ulValueLen);
-    }
-
-    out->ulValueLen = in->ulValueLen;
-    out->type = in->type;
-    out->pValue = newval;
-
-    return CKR_OK;
-}
-CK_RV fake_ec_param_copy(CK_ATTRIBUTE_PTR in, CK_ULONG count, void *udata) {
-    CK_ATTRIBUTE_PTR out = &((CK_ATTRIBUTE_PTR)udata)[count];
-
-
-    void *newval = NULL;
-    unsigned char fake_oid[] = { 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07 };
-
-
-    if (in->pValue) {
-        newval = calloc(1, 10);
-        if (!newval) {
-            return CKR_HOST_MEMORY;
-        }
-        memcpy(newval, fake_oid, 10);
-    }
-
-    out->ulValueLen = 10;
-    out->type = in->type;
-    out->pValue = newval;
-
-    return CKR_OK;
-}
-
-CK_RV generic_mech_copy(CK_MECHANISM_PTR in, CK_ULONG count, void *udata) {
-    CK_MECHANISM_PTR out = &((CK_MECHANISM_PTR)udata)[count];
-
-
-    void *newval = NULL;
-
-    if (in->pParameter) {
-        newval = calloc(1, in->ulParameterLen);
-        if (!newval) {
-            return CKR_HOST_MEMORY;
-        }
-        memcpy(newval, in->pParameter, in->ulParameterLen);
-    }
-
-    out->ulParameterLen = in->ulParameterLen;
-    out->mechanism = in->mechanism;
-    out->pParameter = newval;
 
     return CKR_OK;
 }

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -22,6 +22,15 @@
 
 #define UNUSED(x) (void)x
 
+#define SAFE_CAST(m, r) \
+    do { \
+        if (!m->pParameter || m->ulParameterLen != sizeof(typeof(*r))) { \
+            return CKR_MECHANISM_PARAM_INVALID; \
+        } \
+        \
+        r = (typeof(r))m->pParameter; \
+    } while (0)
+
 #define goto_error_false(r) if(!r) { goto error; }
 
 int str_to_ul(const char *val, size_t *res);

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -56,27 +56,6 @@ twist aes256_gcm_encrypt(twist keybin, twist plaintextbin);
 size_t utils_get_halg_size(CK_MECHANISM_TYPE mttype);
 
 /**
- * True if a mechanism is a "raw" sign. A raw signing operation
- * is defined as a signing structure constructed by the application,
- * for instance mechanism type CKM_RSA_PKCS.
- * @param mech
- *  The mechanism to check.
- * @return
- *  True if it is a raw signature, else it isn't.
- */
-bool utils_mech_is_raw_sign(CK_MECHANISM_TYPE mech);
-
-/**
- * True if the mechanism is an RSA PKCS v1.5 signing
- * scheme.
- * @param mech
- *  The mechanism to check
- * @return
- *  True if it is, false otherwise.
- */
-bool utils_mech_is_rsa_pkcs(CK_MECHANISM_TYPE mech);
-
-/**
  *
  * @param size
  * @return

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -119,7 +119,7 @@ void test_get_mechanism_info_good(void **state) {
     /* Test all other mechanisms */
     CK_ULONG aes_mechs[] = {
         CKM_AES_CBC,
-        CKM_AES_CFB1,
+        CKM_AES_CFB128,
         CKM_AES_ECB,
     };
     for (size_t i = 0; i < ARRAY_LEN(aes_mechs); i++) {
@@ -128,7 +128,7 @@ void test_get_mechanism_info_good(void **state) {
 
         assert_int_equal(mech_info.ulMinKeySize, 128/8);
         assert_int_equal(mech_info.ulMaxKeySize, 256/8);
-        assert_int_equal(mech_info.flags, CKF_HW);
+        assert_int_equal(mech_info.flags, CKF_ENCRYPT|CKF_DECRYPT|CKF_HW);
     }
 
     struct {
@@ -142,7 +142,7 @@ void test_get_mechanism_info_good(void **state) {
         { CKM_SHA1_RSA_PKCS,         CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
         { CKM_SHA256_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
         { CKM_SHA384_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
-        { CKM_SHA512_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
+        { CKM_SHA512_RSA_PKCS,                CKF_SIGN    | CKF_VERIFY                          },
     };
     for (size_t i = 0; i < ARRAY_LEN(rsa_mechs); i++) {
         rv = C_GetMechanismInfo(slot_id, rsa_mechs[i].mech, &mech_info);

--- a/test/integration/pkcs-sign-verify.int.c
+++ b/test/integration/pkcs-sign-verify.int.c
@@ -406,7 +406,7 @@ static void test_sign_verify_CKM_ECDSA(void **state) {
         0x67, 0x58, 0xae, 0x5a, 0xa3, 0x2e, 0x47, 0x0d
     };
 
-    CK_ULONG siglen;
+    CK_ULONG siglen = 0;
 
     /* Call C_Sign for size */
     rv = C_Sign(session, sha256_msg_hash, sizeof(sha256_msg_hash), NULL,


### PR DESCRIPTION
Mechanisms have long been a sore point. The multiple switches and locations that had to make decisions on CKM_* values meant that adding in new algorithms as folks needed support was quite difficult. Move away from a decentralized chaotic mess and into a common table handler, much like the attribute code. While the table and idoms aren't as clean as I hoped for, it's a vast improvement in reducing CKM_ calls.

TODO: Utils needs some more house keeping.

Fixes: #404 