### PR TITLE
build: always distribute test files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,19 @@ check_SCRIPTS =
 
 TEST_EXTENSIONS = .sh .int .nosetup .java
 
+integration_scripts = \
+    test/integration/pkcs11-tool.sh \
+    test/integration/pkcs11-tool-init.sh.nosetup \
+    test/integration/pkcs11-dbup.sh.nosetup \
+    test/integration/tls-tests.sh \
+    test/integration/openssl.sh \
+    test/integration/pkcs11-javarunner.sh.java
+
+EXTRA_DIST += \
+    $(integration_scripts) \
+    test/integration/test.h \
+    test/integration/fixtures
+
 ### Integration Tests ###
 if ENABLE_INTEGRATION
 
@@ -116,12 +129,7 @@ check_PROGRAMS += \
     test/integration/pkcs-session-state.int
 
 # add test scripts
-check_SCRIPTS += \
-    test/integration/pkcs11-tool.sh \
-    test/integration/pkcs11-tool-init.sh.nosetup \
-    test/integration/pkcs11-dbup.sh.nosetup \
-    test/integration/tls-tests.sh \
-    test/integration/openssl.sh
+check_SCRIPTS += $(integration_scripts)
 
 LOG_COMPILER = $(srcdir)/test/integration/scripts/int-test-setup.sh
 
@@ -177,18 +185,12 @@ test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-
 #
 # Java Tests
 #
-check_SCRIPTS+=test/integration/pkcs11-javarunner.sh.java
 AM_JAVA_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
 JAVA_LOG_COMPILER=$(LOG_COMPILER)
 dist_noinst_JAVA = test/integration/PKCS11JavaTests.java
 
 endif
 # END INTEGRATION
-
-EXTRA_DIST += \
-    $(check_SCRIPTS) \
-    test/integration/test.h \
-    test/integration/fixtures
 
 ### Unit Tests ###
 if UNIT

--- a/Makefile.am
+++ b/Makefile.am
@@ -188,6 +188,7 @@ test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-
 AM_JAVA_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
 JAVA_LOG_COMPILER=$(LOG_COMPILER)
 dist_noinst_JAVA = test/integration/PKCS11JavaTests.java
+CLEANFILES += test/integration/PKCS11JavaTests.class
 
 endif
 # END INTEGRATION

--- a/test/integration/openssl.sh
+++ b/test/integration/openssl.sh
@@ -170,4 +170,6 @@ pkcs11_tool --pin "$PIN" --token-label "$token_label" --id "$cka_id_hex" --sign 
 
 openssl dgst -sha1 -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -signature data.sig -verify pubkey.pem data.txt
 
+rm data.sig
+
 exit 0


### PR DESCRIPTION
The release tarball for the current [release candiate](https://github.com/tpm2-software/tpm2-pkcs11/releases/tag/1.1.0-RC0) appears to have been build without `--enable-integration`. This means the integration test suite cannot be run because some required scripts are distributed depending on the state of `ENABLE_INTEGRATION`.  Make sure that `EXTRA_DIST` is independent of the configuration options to avoid such problems in the future. Additionally there are two leftover files that `make distcheck` may complain about, make sure to remove these.