### PR TITLE
test: fix expect script for NSS pinentry

### DIFF
--- a/test/integration/fixtures/client.cnf
+++ b/test/integration/fixtures/client.cnf
@@ -3,7 +3,7 @@ default_ca		= CA_default
 
 [ CA_default ]
 fixtures    = $ENV::TEST_FIXTURES
-dir			= ./
+dir			= $ENV::CA_DIR
 certs			= $dir
 crl_dir			= $dir/crl
 database		= $dir/index.txt

--- a/test/integration/nss-tests.sh
+++ b/test/integration/nss-tests.sh
@@ -36,8 +36,8 @@ function cleanup() {
   if [ "$1" != "no-kill" ]; then
       pkill -P $$ || true
   fi
-  rm -f index.txt index.txt.attr serial serial.old index.txt.old index.txt.attr.old \
-        03.pem smimeclient.csr smimeclient.crt smimeclient.key smimeclient.pem \
+  cleanup_ca
+  rm -f smimeclient.csr smimeclient.crt smimeclient.key smimeclient.pem \
         pkcs11.txt cert9.db key4.db userpin.txt
 }
 trap cleanup EXIT
@@ -57,7 +57,7 @@ fi
 echo "modpath=$modpath"
 
 # setup the CA BEFORE EXPORTING THE CA CONF for the clients
-setup_ca "03"
+setup_ca
 
 echo "Creating S/MIME certificate for testuser@example.org"
 openssl req -new -newkey rsa:2048 -nodes -keyout smimeclient.key \

--- a/test/integration/nss-tests.sh
+++ b/test/integration/nss-tests.sh
@@ -16,12 +16,20 @@ if [ "$ASAN_ENABLED" = "true" ]; then
 fi
 
 function pinentry() {
-  pin="$1"
-  shift
-  cmd="$*"
-  printf 'spawn %s\nexpect "Password or Pin"\nsend -- %s\\r\nexpect eof\n' \
-	  "$cmd" "$pin" | expect
-  exit $?
+  expect <<END
+spawn $*
+expect {
+  "Password or Pin *label*:" {
+    sleep 1; send -- "myuserpin\r"; exp_continue
+  } "Password or Pin *import-keys*:" {
+    sleep 1; send -- "anotheruserpin\r"; exp_continue
+  } "Password or Pin *esys-tr*:" {
+    sleep 1; send -- "userpin3\r"; exp_continue
+  } eof
+}
+catch wait result
+exit [ lindex \$result 3 ]
+END
 }
 
 function cleanup() {
@@ -81,20 +89,20 @@ echo "Importing S/MIME certificate to TPM2 token"
 tpm2_ptool addcert --label import-keys --key-label smimetest smimeclient.pem
 
 echo "Testing S/MIME certificate lookup in NSS DB via label"
-pinentry anotheruserpin certutil -L -d . -n import-keys:smimetest
+pinentry certutil -L -d . -n import-keys:smimetest
 
 # See: https://github.com/tpm2-software/tpm2-pkcs11/issues/444
-#echo "Testing S/MIME certificate lookup in NSS DB via mail address"
-#pinentry anotheruserpin certutil -L -d . --email testuser@example.org
+echo "Testing S/MIME certificate lookup in NSS DB via mail address"
+pinentry certutil -L -d . -h import-keys --email testuser@example.org
 
 echo "Testing if S/MIME certificate in NSS DB has user trust"
-pinentry anotheruserpin certutil -L -d . -h import-keys | \
+pinentry certutil -L -d . -h import-keys | \
    grep import-keys:smimetest | grep -q u,u,u
 
 echo "Testing if S/MIME certificate in NSS DB is valid for mail signing"
-pinentry anotheruserpin certutil -V -d . -n import-keys:smimetest -u S
+pinentry certutil -V -d . -n import-keys:smimetest -u S
 
 echo "Testing if S/MIME certificate in NSS DB is valid for mail reception"
-pinentry anotheruserpin certutil -V -d . -n import-keys:smimetest -u R
+pinentry certutil -V -d . -n import-keys:smimetest -u R
 
 exit 0


### PR DESCRIPTION
Make sure all test tokens can be unlocked with matching PINs, and
propagate exit code of spawned process from expect.

Fixes: #444