### PR TITLE
test/pkcs11-dbup: clone from GitHub project repository

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,7 @@ AM_TESTS_ENVIRONMENT = \
     PATH=$(abs_top_srcdir)/tools:./src:$(PATH) \
     PYTHONPATH=$(abs_top_srcdir)/tools \
     TEST_JAVA_ROOT=$(JAVAROOT) \
-    T=$(abs_top_srcdir) \
+    PACKAGE_URL=$(PACKAGE_URL) \
     dbus-run-session
 
 TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(p11lib_LTLIBRARIES) $(AM_LDFLAGS) $(CMOCKA_LIBS) $(CRYPTO_LIBS)

--- a/test/integration/pkcs11-dbup.sh.nosetup
+++ b/test/integration/pkcs11-dbup.sh.nosetup
@@ -40,13 +40,14 @@ setup_asan()
 # we need to clone and build v1.0 and test HEAD (current built)
 # against it in the tempdir.
 #
-echo "T=$T"
-
 pushd "$tempdir"
 
-git clone $(realpath $T)
+if ! git clone --branch 1.0 --depth 1 "$PACKAGE_URL" tpm2-pkcs11; then
+    echo "Could not clone project repository '$PACKAGE_URL'"
+    exit 77
+fi
+
 pushd tpm2-pkcs11
-git checkout 1.0
 ./bootstrap
 ./configure --enable-debug --disable-hardening
 make -j$(nproc)


### PR DESCRIPTION
This works even if running the test suite from a release tarball. If cloning fails e.g. because the software is build without internet access, skip the test instead of failing the test suite.

Fixes: #410