### PR TITLE
test: fix unitialized variable warnings

### DIFF
--- a/test/unit/test_attr.c
+++ b/test/unit/test_attr.c
@@ -31,7 +31,7 @@ static void test_config_parser_empty_seq(void **state) {
     /* test class */
     CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, CKA_CLASS);
     assert_non_null(a);
-    CK_OBJECT_CLASS got_class;
+    CK_OBJECT_CLASS got_class = CKO_DATA;
     CK_RV rv = attr_CK_OBJECT_CLASS(a, &got_class);
     assert_int_equal(rv, CKR_OK);
     assert_int_equal(got_class, CKO_CERTIFICATE);
@@ -45,7 +45,7 @@ static void test_config_parser_empty_seq(void **state) {
     /* test decrypt */
     a = attr_get_attribute_by_type(attrs, CKA_DECRYPT);
     assert_non_null(a);
-    CK_BBOOL got_bool;
+    CK_BBOOL got_bool = CK_FALSE;
     rv = attr_CK_BBOOL(a, &got_bool);
     assert_int_equal(rv, CKR_OK);
     assert_int_equal(got_bool, CK_TRUE);


### PR DESCRIPTION
Fix:
libtool: link: gcc -I./src -I./src/lib -Wall -Wextra -Werror -Wformat -Wformat-security -Wstack-protector -fstack-protector-all -Wstrict-overflow=5 -O2 -fPIC -fPIE -pthread -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -flto=auto -flto-partition=none -pie -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,relro -Wl,--as-needed -Wl,-z -Wl,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -flto=auto -flto-partition=none -fuse-linker-plugin -o test/unit/test_attr test/unit/test_attr-test_attr.o  -lcmocka src/.libs/libtpm2_test_internal.a src/.libs/libtpm2_test_pkcs11.a -ltss2-esys -ltss2-mu -ltss2-tctildr -ltss2-rc -lsqlite3 -lcrypto -lyaml -pthread
test/unit/test_attr.c: In function 'test_config_parser_empty_seq':
test/unit/test_attr.c:51:5: error: 'got_bool' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   51 |     assert_int_equal(got_bool, CK_TRUE);
      |     ^
test/unit/test_attr.c:48:14: note: 'got_bool' was declared here
   48 |     CK_BBOOL got_bool;
      |              ^
test/unit/test_attr.c:37:5: error: 'got_class' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   37 |     assert_int_equal(got_class, CKO_CERTIFICATE);
      |     ^
test/unit/test_attr.c:34:21: note: 'got_class' was declared here
   34 |     CK_OBJECT_CLASS got_class;
      |                     ^

Fixes: #416

Signed-off-by: William Roberts <william.c.roberts@intel.com>