### PR TITLE
C_Login: fix segfault on no userpin

### DIFF
--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -180,10 +180,10 @@ CK_RV backend_init_user(token *t, const twist sealdata,
 CK_RV backend_add_object(token *t, tobject *tobj) {
     switch (t->type) {
     case token_type_esysdb:
-        LOGE("Adding object to token using esysdb backend.");
+        LOGV("Adding object to token using esysdb backend.");
         return backend_esysdb_add_object(t, tobj);
     case token_type_fapi:
-        LOGE("Adding object to token using fapi backend.");
+        LOGV("Adding object to token using fapi backend.");
         return backend_fapi_add_object(t, tobj);
     default:
         assert(1);


### PR DESCRIPTION
Fix:
tpm2pkcs11-tool --slot-index=0 --login --pin="myuserpin" --label="myrsakey" --keypairgen
Using slot with index 0 (0x1)
Segmentation fault (core dumped)

Caused by seal object's private and public twist blobs being NULL and
where twist_len was called and dereferences NULL. This occurs when a
token is initialized but a userpin is not set. This condition should
return CKR_USER_PIN_NOT_INITIALIZED.

Signed-off-by: William Roberts <william.c.roberts@intel.com>