### PR TITLE
FAPI backend

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -6,7 +6,7 @@ function get_deps() {
 	# The list order is important and thus we can't use the keys of the dictionary as order is not preserved.
 	local github_deps=("tpm2-tss" "tpm2-abrmd" "tpm2-tools")
 	declare -A local config_flags=( ["tpm2-tss"]="--disable-doxygen-doc --enable-debug" ["tpm2-abrmd"]="--enable-debug" ["tpm2-tools"]="--disable-hardening --enable-debug")
-	declare -A local versions=( ["tpm2-tss"]="2.3.0" ["tpm2-abrmd"]="2.3.0" ["tpm2-tools"]="4.0.1")
+	declare -A local versions=( ["tpm2-tss"]="master" ["tpm2-abrmd"]="2.1.0" ["tpm2-tools"]="master")
 
 	echo "pwd starting: `pwd`"
 	pushd "$1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 # only one build should report coverage stats
 matrix:
   include:
-  - env: ENABLE_COVERAGE=true DOCKER_TAG=ubuntu-16.04
+  - env: ENABLE_COVERAGE=true DOCKER_TAG=ubuntu-18.04
     compiler: gcc
 
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,11 +5,11 @@ ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
                   $(TSS2_ESYS_CFLAGS) $(TSS2_MU_CFLAGS) $(TSS2_TCTILDR_CFLAGS) \
 		  $(TSS2_RC_CFLAGS) $(SQLITE3_CFLAGS) $(PTHREAD_CFLAGS) \
-		  $(CRYPTO_CFLAGS) $(YAML_CFLAGS)
+		  $(CRYPTO_CFLAGS) $(YAML_CFLAGS) $(TSS2_FAPI_CFLAGS)
 
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS) $(TSS2_ESYS_LIBS) \
                   $(TSS2_MU_LIBS) $(TSS2_TCTILDR_LIBS) $(TSS2_RC_LIBS) \
