### PR TITLE
tpm2_ptool: fix LGTM py/catch-base-exception

### DIFF
--- a/tools/tpm2_pkcs11/command.py
+++ b/tools/tpm2_pkcs11/command.py
@@ -16,7 +16,7 @@ class commandlet(object):
                 os.mkdir(store, 0o770);
             except FileExistsError:
                 return store
-            except:
+            except Exception:
                 # Keep trying
                 pass
             # Exists, use it
@@ -34,7 +34,7 @@ class commandlet(object):
                 os.mkdir(store, 0o770);
             except FileExistsError:
                 return store
-            except:
+            except Exception:
                 # Keep trying
                 pass
             # Exists, use it


### PR DESCRIPTION
I accidentally missed these LGTM Python warnings when I merged PR #436,
so fix them.

See:
  - https://lgtm.com/projects/g/tpm2-software/tpm2-pkcs11/rev/pr-670ec0eda659019041aa7246b9a1b86860526474
  - https://lgtm.com/rules/6780080/

Signed-off-by: William Roberts <william.c.roberts@intel.com>