### PR TITLE
test/pkcs-get-mechanism: re-add CFK_HW to CKM_SHA512_RSA_PKCS flags

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -33,7 +33,7 @@ in known package managers are likely too old.
 
 ### Optional Dependencies for Enabling Testing
 1. [CMocka](https://cmocka.org/)
-2. [TPM2.0 Simulator v194](https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download): **Tested with version 1119**
+2. [TPM 2.0 Simulator](https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1563.tar.gz/download): **Tested with version 1563**
 4. [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd)
 5. Dependencies for [tpm2-ptool](# Optional Dependencies for tpm2_ptool)
 

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -142,7 +142,7 @@ void test_get_mechanism_info_good(void **state) {
         { CKM_SHA1_RSA_PKCS,         CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
         { CKM_SHA256_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
         { CKM_SHA384_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
-        { CKM_SHA512_RSA_PKCS,                CKF_SIGN    | CKF_VERIFY                          },
+        { CKM_SHA512_RSA_PKCS,       CKF_HW | CKF_SIGN    | CKF_VERIFY                          },
     };
     for (size_t i = 0; i < ARRAY_LEN(rsa_mechs); i++) {
         rv = C_GetMechanismInfo(slot_id, rsa_mechs[i].mech, &mech_info);


### PR DESCRIPTION
SHA-512 is supported by the IBM TPM simulator since version 1332, update the CI build environment instead, see tpm2-software/tpm2-software-container#26, to make the test pass.