### PR TITLE
pkcs11: Implement C_VerifyRecovery

### DIFF
--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -18,6 +18,7 @@ enum operation {
     operation_find,
     operation_sign,
     operation_verify,
+    operation_verify_recover,
     operation_encrypt,
     operation_decrypt,
     operation_digest,

--- a/src/lib/sign.h
+++ b/src/lib/sign.h
@@ -26,4 +26,9 @@ CK_RV verify_final(session_ctx *ctx, unsigned char *signature, unsigned long sig
 
 CK_RV verify(session_ctx *ctx, unsigned char *data, unsigned long data_len, unsigned char *signature, unsigned long signature_len);
 
+CK_RV verify_recover_init (session_ctx *ctx, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
+
+CK_RV verify_recover (session_ctx *ctx, CK_BYTE_PTR signature, CK_ULONG signature_len,
+        CK_BYTE_PTR data, CK_ULONG_PTR data_len);
+
 #endif

--- a/src/lib/ssl_util.h
+++ b/src/lib/ssl_util.h
@@ -62,4 +62,9 @@ CK_RV ssl_util_sig_verify(EVP_PKEY *pkey,
         CK_BYTE_PTR digest, CK_ULONG digest_len,
         CK_BYTE_PTR signature, CK_ULONG signature_len);
 
+CK_RV ssl_util_verify_recover(EVP_PKEY *pkey,
+        int padding, const EVP_MD *md,
+        CK_BYTE_PTR signature, CK_ULONG signature_len,
+        CK_BYTE_PTR data, CK_ULONG_PTR data_len);
+
 #endif /* SRC_LIB_SSL_UTIL_H_ */

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -584,11 +584,11 @@ CK_RV C_VerifyFinal (CK_SESSION_HANDLE session, CK_BYTE_PTR signature, CK_ULONG 
 }
 
 CK_RV C_VerifyRecoverInit (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key) {
-    TOKEN_UNSUPPORTED;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify_recover_init, session, mechanism, key);
 }
 
 CK_RV C_VerifyRecover (CK_SESSION_HANDLE session, CK_BYTE_PTR signature, CK_ULONG signature_len, CK_BYTE_PTR data, CK_ULONG_PTR data_len) {
-    TOKEN_UNSUPPORTED;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(verify_recover, session, signature, signature_len, data, data_len);
 }
 
 CK_RV C_DigestEncryptUpdate (CK_SESSION_HANDLE session, CK_BYTE_PTR part, CK_ULONG part_len, CK_BYTE_PTR encrypted_part, CK_ULONG_PTR encrypted_part_len) {

--- a/test/integration/PKCS11JavaTests.java
+++ b/test/integration/PKCS11JavaTests.java
@@ -92,6 +92,19 @@ public class PKCS11JavaTests {
 		String decrypted = new String(decryptedData, output - plainData.length, plainData.length);
 
 		Assert.assertEquals(plaintext, decrypted);
+
+		/* Encrypt private decrypt public */
+		cipher.init(Cipher.ENCRYPT_MODE, rsaKey);
+		encryptedData = cipher.doFinal(plainData);
+
+		cipher.init(Cipher.DECRYPT_MODE, rsaPublicKey);
+		output = cipher.getOutputSize(encryptedData.length);
+		decryptedData = cipher.doFinal(encryptedData);
+
+		Assert.assertArrayEquals(plainData, decryptedData);
+
+		String s = new String(decryptedData);
+		Assert.assertEquals(plaintext, s);
 	}
 
 	@Test


### PR DESCRIPTION
Implement C_VerifyRecover API. Known to work with RSA mechanism
CKM_RSA_PKCS as used by the Java PKCS11 Provider implementation.

Fixes: #383

Signed-off-by: William Roberts <william.c.roberts@intel.com>