### PR TITLE
configure: check for python >= 3.7

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -39,9 +39,8 @@ if [[ "$CC" == clang* ]]; then
     echo "No llvm symbolizer found at: $ASAN_SYMBOLIZER_PATH"
     unset ASAN_SYMBOLIZER_PATH
   fi
-else #GCC
-  export ENABLE_COVERAGE=true
-  echo "Exported ENABLE_COVERAGE=true"
+else
+  echo "Enabling Code Coverage"
   config_flags="--disable-hardening --enable-code-coverage"
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     for details.
   * Fix printf(3) format specifier errors.
   * ci: increase CI coverage to: Fedora 30, Ubuntu 16.04, Ubuntu 18.04.
+  * configure: check for Python version >= 3.7 and pass to Automake. No
+    need to set PYTHON\_INTERPRETER anymore.
 
 ### 1.1.0 - 2020-03-09
   * DB Schema Change from 1 to 3.

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --with-p11kitconfigdir='$$(datarootdir)/p11kitcon
 # test harness configuration
 AM_TESTS_ENVIRONMENT = \
     T=$(abs_top_srcdir) \
+    PYTHON_INTERPRETER=@PYTHON_INTERPRETER@ \
     TEST_FUNC_LIB=$(srcdir)/test/integration/scripts/int-test-funcs.sh \
     TEST_FIXTURES=$(abs_top_srcdir)/test/integration/fixtures \
     PATH=$(abs_top_srcdir)/tools:./src:$(PATH) \

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,11 @@ AC_DEFUN([integration_test_checks], [
     AS_IF([test "x$bash" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but bash executable not found.])])
 
+  AM_PATH_PYTHON([3.7],
+    [AC_SUBST([PYTHON_INTERPRETER], [$PYTHON])],
+    [AC_MSG_ERROR([Integration tests enabled but python >= 3.7 executable not found.])]
+  )
+
   AS_IF([test "x$have_javac" = "xno"],
     [AC_MSG_ERROR([Integration tests enabled but no Java compiler was found])])
   AX_CHECK_CLASS([org.junit.Assert], ,

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,10 @@ AC_DEFUN([integration_test_checks], [
     AS_IF([test "x$bash" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but bash executable not found.])])
 
+  AC_CHECK_PROG([sqlite3], [sqlite3], [yes], [no])
+    AS_IF([test "x$sqlite3" != "xyes"],
+      [AC_MSG_ERROR([Integration tests enabled but sqlite3 executable not found.])])
+
   AM_PATH_PYTHON([3.7],
     [AC_SUBST([PYTHON_INTERPRETER], [$PYTHON])],
     [AC_MSG_ERROR([Integration tests enabled but python >= 3.7 executable not found.])]

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,8 @@ m4_popdef([AC_MSG_ERROR])
 AC_DEFUN([integration_test_checks], [
 
   PKG_CHECK_MODULES([CMOCKA],[cmocka])
-  PKG_CHECK_MODULES([OPENSC_PKCS11],[opensc-pkcs11])
+  PKG_CHECK_MODULES([OPENSC_PKCS11],[opensc-pkcs11],,
+    [AC_CHECK_FILE([/usr/lib/engines/engine_pkcs11.so])])
 
   AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
   AS_IF([test "x$tpm_server" != "xyes"],

--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,7 @@ m4_popdef([AC_MSG_ERROR])
 AC_DEFUN([integration_test_checks], [
 
   PKG_CHECK_MODULES([CMOCKA],[cmocka])
+  PKG_CHECK_MODULES([OPENSC_PKCS11],[opensc-pkcs11])
 
   AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
   AS_IF([test "x$tpm_server" != "xyes"],


### PR DESCRIPTION
Use autoconf to check for Python version >= 3.7 when enabling
integration tests and automatically pass that version into the
PYTHON_INTERPRETER variable in the automake check ENV.

Signed-off-by: William Roberts <william.c.roberts@intel.com>