### PR TITLE
sign: fix hash_len type for 32 bit compilation

### DIFF
--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -216,7 +216,7 @@ CK_RV sign_final_ex(session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG_PTR signat
 
     if (opdata->do_hash) {
 
-        size_t hash_len = utils_get_halg_size(opdata->mech.mechanism);
+        CK_ULONG hash_len = utils_get_halg_size(opdata->mech.mechanism);
         if (!hash_len) {
             LOGE("Hash algorithm cannot have 0 size");
             return CKR_GENERAL_ERROR;


### PR DESCRIPTION
The wrong type, introduced during refactoring in d80809ac3b8267f346f90bc3c73275bd8c66456e, causes errors for 32 bit builds of the form
```
src/lib/sign.c: In function 'sign_final_ex':
src/lib/sign.c:231:83: error: passing argument 4 of 'digest_final_op' from incompatible pointer type [-Werror=incompatible-pointer-types]
  231 |         rv = digest_final_op(ctx, opdata->digest_opdata, (CK_BYTE_PTR)digest_buf, &hash_len);
      |                                                                                   ^~~~~~~~~
      |                                                                                   |
      |                                                                                   size_t * {aka unsigned int *}
In file included from src/lib/sign.c:9:
src/lib/digest.h:35:107: note: expected 'CK_ULONG_PTR' {aka 'long unsigned int *'} but argument is of type 'size_t *' {aka 'unsigned int *'}
   35 | CK_RV digest_final_op(session_ctx *ctx, digest_op_data *supplied_opdata, CK_BYTE_PTR digest, CK_ULONG_PTR digest_len);
      |                                                                                              ~~~~~~~~~~~~~^~~~~~~~~~
```

Fixes: #420