### PR TITLE
ESYS: Implement ESYS 3.0 ABI break

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,10 @@ AC_DEFUN([do_esapi_manage_flags], [
 # Check for ESYS version below 2.2.1 which requires us to manage ESYS session flags
 PKG_CHECK_EXISTS([tss2-esys < 2.2.1], [do_esapi_manage_flags])
 
+# ESYS >= 3.0 uses a different ABI param hierarchy in Esys_LoadExternal()
+PKG_CHECK_EXISTS([tss2-esys >= 3.0],
+                 [AC_DEFINE([ESYS_3], [1], [Esys3])])
+
 # require sqlite3 and libcrypto
 PKG_CHECK_MODULES([SQLITE3],     [sqlite3])
 PKG_CHECK_MODULES([YAML],        [yaml-0.1])

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -774,7 +774,19 @@ static bool tpm_loadexternal(tpm_ctx *ctx,
         TPM2B_PUBLIC *pub,
         uint32_t *handle) {
 
-    TSS2_RC rval = Esys_LoadExternal(
+    TSS2_RC rval;
+#ifdef ESYS_3
+    rval = Esys_LoadExternal(
+           ctx->esys_ctx,
+           ESYS_TR_NONE,
+           ESYS_TR_NONE,
+           ESYS_TR_NONE,
+           NULL,
+           pub,
+           ESYS_TR_RH_NULL,
+           handle);
+#else /* ESYS_3 */
+    rval = Esys_LoadExternal(
            ctx->esys_ctx,
            ESYS_TR_NONE,
            ESYS_TR_NONE,
@@ -783,6 +795,7 @@ static bool tpm_loadexternal(tpm_ctx *ctx,
            pub,
            TPM2_RH_NULL,
            handle);
+#endif /* ESYS_3 */
     if (rval != TSS2_RC_SUCCESS) {
         LOGE("Esys_LoadExternal: %s:", Tss2_RC_Decode(rval));
         return false;


### PR DESCRIPTION
Latest tpm2-tss master includes an ABI break for ESYS that affects this project in the Esys_LoadExternal() call.
See https://github.com/tpm2-software/tpm2-tss/pull/1531 for details.

Evidence that this PR works on Esys >= 3.0 can be found here: https://travis-ci.org/github/AndreasFuchsSIT/tpm2-pkcs11/builds/663011856?utm_source=github_status&utm_medium=notification
(Note that the failed jobs there originate from the pkcs11-tool problems)