### PR TITLE
config: move per token config tcti/log-level

### DIFF
--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -6,6 +6,7 @@
 #include <sqlite3.h>
 
 #include "pkcs11.h"
+#include "store-config.h"
 #include "token.h"
 #include "twist.h"
 
@@ -15,7 +16,7 @@
  */
 #define MAX_TOKEN_CNT 255
 
-CK_RV db_init(void);
+CK_RV db_init(store_config *config);
 CK_RV db_destroy(void);
 
 CK_RV db_get_tokens(token **t, size_t *len);

--- a/src/lib/emitter.h
+++ b/src/lib/emitter.h
@@ -5,10 +5,12 @@
 
 #include "attrs.h"
 #include "pkcs11.h"
+#include "store-config.h"
 #include "token.h"
 
 char *emit_attributes_to_string(attr_list *attrs);
 
-char *emit_config_to_string(token *tok);
+char *emit_token_config_to_string_v2(token_config_v2 *config);
+char *emit_store_config_to_string(store_config *config);
 
 #endif /* SRC_LIB_EMITTER_H_ */

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -6,12 +6,18 @@
 
 #include "attrs.h"
 #include "pkcs11.h"
+#include "store-config.h"
 #include "token.h"
 
 bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
         attr_list **attrs);
 
-bool parse_token_config_from_string(const unsigned char *yaml, size_t size,
-        token_config *config);
+bool parse_token_config_from_string_v1(const unsigned char *yaml, size_t size,
+        token_config_v1 *config);
+
+bool parse_token_config_from_string_v2(const unsigned char *yaml, size_t size,
+        token_config_v2 *config);
+
+bool parse_store_config_from_string(const unsigned char *yaml, size_t size, store_config *config);
 
 #endif /* SRC_LIB_PARSER_H_ */