-		  $(SQLITE3_LIBS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(YAML_LIBS)
+		  $(SQLITE3_LIBS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(YAML_LIBS) $(TSS2_FAPI_LIBS)
 
 check-programs: $(check_PROGRAMS)
 
@@ -133,6 +133,15 @@ check_PROGRAMS += \
 
 # add test scripts
 check_SCRIPTS += $(integration_scripts)
+
+#Cannot be part of $(integration_scripts) since its not EXTRA_DIST
+check_SCRIPTS += test/integration/pkcs11-tool-init-fapi.sh.nosetup
+
+test/integration/pkcs11-tool-init-fapi.sh.nosetup: test/integration/pkcs11-tool-init.sh.nosetup
+	$(AM_V_GEN)(echo "#!/usr/bin/env bash"; echo "export FAPI_PREVIEW=true"; cat $^)>$@ \
+		&& chmod +x "$@"
+
+CLEANFILES += test/integration/pkcs11-tool-init-fapi.sh.nosetup
 
 LOG_COMPILER = $(srcdir)/test/integration/scripts/int-test-setup.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,10 @@ AC_DEFUN([do_esapi_manage_flags], [
 # Check for ESYS version below 2.2.1 which requires us to manage ESYS session flags
 PKG_CHECK_EXISTS([tss2-esys < 2.2.1], [do_esapi_manage_flags])
 
+# ESYS >= 3.0 uses a different ABI param hierarchy in Esys_LoadExternal()
+PKG_CHECK_EXISTS([tss2-esys >= 3.0],
+                 [AC_DEFINE([ESYS_3], [1], [Esys3])])
+
 # require sqlite3 and libcrypto
 PKG_CHECK_MODULES([SQLITE3],     [sqlite3])
 PKG_CHECK_MODULES([YAML],        [yaml-0.1])

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ AC_CONFIG_FILES([Makefile lib/tpm2-pkcs11.pc])
 AC_CONFIG_HEADERS([src/lib/config.h])
 
 # test for TSS dependecies
+PKG_CHECK_MODULES([TSS2_FAPI],   [tss2-fapi])
 PKG_CHECK_MODULES([TSS2_ESYS],   [tss2-esys >= 2.0])
 PKG_CHECK_MODULES([TSS2_MU],     [tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include "config.h"
+#include "backend.h"
+#include "backend_esysdb.h"
+
+/* This file includes the logic for selecting, aggregating and
+ * distributing calls to different backends.
+ * For now this will only be the esysdb backend that uses tss2-esys
+ * and sqlite3 for operations.
+ * In the future, logic will be added to also inlcude the tss2-fapi
+ * library for storage and TPM interaction.
+ */
+
+CK_RV backend_init(void) {
+    return backend_esysdb_init();
+}
+
+CK_RV backend_destroy(void) {
+    return backend_esysdb_destroy();
+}
+
+/** Create a new token
+ *
+ * Create a new sealed object and store it in the data store.
+ *
+ * @param[in,out] t The token information on input and generated token
+ *                  on output.
+ * @param[in] hexwrappingkey TODO
+ * @param[in] newauth The authorization value for the security operator
+ *                    of the newly created token.
+ * @param[in] newsalthex TODO
+ * @returns TODO
+ */
+CK_RV backend_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex) {
+    return backend_esysdb_create_token_seal(t, hexwrappingkey, newauth, newsalthex);
+}
+
+/** Retrieve the all tokens available.
+ *
+ * The returned list is a set of all stored tokens with all
+ * objects inside the token structure.
+ * @param[out] tok The list of tokens.
+ * @param[out] len The number of entries in tok.
+ * @returns TODO
+ */
+CK_RV backend_get_tokens(token **tok, size_t *len) {
+    return backend_esysdb_get_tokens(tok, len);
+}

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "backend.h"
 #include "backend_esysdb.h"
+#include "backend_fapi.h"
 
 /* This file includes the logic for selecting, aggregating and
  * distributing calls to different backends.
@@ -13,11 +14,32 @@
  */
 
 CK_RV backend_init(void) {
-    return backend_esysdb_init();
+    LOGV("Initializing backends");
+    CK_RV rv = backend_fapi_init();
+    if (rv)
+        return rv;
+    rv = backend_esysdb_init();
+    if (rv)
+        backend_fapi_destroy();
+    return rv;
 }
 
 CK_RV backend_destroy(void) {
+    LOGV("Destroying backends");
+    backend_fapi_destroy();
     return backend_esysdb_destroy();
+}
+
+CK_RV backend_ctx_new(token *t) {
+    CK_RV rv = backend_fapi_ctx_new(t);
+    if (rv)
+        return rv;
+    return backend_esysdb_ctx_new(t);
+}
+
+void backend_ctx_free(token *t) {
+    backend_fapi_ctx_free(t);
+    backend_esysdb_ctx_free(t);
 }
 
 /** Create a new token
@@ -34,10 +56,17 @@ CK_RV backend_destroy(void) {
  */
 CK_RV backend_create_token_seal(token *t, const twist hexwrappingkey,
                        const twist newauth, const twist newsalthex) {
-    return backend_esysdb_create_token_seal(t, hexwrappingkey, newauth, newsalthex);
+    const char *env = getenv("FAPI_PREVIEW");
+    if (env && (!strcmp(env, "yes") || !strcmp(env, "true"))) {
+        LOGV("Creating token under FAPI");
+        return backend_fapi_create_token_seal(t, hexwrappingkey, newauth, newsalthex);
+    } else {
+        LOGV("Creating token under ESYSDB");
+        return backend_esysdb_create_token_seal(t, hexwrappingkey, newauth, newsalthex);
+    }
 }
 
-/** Retrieve the all tokens available.
+/** Retrieve all tokens available.
  *
  * The returned list is a set of all stored tokens with all
  * objects inside the token structure.
@@ -46,5 +75,54 @@ CK_RV backend_create_token_seal(token *t, const twist hexwrappingkey,
  * @returns TODO
  */
 CK_RV backend_get_tokens(token **tok, size_t *len) {
-    return backend_esysdb_get_tokens(tok, len);
+    CK_RV rv;
+
+    /* This is used to move the empty token to the end. */
+    /* TODO: Would be better to have a nicer way of doing so. */
+    token tmp;
+
+    rv = backend_esysdb_get_tokens(tok, len);
+    if (rv) {
+        LOGE("Getting tokens from esysdb backend failed.");
+        return rv;
+    }
+    LOGV("Esysdb returned %zi token", *len);
+
+    tmp = (*tok)[*len - 1];
+    *len -= 1;
+
+    rv = backend_fapi_add_tokens(*tok, len);
+    if (rv) {
+        LOGE("Getting tokens from fapi backend failed.");
+        token_free_list(*tok, *len);
+        return rv;
+    }
+
+    (*tok)[*len] = tmp;
+    *len += 1;
+
+    LOGV("Esysdb + FAPI returned %zi token", *len);
+
+    return rv;
+}
+
+/** Initialize the user PIN data for a given token.
+ *
+ * @param[in,out] t The token to initialize user pin for.
+ * @param[in] sealdata The data to be stored inside the created seal.
+ * @param[in] newauthhex The auth value to be set of the created seal.
+ * @param[in] newsalthex The salt value to be stored for this auth.
+ * returns TODO
+ */
+CK_RV backend_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex) {
+    switch (t->type) {
+    case token_type_esysdb:
+        return backend_esysdb_init_user(t, sealdata, newauthhex, newsalthex);
+    case token_type_fapi:
+        return backend_fapi_init_user(t, sealdata, newauthhex, newsalthex);
+    default:
+        assert(1);
+        return CKR_GENERAL_ERROR;
+    }
 }

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -126,3 +126,26 @@ CK_RV backend_init_user(token *t, const twist sealdata,
         return CKR_GENERAL_ERROR;
     }
 }
+
+/** Store a new object for a given token in the backend.
+ *
+ * Note: Adding the the object to the ring buffer in the token
+ *       struct is done independantly.
+ *
+ * @param[in,out] t The token to add the object to.
+ * @param[in] tobj The object to store.
+ * @returns TODO
+ */
+CK_RV backend_add_object(token *t, tobject *tobj) {
+    switch (t->type) {
+    case token_type_esysdb:
+        LOGE("Adding object to token using esysdb backend.");
+        return backend_esysdb_add_object(t, tobj);
+    case token_type_fapi:
+        LOGE("Adding object to token using fapi backend.");
+        return backend_fapi_add_object(t, tobj);
+    default:
+        assert(1);
+        return CKR_GENERAL_ERROR;
+    }
+}

--- a/src/lib/backend.h
+++ b/src/lib/backend.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#ifndef SRC_LIB_BACKEND_H_
+#define SRC_LIB_BACKEND_H_
+
+#include "pkcs11.h"
+#include "twist.h"
+#include "token.h"
+
+#define MAX_TOKEN_CNT 255
+
+CK_RV backend_init(void);
+CK_RV backend_destroy(void);
+
+CK_RV backend_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex);
+
+CK_RV backend_get_tokens(token **tok, size_t *len);
+
+#endif /* SRC_LIB_BACKEND_H_ */

--- a/src/lib/backend.h
+++ b/src/lib/backend.h
@@ -11,9 +11,15 @@
 CK_RV backend_init(void);
 CK_RV backend_destroy(void);
 
+CK_RV backend_ctx_new(token *t);
+void backend_ctx_free(token *t);
+
 CK_RV backend_create_token_seal(token *t, const twist hexwrappingkey,
-                       const twist newauth, const twist newsalthex);
+                        const twist newauth, const twist newsalthex);
 
 CK_RV backend_get_tokens(token **tok, size_t *len);
+
+CK_RV backend_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex);
 
 #endif /* SRC_LIB_BACKEND_H_ */

