### PR TITLE
test: add regression test for delete objects

### DIFF
--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -178,8 +178,14 @@ void token_rm_tobject(token *tok, tobject *t) {
     assert(tok->tobjects.head);
     assert(tok->tobjects.tail);
 
-    if (t == tok->tobjects.head) {
-        tok->tobjects.head = list_entry(tok->tobjects.head->l.next, tobject, l);
+    /* only item in the list */
+    if (t == tok->tobjects.tail &&
+            t == tok->tobjects.head) {
+        /* just empty the list */
+        tok->tobjects.head = tok->tobjects.tail = NULL;
+    } else if (t == tok->tobjects.head) {
+        tok->tobjects.head = tok->tobjects.head->l.next ?
+                list_entry(tok->tobjects.head->l.next, tobject, l) : NULL;
     } else if (t == tok->tobjects.tail) {
         /*
          * remove the tail by setting the tail equal to the previous list object

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -74,4 +74,14 @@ openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/si
              -sigopt rsa_padding_mode:pkcs1 \
              ${tempdir}/data
 echo "RSA signature tested"
+
+#
+# Regression test for https://github.com/tpm2-software/tpm2-pkcs11/issues/399
+# Delete Private Key then Public Key.
+pkcs11_tool --delete-object --slot-index=0 --label="myrsakey" --pin=mynewuserpin --login --type=privkey
+pkcs11_tool --list-objects --slot-index=0
+
+pkcs11_tool --delete-object --slot-index=0 --label="myrsakey" --pin=mynewuserpin --login --type=pubkey
+pkcs11_tool --list-objects --slot-index=0
+
 exit 0


### PR DESCRIPTION
This adds a regression test that deleting objects via pkcs11-tool,
specifically the private RSA object followed by the Public RSA object,
works.

Fixes: #399

Signed-off-by: William Roberts <william.c.roberts@intel.com>