--- a/src/lib/store-config.h
+++ b/src/lib/store-config.h
@@ -1,0 +1,17 @@
+#ifndef SRC_LIB_STORE_CONFIG_H_
+#define SRC_LIB_STORE_CONFIG_H_
+
+/*
+ * Defines the per-store config data.
+ *
+ * Since db.h depdend on the parser.h, define these here
+ * to avoid a cyclic depndency of placing them in
+ * db.h
+ */
+typedef struct store_config store_config;
+struct store_config {
+    const char *tcti;
+    const char *loglevel;
+};
+
+#endif /* SRC_LIB_STORE_CONFIG_H_ */

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -33,7 +33,7 @@ CK_RV token_min_init(token *t) {
     /*
      * Initialize the per-token tpm context
      */
-    rv = tpm_ctx_new(t->config.tcti, &t->tctx);
+    rv = tpm_ctx_new(&t->tctx);
     if (rv != CKR_OK) {
         LOGE("Could not initialize tpm ctx: 0x%lx", rv);
         return rv;
@@ -233,9 +233,6 @@ void token_free(token *t) {
 
     mutex_destroy(t->mutex);
     t->mutex = NULL;
-
-    free(t->config.tcti);
-    t->config.tcti = NULL;
 }
 
 CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -10,10 +10,30 @@
 #include "twist.h"
 #include "utils.h"
 
-typedef struct token_config token_config;
-struct token_config {
+typedef struct token_config_v2 token_config_v2;
+struct token_config_v2 {
     bool is_initialized;  /* token initialization state */
-    char *tcti;           /* token specific tcti config */
+};
+
+/*
+ * Old Token Config structure. Per token data for
+ * tcti and loglevel where broken, since they had
+ * to be done on a per process level. Log level affects
+ * the process wide logging, independent of tokens,
+ * so conflicting options wouldn't work right, and the tct
+ * loader loads tcti's in a static scope, ie one tcti per
+ * process. Since no one really needs this per-token tcti,
+ * and you can replicate the behavior with a store per desired
+ * target tpm, just drop it.
+ *
+ * The loglevel and tcti data are now in the db under the config
+ * table, which is a store wide configuration.
+ */
+typedef struct token_config_v1 token_config_v1;
+struct token_config_v1 {
+    bool is_initialized;
+    const char *tcti;
+    const char *loglevel;
 };
 
 typedef struct session_table session_table;
@@ -57,7 +77,7 @@ struct token {
     unsigned pid;
     unsigned char label[32];
 
-    token_config config;
+    token_config_v2 config;
 
     pobject pobject;
 

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -33,14 +33,12 @@ void tpm_ctx_free(tpm_ctx *ctx);
 /**
  * Creates a new tpm_ctx with it's own ESAPI
  * and TCTI contexts internally.
- * @param tcti
- *  An optional (can be null) tcti config string.
  * @param tctx
  *  The tpm_ctx to create.
  * @return
  *  CJR_OK on success, anything else is a failure.
  */
-CK_RV tpm_ctx_new(const char *tcti, tpm_ctx **tctx);
+CK_RV tpm_ctx_new(tpm_ctx **tctx);
 
 /**
  * Retrieves Spec Version, FW Version, Manufacturer and Model from TPM
@@ -164,7 +162,7 @@ CK_RV tpm_get_existing_primary(tpm_ctx *tpm, uint32_t *primary_handle, twist *pr
 
 CK_RV tpm_create_primary(tpm_ctx *tpm, uint32_t *primary_handle, twist *primary_blob);
 
-void tpm_init(void);
+CK_RV tpm_init(const char *tcti);
 
 void tpm_destroy(void);
 

--- a/test/unit/test_parser.c
+++ b/test/unit/test_parser.c
@@ -107,11 +107,11 @@ static unsigned char _config_yaml[] = {
 };
 static unsigned int _config_yaml_len = 53;
 
-static void test_config_parser_good(void **state) {
+static void test_config_parser_good_v1(void **state) {
     (void) state;
 
-    token_config config = { 0 };
-    bool res = parse_token_config_from_string(_config_yaml, _config_yaml_len,
+    token_config_v1 config = { 0 };
+    bool res = parse_token_config_from_string_v1(_config_yaml, _config_yaml_len,
             &config);
     assert_true(res);
     assert_true(config.is_initialized);
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_config_parser_empty_seq),
         cmocka_unit_test(test_attr_parser_good),
-        cmocka_unit_test(test_config_parser_good),
+        cmocka_unit_test(test_config_parser_good_v1),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -17,7 +17,6 @@ from .utils import hash_pass
 from .utils import rand_hex_str
 from .utils import AESAuthUnwrapper
 from .utils import load_sealobject
-from .utils import str2bool
 from .utils import pkcs11_cko_to_str
 from .utils import pkcs11_ckk_to_str
 from .tpm2 import Tpm2
@@ -427,92 +426,6 @@ class InitPinCommand(Command):
             with TemporaryDirectory() as d:
                 tpm2 = Tpm2(d)
                 InitPinCommand.initpin(db, tpm2, args)
-
-@staticmethod
-def _empty_validator(s):
-    return s
-
-@staticmethod
-def _log_level_validator(s):
-
-    try:
-        x = int(s, 0)
-    except ValueError:
-        try:
-            x = ['error', 'warn', 'verbose'].index(s)
-        except ValueError:
-            sys.exit('Expected log-level to be one of "error", "warn", or "verbose"')
-
-    return x
-
-@commandlet("config")
-class ConfigCommand(Command):
-    '''
-    Manipulates and retrieves token configuration data.
-    '''
-    _keys = {
-        'token-init' : str2bool,
-        'log-level'  : _log_level_validator.__func__,
-        'tcti'       : _empty_validator.__func__
-    }
-
-    # adhere to an interface
-    # pylint: disable=no-self-use
-    def generate_options(self, group_parser):
-        group_parser.add_argument(
-            '--key', type=str, help='The key to set, valid keys are: %s.\n' % self._keys.keys())
-        group_parser.add_argument(
-            '--value', type=str, help='The value for the key.\n')
-        group_parser.add_argument(
-            '--label',
-            type=str,
-            help='The label of the token.\n',
-            required=True)
-
-    @classmethod
-    def get_validator_for_key(cls, key):
-        return cls._keys[key]
-
-    @classmethod
-    def config(cls, db, args):
-
-        label = args['label']
-
-        key = args['key']
-        value = args['value']
-
-        token = db.gettoken(label)
-
-        token_config = yaml.safe_load(io.StringIO(token['config']))
-        if not key and not value:
-            yaml_tok_cconf = yaml.safe_dump(token_config, default_flow_style=False)
-            print(yaml_tok_cconf)
-            sys.exit(0)
-
-        if not key and value:
-            sys.exit("Cannot specify --value without a key")
-
-        # key has to be set here based on above logical check
-        # throws an error if the key isn't known to the system
-        validator = cls.get_validator_for_key(key)
-
-        # no value, just key. Print the current value for key is set or empty if not set
-        if not value:
-            print("%s=%s" % (key, str(token_config[key] if key in token_config else "")))
-            sys.exit(0)
-
-        v = validator(value)
-        token_config[key] = v
-
-        # update the database
-        db.updateconfig(token, token_config)
-
-    def __call__(self, args):
-
-        path = args['path']
-
-        with Db(path) as db:
-            ConfigCommand.config(db, args)
 
 @commandlet("listprimaries")
 class ListPrimaryCommand(Command):


### PR DESCRIPTION
WARNING THIS PATCH BUMPS THE DB VERSION FROM 3 TO 4. AS ALWAYS BACKUP
YOUR DB UNDER THESE CONDITIONS.

WARNING THIS IS NON BACKWARDS COMPATIBLE CHANGES.

Currently, one can configure per-token configuration variables via the
tpm2_ptool config commandlet. The config variables "tcti" and
"log-level" were fundamentally broken by design. Each of those variables
is a process wide control, thus if tokens have conflicting options
between them, chaos will ensue.

To correct this, modify tpm2_ptool config commandlet to work on a store
wide config table. This is a non-backwards compatible change to
tpm2_ptool config commandlet, but should cause only minor issues as the
only commandline change is that --label is no longer required.

Bump the DB version to 4, and handle the upgrade paths.

Fixes: #432

Signed-off-by: William Roberts <william.c.roberts@intel.com>