### PR TITLE
Test: Extend pkcs11-tool tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 # only one build should report coverage stats
 matrix:
   include:
-  - env: ENABLE_COVERAGE=true DOCKER_TAG=ubuntu-16.04
+  - env: ENABLE_COVERAGE=true DOCKER_TAG=ubuntu-18.04
     compiler: gcc
 
 script:

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
+set -x
+
 source "$T/test/integration/scripts/helpers.sh"
 
 tempdir=$(mktemp -d)
@@ -25,6 +27,7 @@ fi
 echo "modpath=$modpath"
 
 pkcs11_tool() {
+#  valgrind pkcs11-tool --module "$modpath" "$@"
   pkcs11-tool --module "$modpath" "$@"
   return $?
 }
@@ -33,13 +36,20 @@ export TPM2_PKCS11_STORE="$tempdir"
 
 echo "TPM2_PKCS11_STORE=$TPM2_PKCS11_STORE"
 
+echo "testdata">${tempdir}/data
+
 echo "Should have unitialized token"
 pkcs11_tool -T | grep -q uninitialized
 echo "Found unitialized token"
 
+pkcs11_tool -I
+pkcs11_tool -T
+
 echo "Initializing token"
 pkcs11_tool --slot=1 --init-token --label=mynewtoken --so-pin=mynewsopin
 echo "Token initialized"
+
+pkcs11_tool -T
 
 echo "Initializing user pin"
 pkcs11_tool --slot=1 --login --login-type="so" --init-pin --so-pin=mynewsopin --pin=mynewuserpin
@@ -49,4 +59,20 @@ echo "Generating RSA keypair"
 pkcs11_tool --slot=1 --label="myrsakey" --login --pin=mynewuserpin --keypairgen
 echo "RSA Keypair generated"
 
+echo "Testing RSA signature"
+pkcs11_tool -v --list-objects --login --pin mynewuserpin
+
+pkcs11_tool -v --sign --login --slot=1 --label="myrsakey" --pin mynewuserpin \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism SHA256-RSA-PKCS
+
+pkcs11_tool -v --read-object --slot=1 --label="myrsakey" \
+            --type pubkey --output-file ${tempdir}/pubkey.der \
+    || exit 77
+#This fails on old pkcs11-tool versions, thus exit-skip here
+
+openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/sig -sha256 \
+             -sigopt rsa_padding_mode:pkcs1 \
+             ${tempdir}/data
+echo "RSA signature tested"
 exit 0


### PR DESCRIPTION
Add tests for listing and reading objects as well as signing (verified using openssl).

This should trigger a bug in CI that I cannot reproduce locally.