--- a/src/lib/backend.h
+++ b/src/lib/backend.h
@@ -22,4 +22,6 @@ CK_RV backend_get_tokens(token **tok, size_t *len);
 CK_RV backend_init_user(token *t, const twist sealdata,
                         const twist newauthhex, const twist newsalthex);
 
+CK_RV backend_add_object(token *t, tobject *tobj);
+
 #endif /* SRC_LIB_BACKEND_H_ */

--- a/src/lib/backend_esysdb.c
+++ b/src/lib/backend_esysdb.c
@@ -206,3 +206,12 @@ out:
 
     return rv;
 }
+
+/** Store a new object for a given token in the backend.
+ *
+ * See backend_add_object()
+ */
+CK_RV backend_esysdb_add_object(token *t, tobject *tobj) {
+    LOGV("Adding object to esysdb backend");
+    return db_add_new_object(t, tobj);
+}

--- a/src/lib/backend_esysdb.c
+++ b/src/lib/backend_esysdb.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include "config.h"
+#include "backend_esysdb.h"
+#include "db.h"
+#include "tpm.h"
+
+CK_RV backend_esysdb_init(void) {
+    tpm_init();
+
+    return db_init();
+}
+
+CK_RV backend_esysdb_destroy(void) {
+    db_destroy();
+
+    tpm_destroy();
+
+    return CKR_OK;
+}
+
+static CK_RV get_or_create_primary(token *t) {
+
+    twist blob = NULL;
+
+    /* if there is no primary object ... */
+    if (t->pid) {
+        return CKR_OK;
+    }
+
+    /* is there one in the db to use ? */
+    CK_RV rv = db_get_first_pid(&t->pid);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    /* if so use it */
+    if (t->pid) {
+        /* tokens in the DB store already have an associated primary object */
+        return db_init_pobject(t->pid, &t->pobject, t->tctx);
+    }
+
+    /* is their a PC client spec key ? */
+    rv = tpm_get_existing_primary(t->tctx, &t->pobject.handle, &blob);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    /* nothing, create one */
+    if (!t->pobject.handle) {
+        rv = tpm_create_primary(t->tctx, &t->pobject.handle, &blob);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+    }
+
+    assert(t->pobject.handle);
+
+    rv = db_add_primary(blob, &t->pid);
+    assert(t->pid);
+    twist_free(blob);
+    return rv;
+}
+
+/** Create a new token in esysdb backend.
+ *
+ * See backend_create_token_seal()
+ */
+CK_RV backend_esysdb_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex) {
+
+    CK_RV rv = CKR_GENERAL_ERROR;
+
+    /*
+     * find or create a primary object and get the serialized blob
+     * for it.
+     */
+    rv = get_or_create_primary(t);
+    if (rv != CKR_OK) {
+        LOGE("Could not find nor create a primary object");
+        goto error;
+    }
+
+    /* we have a primary object, create the seal object underneath it */
+    rv = tpm2_create_seal_obj(t->tctx, t->pobject.objauth, t->pobject.handle,
+            newauth, NULL, hexwrappingkey, &t->sealobject.sopub,
+            &t->sealobject.sopriv, &t->sealobject.handle);
+    if (rv != CKR_OK) {
+        LOGE("Could not create SO seal object");
+        goto error;
+    }
+
+    t->sealobject.soauthsalt = newsalthex;
+
+    /* TODO get TCTI config from ENV var and use throughout this process */
+    t->config.is_initialized = true;
+
+    rv = db_add_token(t);
+    if (rv != CKR_OK) {
+        LOGE("Could not add token to db");
+        goto error;
+    }
+
+    assert(t->id);
+
+error:
+    return rv;
+}
+
+/** Retrieve the all tokens available.
+ *
+ * See backend_get_tokens()
+ */
+CK_RV backend_esysdb_get_tokens(token **tok, size_t *len) {
+    return db_get_tokens(tok, len);
+}

--- a/src/lib/backend_esysdb.h
+++ b/src/lib/backend_esysdb.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#ifndef SRC_LIB_BACKEND_ESYSDB_H_
+#define SRC_LIB_BACKEND_ESYSDB_H_
+
+#include "pkcs11.h"
+#include "twist.h"
+#include "token.h"
+
+CK_RV backend_esysdb_init(void);
+CK_RV backend_esysdb_destroy(void);
+
+CK_RV backend_esysdb_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex);
+
+CK_RV backend_esysdb_get_tokens(token **tok, size_t *len);
+
+#endif /* SRC_LIB_BACKEND_ESYSDB_H_ */

--- a/src/lib/backend_esysdb.h
+++ b/src/lib/backend_esysdb.h
@@ -9,9 +9,15 @@
 CK_RV backend_esysdb_init(void);
 CK_RV backend_esysdb_destroy(void);
 
+CK_RV backend_esysdb_ctx_new(token *t);
+void backend_esysdb_ctx_free(token *t);
+
 CK_RV backend_esysdb_create_token_seal(token *t, const twist hexwrappingkey,
                        const twist newauth, const twist newsalthex);
 
 CK_RV backend_esysdb_get_tokens(token **tok, size_t *len);
+
+CK_RV backend_esysdb_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex);
 
 #endif /* SRC_LIB_BACKEND_ESYSDB_H_ */

--- a/src/lib/backend_esysdb.h
+++ b/src/lib/backend_esysdb.h
@@ -20,4 +20,6 @@ CK_RV backend_esysdb_get_tokens(token **tok, size_t *len);
 CK_RV backend_esysdb_init_user(token *t, const twist sealdata,
                         const twist newauthhex, const twist newsalthex);
 
+CK_RV backend_esysdb_add_object(token *t, tobject *tobj);
+
 #endif /* SRC_LIB_BACKEND_ESYSDB_H_ */

--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -1,0 +1,379 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include "config.h"
+#include "backend_fapi.h"
+#include <tss2/tss2_fapi.h>
+
+FAPI_CONTEXT *fctx = NULL;
+
+CK_RV backend_fapi_init(void) {
+    if (fctx != NULL) {
+        LOGW("Backend FAPI already initialized.");
+        return CKR_OK;
+    }
+    LOGV("Calling Fapi_Initialize");
+    TSS2_RC rc = Fapi_Initialize(&fctx, NULL);
+    if (rc) {
+        LOGW("Could not initialize FAPI");
+        return CKR_GENERAL_ERROR;
+    }
+    return CKR_OK;
+}
+
+CK_RV backend_fapi_destroy(void) {
+    LOGV("Calling Fapi_Finalize");
+    Fapi_Finalize(&fctx);
+    return CKR_OK;
+}
+
+CK_RV backend_fapi_ctx_new(token *t) {
+    t->fapi.ctx = fctx;
+    return CKR_OK;
+}
+
+void backend_fapi_ctx_free(token *t) {
+    (void)(t);
+}
+
+
+#define PREFIX "/HS/SRK/tpm2-pkcs11-token-"
+
+static char * tss_path_from_id(unsigned id, const char *type) {
+    char *path = malloc(strlen(PREFIX) + strlen(type) + 1 + 8 + 1);
+    if (!path)
+        return NULL;
+
+    sprintf(&path[0], PREFIX "%s-%08x", type, id);
+
+    return path;
+}
+
+/** Create a new token in fapi backend.
+ *
+ * See backend_create_token_seal()
+ */
+CK_RV backend_fapi_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex) {
+    TSS2_RC rc;
+    uint8_t *tpm2bPublic, *tpm2bPrivate, *appdata;
+    size_t tpm2bPublicSize, tpm2bPrivateSize, appdata_len;
+    twist pub, priv;
+
+    char *path = tss_path_from_id(t->id, "so");
+
+    rc = Fapi_CreateSeal(t->fapi.ctx, path,
+                         NULL /*type*/, twist_len(hexwrappingkey),
+                         NULL /*policy*/, newauth, (uint8_t*)hexwrappingkey);
+    if (rc) {
+        LOGE("Creation of a FAPI seal failed.");
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    rc = Fapi_SetDescription(t->fapi.ctx, path, (char*)&t->label[0]);
+    if (rc) {
+        LOGE("Setting FAPI seal description failed.");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    appdata_len = twist_len(newsalthex) + 1;
+    appdata = malloc(appdata_len);
+    if (!appdata) {
+        LOGE("oom");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }        
+    memcpy(appdata, newsalthex, appdata_len - 1);
+    appdata[appdata_len - 1] = '\0';
+
+    rc = Fapi_SetAppData(t->fapi.ctx, path, appdata, appdata_len);
+    free(appdata);
+    if (rc) {
+        LOGE("Setting FAPI seal appdata failed.");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    rc = Fapi_GetTpmBlobs(t->fapi.ctx, path, &tpm2bPublic, &tpm2bPublicSize,
+                          &tpm2bPrivate, &tpm2bPrivateSize, NULL /* policy */);
+    free(path);
+    if (rc) {
+        LOGE("Getting the TPM data blobs failed.");
+        return CKR_GENERAL_ERROR;
+    }
+
+    pub = twistbin_new(tpm2bPublic, tpm2bPublicSize);
+    Fapi_Free(tpm2bPublic);
+    priv = twistbin_new(tpm2bPrivate, tpm2bPrivateSize);
+    Fapi_Free(tpm2bPrivate);
+    if (!pub || !priv) {
+        LOGE("Out of memory");
+        return CKR_GENERAL_ERROR;
+    }
+
+    t->sealobject.sopub = pub;
+    t->sealobject.sopriv = priv;
+    t->sealobject.soauthsalt = newsalthex;
+
+    t->type = token_type_fapi;
+
+    /* TODO get TCTI config from ENV var and use throughout this process */
+    t->config.is_initialized = true;
+
+    assert(t->id);
+
+    /* FIXME Manually setting SRK handle here */
+    t->pid = 0x81000001;
+
+    return CKR_OK;
+}
+
+/** Retrieve all fapi tokens available.
+ *
+ * See backend_get_tokens()
+ */
+CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
+    CK_RV rv = CKR_GENERAL_ERROR;
+    TSS2_RC rc;
+    char *pathlist, *path, *subpath, *strtokr_save = NULL;
+    unsigned id;
+    char *label;
+    uint8_t *tpm2bPublic, *tpm2bPrivate, *appdata;
+    size_t tpm2bPublicSize, tpm2bPrivateSize, appdata_len;
+    twist pub, priv, blob;
+    token *t;
+
+    rc = Fapi_List(fctx, "/HS/SRK", &pathlist);
+    if (rc == 0x0006000a) {
+        /* If no token seals were found, we're done here. */
+        LOGV("No FAPI token seals found.");
+        return CKR_OK;
+    }
+    if (rc) {
+        LOGE("Listing FAPI token objects failed.");
+        return CKR_GENERAL_ERROR;
+    }
+
+    for (path = strtok_r(pathlist, ":", &strtokr_save); path != NULL;
+            path = strtok_r(NULL, ":", &strtokr_save)) {
+        /* Skip over potential profile nodes that don't interest us. */
+        if (!strncmp(path, "/P_", strlen("/P_"))) {
+            subpath = index(path + 1, '/');
+            if (!subpath) {
+                LOGE("Malformed path received");
+                goto error;
+            }
+        } else {
+            subpath = path;
+        }
+        if (sscanf(subpath, PREFIX "so-%08x", &id) != 1) {
+            LOGV("%s aka %s is not a token, ignoring", path, subpath);
+            continue;
+        }
+        LOGV("Found a token at %s", path);
+
+        t = &tok[*len];
+        *len += 1;
+
+        t->type = token_type_fapi;
+        t->id = id;
+
+        rv = token_min_init(t);
+        if (rv) {
+            LOGE("token min init failed");
+            goto error;
+        }
+
+        //FIXME
+        t->fapi.ctx = fctx;
+
+        rc = Fapi_GetDescription(t->fapi.ctx, path, &label);
+        if (rc) {
+            LOGE("Getting FAPI seal description failed.");
+            goto error;
+        }
+        memcpy(&t->label[0], label, strlen(label));
+        Fapi_Free(label);
+
+        /* FIXME Manually setting SRK handle here */
+        t->pid = 0x81000001;
+
+        rc = Fapi_GetTpmBlobs(t->fapi.ctx, path, &tpm2bPublic, &tpm2bPublicSize,
+                              &tpm2bPrivate, &tpm2bPrivateSize, NULL /* policy */);
+        if (rc) {
+            LOGE("Getting the TPM data blobs failed.");
+            goto error;
+        }
+
+        pub = twistbin_new(tpm2bPublic, tpm2bPublicSize);
+        Fapi_Free(tpm2bPublic);
+        priv = twistbin_new(tpm2bPrivate, tpm2bPrivateSize);
+        Fapi_Free(tpm2bPrivate);
+        if (!pub || !priv) {
+            LOGE("Out of memory");
+            goto error;
+        }
+
+        t->sealobject.sopub = pub;
+        t->sealobject.sopriv = priv;
+
+        rc = Fapi_GetAppData(t->fapi.ctx, path, &appdata, &appdata_len);
+        if (rc) {
+            LOGE("Getting FAPI seal appdata failed.");
+            goto error;
+        }
+
+        t->sealobject.soauthsalt = twistbin_new(appdata, strlen((char *)appdata));
+        if (t->sealobject.soauthsalt == NULL) {
+            LOGE("OOM");
+            goto error;
+        }
+
+        rv = tpm_get_existing_primary(t->tctx, &t->pobject.handle, &blob);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+        twist_free(blob);
+
+        t->config.is_initialized = true;
+
+        /* Initialize the User PIN area. */
+        /*********************************/
+        path = tss_path_from_id(t->id, "usr");
+        if (!path) {
+            LOGE("OOM");
+            goto error;
+        }
+        rc = Fapi_GetTpmBlobs(t->fapi.ctx, path, &tpm2bPublic, &tpm2bPublicSize,
+                              &tpm2bPrivate, &tpm2bPrivateSize, NULL /* policy */);
+        if (rc == 0x00060020) {
+            LOGV("No user pin found for token %08x.", t->id);
+            free(path);
+            continue;
+        }
+        if (rc) {
+            LOGE("Getting the TPM data blobs failed.");
+            free(path);
+            return CKR_GENERAL_ERROR;
+        }
+        LOGV("Adding user pin at %s", path);
+
+        pub = twistbin_new(tpm2bPublic, tpm2bPublicSize);
+        Fapi_Free(tpm2bPublic);
+        priv = twistbin_new(tpm2bPrivate, tpm2bPrivateSize);
+        Fapi_Free(tpm2bPrivate);
+        if (!pub || !priv) {
+            LOGE("Out of memory");
+            goto error;
+        }
+
+        t->sealobject.userpub = pub;
+        t->sealobject.userpriv = priv;
+
+        rc = Fapi_GetAppData(t->fapi.ctx, path, &appdata, NULL);
+        if (rc) {
+            LOGE("Getting FAPI seal appdata failed.");
+            goto error;
+        }
+
+        t->sealobject.userauthsalt = twistbin_new(appdata, strlen((char *)appdata));
+        Fapi_Free(appdata);
+        if (t->sealobject.userauthsalt == NULL) {
+            LOGE("OOM");
+            goto error;
+        }
+    }
+
+    rv = CKR_OK;
+
+out:
+    Fapi_Free(pathlist);
+    return rv;
+
+error:
+    if (rv == CKR_OK)
+        rv = CKR_GENERAL_ERROR;
+    goto out;
+}
+
+/** Initialize the user PIN data for a given token.
+ *
+ * See backend_init_user()
+ */
+CK_RV backend_fapi_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex) {
+    TSS2_RC rc;
+    uint8_t *tpm2bPublic, *tpm2bPrivate, *appdata;
+    size_t tpm2bPublicSize, tpm2bPrivateSize, appdata_len;
+    twist pub, priv;
+
+    char *path = tss_path_from_id(t->id, "usr");
+
+    rc = Fapi_CreateSeal(t->fapi.ctx, path,
+                         NULL /*type*/, twist_len(sealdata),
+                         NULL /*policy*/, newauthhex, (uint8_t*)sealdata);
+    if (rc) {
+        LOGE("Creation of a FAPI seal failed.");
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    rc = Fapi_SetDescription(t->fapi.ctx, path, (char*)&t->label[0]);
+    if (rc) {
+        LOGE("Setting FAPI seal description failed.");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    appdata_len = twist_len(newsalthex) + 1;
+    appdata = malloc(appdata_len);
+    if (!appdata) {
+        LOGE("oom");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }        
+    memcpy(appdata, newsalthex, appdata_len - 1);
+    appdata[appdata_len - 1] = '\0';
+
+    rc = Fapi_SetAppData(t->fapi.ctx, path, appdata, appdata_len);
+    free(appdata);
+    if (rc) {
+        LOGE("Setting FAPI seal appdata failed.");
+        Fapi_Delete(t->fapi.ctx, path);
+        free(path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    rc = Fapi_GetTpmBlobs(t->fapi.ctx, path, &tpm2bPublic, &tpm2bPublicSize,
+                          &tpm2bPrivate, &tpm2bPrivateSize, NULL /* policy */);
+    free(path);
+    if (rc) {
+        LOGE("Getting the TPM data blobs failed.");
+        return CKR_GENERAL_ERROR;
+    }
+
+    pub = twistbin_new(tpm2bPublic, tpm2bPublicSize);
+    Fapi_Free(tpm2bPublic);
+    priv = twistbin_new(tpm2bPrivate, tpm2bPrivateSize);
+    Fapi_Free(tpm2bPrivate);
+    if (!pub || !priv) {
+        LOGE("Out of memory");
+        return CKR_GENERAL_ERROR;
+    }
+
+    twist_free(t->sealobject.userpub);
+    twist_free(t->sealobject.userpriv);
+    twist_free(t->sealobject.userauthsalt);
+
+    t->sealobject.userpub = pub;
+    t->sealobject.userpriv = priv;
+    t->sealobject.userauthsalt = newsalthex;
+
+    return CKR_OK;
+}

--- a/src/lib/backend_fapi.h
+++ b/src/lib/backend_fapi.h
@@ -20,4 +20,6 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len);
 CK_RV backend_fapi_init_user(token *t, const twist sealdata,
                         const twist newauthhex, const twist newsalthex);
 
+CK_RV backend_fapi_add_object(token *t, tobject *tobj);
+
 #endif /* SRC_LIB_BACKEND_FAPI_H_ */

--- a/src/lib/backend_fapi.h
+++ b/src/lib/backend_fapi.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#ifndef SRC_LIB_BACKEND_FAPI_H_
+#define SRC_LIB_BACKEND_FAPI_H_
+
+#include "pkcs11.h"
+#include "twist.h"
+#include "token.h"
+
+CK_RV backend_fapi_init(void);
+CK_RV backend_fapi_destroy(void);
+
+CK_RV backend_fapi_ctx_new(token *t);
+void backend_fapi_ctx_free(token *t);
+
+CK_RV backend_fapi_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex);
+
+CK_RV backend_fapi_add_tokens(token *tok, size_t *len);
+
+CK_RV backend_fapi_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex);
+
+#endif /* SRC_LIB_BACKEND_FAPI_H_ */

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -298,7 +298,7 @@ static int init_sealobjects(unsigned tokid, sealobject *sealobj) {
         const char *name = sqlite3_column_name(stmt, i);
 
         if (!strcmp(name, "id")) {
-            sealobj->id = sqlite3_column_int(stmt, i);
+            // pass
         } else if (!strcmp(name, "userauthsalt")) {
             const char *x = (const char *)sqlite3_column_text(stmt, i);
             if (x) {

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -126,38 +126,10 @@ static tobject *db_tobject_new(sqlite3_stmt *stmt) {
 
     assert(tobj->id);
 
-    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_TPM2_OBJAUTH_ENC);
-    if (a && a->pValue && a->ulValueLen) {
-        tobj->objauth = twistbin_new(a->pValue, a->ulValueLen);
-        if (!tobj->objauth) {
-            LOGE("oom");
-            goto error;
-        }
-    }
-
-    a = attr_get_attribute_by_type(tobj->attrs, CKA_TPM2_PUB_BLOB);
-    if (a && a->pValue && a->ulValueLen) {
-
-        tobj->pub = twistbin_new(a->pValue, a->ulValueLen);
-        if (!tobj->pub) {
-            LOGE("oom");
-            goto error;
-        }
-    }
-
-    a = attr_get_attribute_by_type(tobj->attrs, CKA_TPM2_PRIV_BLOB);
-    if (a && a->pValue && a->ulValueLen) {
-
-        if (!tobj->pub) {
-            LOGE("objects with CKA_TPM2_PUB_BLOB should have CKA_TPM2_PRIV_BLOB");
-            goto error;
-        }
-
-        tobj->priv = twistbin_new(a->pValue, a->ulValueLen);
-        if (!tobj->priv) {
-            LOGE("oom");
-            goto error;
-        }
+    CK_RV rv = object_init_from_attrs(tobj);
+    if (rv != CKR_OK) {
+        LOGE("Object initialization failed");
+        goto error;
     }
 
     return tobj;

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -139,7 +139,7 @@ error:
     return NULL;
 }
 
-static int init_tobjects(token *tok) {
+int init_tobjects(token *tok) {
 
     const char *sql =
             "SELECT * FROM tobjects WHERE tokid=?";

--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -246,6 +246,7 @@ CK_RV general_init(void *init_args) {
 
     rv = slot_init();
     if (rv != CKR_OK) {
+        (void)backend_destroy();
         goto err;
     }
 

--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -7,7 +7,7 @@
 
 #include "checks.h"
 #include "config.h"
-#include "db.h"
+#include "backend.h"
 #include "general.h"
 #include "log.h"
 #include "mutex.h"
@@ -239,9 +239,7 @@ CK_RV general_init(void *init_args) {
      *
      * THESE MUST GO AFTER MUTEX INIT above!!
      */
-    tpm_init();
-
-    rv = db_init();
+    rv = backend_init();
     if (rv != CKR_OK) {
         goto err;
     }
@@ -266,10 +264,8 @@ CK_RV general_finalize(void *reserved) {
 
     _g_is_init = false;
 
-    db_destroy();
     slot_destroy();
-
-    tpm_destroy();
+    backend_destroy();
 
     return CKR_OK;
 }

--- a/src/lib/key.c
+++ b/src/lib/key.c
@@ -4,8 +4,8 @@
 #include <openssl/rand.h>
 
 #include "attrs.h"
+#include "backend.h"
 #include "checks.h"
-#include "db.h"
 #include "key.h"
 #include "list.h"
 #include "pkcs11.h"
@@ -298,13 +298,13 @@ CK_RV key_gen (
         goto out;
     }
 
-    rv = db_add_new_object(tok, new_public_tobj);
+    rv = backend_add_object(tok, new_public_tobj);
     if (rv != CKR_OK) {
         LOGE("Failed to add public object to db");
         goto out;
     }
 
-    rv = db_add_new_object(tok, new_private_tobj);
+    rv = backend_add_object(tok, new_private_tobj);
     if (rv != CKR_OK) {
         LOGE("Failed to add public object to db");
         goto out;

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -6,6 +6,7 @@
 #include <openssl/obj_mac.h>
 
 #include "attrs.h"
+#include "backend.h"
 #include "checks.h"
 #include "db.h"
 #include "emitter.h"
@@ -731,7 +732,7 @@ static CK_RV handle_rsa_public(token *tok, CK_ATTRIBUTE_PTR templ, CK_ULONG coun
     tmp_attrs = NULL;
 
     /* add the object to the db */
-    rv = db_add_new_object(tok, obj);
+    rv = backend_add_object(tok, obj);
     if (rv != CKR_OK) {
         goto out;
     }

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -126,4 +126,6 @@ CK_RV object_destroy(session_ctx *ctx, CK_OBJECT_HANDLE object);
 
 CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *object);
 
+CK_RV object_init_from_attrs(tobject *tobj);
+
 #endif /* SRC_PKCS11_OBJECT_H_ */

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -266,9 +266,10 @@ CK_RV session_ctx_login(session_ctx *ctx, CK_USER_TYPE user, CK_BYTE_PTR pin, CK
         return CKR_OK;
     }
 
-
+    LOGV("token parent object handle is 0x%08x", tok->pobject.handle);
     CK_RV tmp = tpm_session_start(tok->tctx, tok->pobject.objauth, tok->pobject.handle);
     if (tmp != CKR_OK) {
+        LOGE("Could not start Auth Session with the TPM.");
         return tmp;
     }
 

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #include "checks.h"
-#include "db.h"
+#include "backend.h"
 #include "mech.h"
 #include "pkcs11.h"
 #include "slot.h"
@@ -24,7 +24,7 @@ CK_RV slot_init(void) {
         return rv;
     }
 
-    return db_get_tokens(&global.token, &global.token_cnt);
+    return backend_get_tokens(&global.token, &global.token_cnt);
 }
 
 static void slot_lock(void) {

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -8,6 +8,7 @@
 #include <time.h>
 
 #include "attrs.h"
+#include "backend.h"
 #include "checks.h"
 #include "db.h"
 #include "list.h"
@@ -293,49 +294,6 @@ CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {
     return CKR_OK;
 }
 
-CK_RV get_or_create_primary(token *t) {
-
-    twist blob = NULL;
-
-    /* if there is no primary object ... */
-    if (t->pid) {
-        return CKR_OK;
-    }
-
-    /* is there one in the db to use ? */
-    CK_RV rv = db_get_first_pid(&t->pid);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    /* if so use it */
-    if (t->pid) {
-        /* tokens in the DB store already have an associated primary object */
-        return db_init_pobject(t->pid, &t->pobject, t->tctx);
-    }
-
-    /* is their a PC client spec key ? */
-    rv = tpm_get_existing_primary(t->tctx, &t->pobject.handle, &blob);
-    if (rv != CKR_OK) {
-        return rv;
-    }
-
-    /* nothing, create one */
-    if (!t->pobject.handle) {
-        rv = tpm_create_primary(t->tctx, &t->pobject.handle, &blob);
-        if (rv != CKR_OK) {
-            return rv;
-        }
-    }
-
-    assert(t->pobject.handle);
-
-    rv = db_add_primary(blob, &t->pid);
-    assert(t->pid);
-    twist_free(blob);
-    return rv;
-}
-
 CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label) {
     check_pointer(pin);
     check_pointer(label);
@@ -358,45 +316,20 @@ CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label)
         goto out;
     }
 
-    /*
-     * find or create a primary object and get the serialized blob
-     * for it.
-     */
-    rv = get_or_create_primary(t);
-    if (rv != CKR_OK) {
-        LOGE("Could not find nor create a primary object");
-        goto error;
-    }
-
     rv = utils_setup_new_object_auth(sopin, &newauth, &newsalthex);
     if (rv != CKR_OK) {
         goto error;
     }
 
-    /* we have a primary object, create the seal object underneath it */
-    rv = tpm2_create_seal_obj(t->tctx, t->pobject.objauth, t->pobject.handle,
-            newauth, NULL, hexwrappingkey, &t->sealobject.sopub,
-            &t->sealobject.sopriv, &t->sealobject.handle);
-    if (rv != CKR_OK) {
-        LOGE("Could not create SO seal object");
-        goto error;
-    }
-
-    t->sealobject.soauthsalt = newsalthex;
-    newsalthex = NULL;
-
     memcpy(t->label, label, sizeof(t->label));
 
-    /* TODO get TCTI config from ENV var and use throughout this process */
-    t->config.is_initialized = true;
-
-    rv = db_add_token(t);
+    rv = backend_create_token_seal(t, hexwrappingkey, newauth, newsalthex);
     if (rv != CKR_OK) {
-        LOGE("Could not add token to db");
+        LOGE("Could not create new token");
         goto error;
     }
-
-    assert(t->id);
+    /* Ownership of newsalthex is transferred in the previous call */
+    newsalthex = NULL;
 
     rv = slot_add_uninit_token();
     if (rv != CKR_OK) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -55,13 +55,19 @@ struct token {
     unsigned pid;
     unsigned char label[32];
 
-    token_config config;
+    union { /* anon union for backend data */
+        struct {
+            token_config config;
 
-    pobject pobject;
+            pobject pobject;
+
+            sealobject sealobject;
+
+            tpm_ctx *tctx;
+        }; /* esysdb */
+    };
 
     twist wappingkey;
-
-    sealobject sealobject;
 
     struct {
         tobject *head;
@@ -71,8 +77,6 @@ struct token {
     session_table *s_table;
 
     token_login_state login_state;
-
-    tpm_ctx *tctx;
 
     void *mutex;
 };

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -37,8 +37,6 @@ struct pobject {
 typedef struct sealobject sealobject;
 struct sealobject {
 
-    unsigned id;
-
     twist userpub;
     twist userpriv;
     twist userauthsalt;

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -10,6 +10,8 @@
 #include "twist.h"
 #include "utils.h"
 
+#include <tss2/tss2_fapi.h>
+
 typedef struct token_config token_config;
 struct token_config {
     bool is_initialized;  /* token initialization state */
@@ -48,6 +50,11 @@ struct sealobject {
     uint32_t handle;
 };
 
+enum token_type {
+    token_type_esysdb = 0,
+    token_type_fapi
+};
+
 typedef struct token token;
 struct token {
 
@@ -55,7 +62,10 @@ struct token {
     unsigned pid;
     unsigned char label[32];
 
-    union { /* anon union for backend data */
+    enum token_type type;
+
+//TODO: uncomment union, once both backends are completely separated.
+//    union { /* anon union for backend data */
         struct {
             token_config config;
 
@@ -63,9 +73,14 @@ struct token {
 
             sealobject sealobject;
 
-            tpm_ctx *tctx;
         }; /* esysdb */
-    };
+        struct {
+            FAPI_CONTEXT *ctx;
+        } fapi;
+//    };
+
+    /* This context will be filled by fapi for use with esys-only commands. */
+    tpm_ctx *tctx;
 
     twist wappingkey;
 

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -774,7 +774,19 @@ static bool tpm_loadexternal(tpm_ctx *ctx,
         TPM2B_PUBLIC *pub,
         uint32_t *handle) {
 
-    TSS2_RC rval = Esys_LoadExternal(
+    TSS2_RC rval;
+#ifdef ESYS_3
+    rval = Esys_LoadExternal(
+           ctx->esys_ctx,
+           ESYS_TR_NONE,
+           ESYS_TR_NONE,
+           ESYS_TR_NONE,
+           NULL,
+           pub,
+           ESYS_TR_RH_NULL,
+           handle);
+#else /* ESYS_3 */
+    rval = Esys_LoadExternal(
            ctx->esys_ctx,
            ESYS_TR_NONE,
            ESYS_TR_NONE,
@@ -783,6 +795,7 @@ static bool tpm_loadexternal(tpm_ctx *ctx,
            pub,
            TPM2_RH_NULL,
            handle);
+#endif /* ESYS_3 */
     if (rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_LoadExternal: %s:", Tss2_RC_Decode(rval));
         return false;

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
+set -x
+
 source "$T/test/integration/scripts/helpers.sh"
 
 tempdir=$(mktemp -d)
@@ -25,6 +27,7 @@ fi
 echo "modpath=$modpath"
 
 pkcs11_tool() {
+#  valgrind pkcs11-tool --module "$modpath" "$@"
   pkcs11-tool --module "$modpath" "$@"
   return $?
 }
@@ -33,13 +36,20 @@ export TPM2_PKCS11_STORE="$tempdir"
 
 echo "TPM2_PKCS11_STORE=$TPM2_PKCS11_STORE"
 
+echo "testdata">${tempdir}/data
+
 echo "Should have unitialized token"
 pkcs11_tool -T | grep -q uninitialized
 echo "Found unitialized token"
 
+pkcs11_tool -I
+pkcs11_tool -T
+
 echo "Initializing token"
 pkcs11_tool --slot=1 --init-token --label=mynewtoken --so-pin=mynewsopin
 echo "Token initialized"
+
+pkcs11_tool -T
 
 echo "Initializing user pin"
 pkcs11_tool --slot=1 --login --login-type="so" --init-pin --so-pin=mynewsopin --pin=mynewuserpin
@@ -49,4 +59,20 @@ echo "Generating RSA keypair"
 pkcs11_tool --slot=1 --label="myrsakey" --login --pin=mynewuserpin --keypairgen
 echo "RSA Keypair generated"
 
+echo "Testing RSA signature"
+pkcs11_tool -v --list-objects --login --pin mynewuserpin
+
+pkcs11_tool -v --sign --login --slot=1 --label="myrsakey" --pin mynewuserpin \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism SHA256-RSA-PKCS
+
+pkcs11_tool -v --read-object --slot=1 --label="myrsakey" \
+            --type pubkey --output-file ${tempdir}/pubkey.der \
+    || exit 77
+#This fails on old pkcs11-tool versions, thus exit-skip here
+
+openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/sig -sha256 \
+             -sigopt rsa_padding_mode:pkcs1 \
+             ${tempdir}/data
+echo "RSA signature tested"
 exit 0

--- a/test/integration/scripts/int-test-setup.sh
+++ b/test/integration/scripts/int-test-setup.sh
@@ -175,6 +175,9 @@ echo ${TPM2TOOLS_TCTI}
 export TPM2_PKCS11_TCTI="tabrmd:${TABRMD_TEST_TCTI_CONF}"
 echo ${TPM2_PKCS11_TCTI}
 
+setup_fapi
+tss2_provision
+
 # if provided, run the test script
 if [ -z "${TSETUP_SCRIPT}" ]; then
     echo "No setup script provided"
@@ -198,6 +201,8 @@ else
         ret_test=$?
     fi
 fi
+
+tss2_list
 
 # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
 # second after the test finishes the simulator will die too. Bug in the


### PR DESCRIPTION
The current status is as follows:
- SO-seal is created in FAPI-store
- USR-seal is created in FAPI-store
- tobjects are part of so-seal appdata
- tokens of SQLite and FAPI are concatenated (so both work in parallel)
- test pkcs11-tool-init{-fapi} uses FAPI

TODOs:
- emptytoken comes from db.c instead of token.c
- Somewhat hacky concatenation (dep: emptytoken)
- pobjects are a bit hacky (need to be made Flushable for FAPI)
- other tests need to learn about FAPI; tpm2_ptool or something else ?