### PR TITLE
use safe arithmetic

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -17,7 +17,7 @@ fi
 # If it's clang, enable asan
 if [[ "$CC" == clang* ]]; then
   echo "Detecting clang, enable asan"
-  export CFLAGS="-O1 -g -fsanitize=address -fno-omit-frame-pointer"
+  export CFLAGS="-O1 -g -fsanitize=address -fno-omit-frame-pointer -DDISABLE_OVERFLOW_BUILTINS"
   echo "Exported CFLAGS=$CFLAGS"
   config_flags="--disable-hardening"
   echo "Disabled configure option hardening"

--- a/src/lib/emitter.c
+++ b/src/lib/emitter.c
@@ -22,16 +22,23 @@ static int output_handler(void *data, unsigned char *buffer, size_t size) {
 
     yaml_emitter_state *s = (yaml_emitter_state *)data;
 
-    /* todo overflow safety */
-    size_t newsize = s->size + size;
-    void *ptr = realloc(s->buf, newsize + 1);
+    size_t newsize = 0;
+    safe_add(newsize, s->size, size);
+
+    size_t newsize_1 = 0;
+    safe_add(newsize_1, newsize, 1);
+
+    void *ptr = realloc(s->buf, newsize_1);
     if (!ptr) {
         free(s->buf);
         return 0;
     }
     s->buf = ptr;
 
-    memset(&s->buf[s->size], 0, size + 1);
+    size_t size_1 = 0;
+    safe_add(size_1, size, 1);
+
+    memset(&s->buf[s->size], 0, size_1);
     memcpy(&s->buf[s->size], buffer, size);
 
     s->size = newsize;

--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -37,7 +37,7 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
     char *split = strchr(buf, '.');
     if (split) {
         split[0] = '\0';
-        minor_str = split + 1;
+        minor_str = &split[1];
     }
 
     if (!major_str[0] || !minor_str[0]) {

--- a/src/lib/mech.c
+++ b/src/lib/mech.c
@@ -606,7 +606,8 @@ CK_RV rsa_keygen_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs) 
         return CKR_TEMPLATE_INCOMPLETE;
     }
 
-    CK_ULONG bits = a->ulValueLen * 8;
+    CK_ULONG bits = 0;
+    safe_mul(bits, a->ulValueLen, 8);
 
     CK_ULONG i;
     for (i=0; i < m->mdetail_len; i++) {
@@ -958,7 +959,8 @@ CK_RV rsa_pkcs_hash_synthesizer(mdetail *mdtl,
                 "got: %lu, expected: %lu", inlen, hash_len);
     }
 
-    size_t total_size = hdr_size + hash_len;
+    size_t total_size = 0;
+    safe_add(total_size, hdr_size, hash_len);
 
     CK_BYTE hdr_buf[4096];
     if (total_size > sizeof(hdr_buf)) {
@@ -1104,7 +1106,9 @@ CK_RV mech_get_supported(mdetail *m, CK_MECHANISM_TYPE_PTR mechlist, CK_ULONG_PT
             rv = CKR_BUFFER_TOO_SMALL;
             goto out;
         }
-        memcpy(mechlist, tmp, supported * sizeof(mechlist[0]));
+        size_t bytes = 0;
+        safe_mul(bytes, supported, sizeof(mechlist[0]));
+        memcpy(mechlist, tmp, bytes);
     }
 
     rv = CKR_OK;

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -152,7 +152,10 @@ CK_RV tobject_get_max_buf_size(tobject *tobj, size_t *maxsize) {
         /* an R or S with a high bit set needs an extra nul byte so it's not negative (twos comp)*/
         static const unsigned EXTRA = 1U;
 
-        unsigned tmp = ((keysize + INT_HDR + EXTRA) * 2); /* x2 1 for R and 1 for S */
+        unsigned tmp = 0;
+        safe_add(tmp, keysize, INT_HDR);
+        safe_adde(tmp, EXTRA);
+        safe_mule(tmp, 2);
 
         tmp += SEQ_HDR;
 

--- a/src/lib/typed_memory.c
+++ b/src/lib/typed_memory.c
@@ -6,14 +6,15 @@
 
 #include "pkcs11.h"
 #include "typed_memory.h"
+#include "utils.h"
 
 void *type_calloc(size_t nmemb, size_t size, CK_BYTE type) {
 
     assert(size != 0);
 
-    // overflow safety here...
-    size_t total = nmemb * size;
-    total += 1;
+    size_t total = 0;
+    safe_mul(total, nmemb, size);
+    safe_adde(total, 1);
 
     CK_BYTE_PTR ptr = (CK_BYTE_PTR)calloc(1, total);
     if (!ptr) {
@@ -64,10 +65,11 @@ void type_mem_cpy(void *dest, void *in, size_t size) {
     assert(in);
     assert(dest);
     assert(size);
-    memcpy(dest, in, size + 1);
+    safe_adde(size, 1);
+    memcpy(dest, in, size);
 #ifndef NDEBUG
-    CK_BYTE check = type_from_ptr(in, size);
-    CK_BYTE got = type_from_ptr(dest, size);
+    CK_BYTE check = type_from_ptr(in, size - 1);
+    CK_BYTE got = type_from_ptr(dest, size - 1);
     assert(check == got);
 #endif
 }

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -176,7 +176,7 @@ twist aes256_gcm_encrypt(twist keybin, twist plaintextbin) {
     assert((size_t)len == twist_len(plaintextbin));
 
     int left = 0;
-    ret = EVP_EncryptFinal_ex(ctx, ctextbin + len, &left);
+    ret = EVP_EncryptFinal_ex(ctx, &ctextbin[len], &left);
     if (!ret) {
         LOGE("AES GCM verification failed!");
         goto out;

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -167,7 +167,7 @@ twist aes256_gcm_encrypt(twist keybin, twist plaintextbin) {
     }
 
     int len = 0;
-    ret = EVP_EncryptUpdate(ctx, (CK_BYTE_PTR )ctextbin, &len, (CK_BYTE_PTR )plaintextbin, twist_len(plaintextbin));
+    ret = EVP_EncryptUpdate(ctx, ctextbin, &len, (CK_BYTE_PTR )plaintextbin, twist_len(plaintextbin));
     if (!ret) {
         LOGE("EVP_EncryptUpdate failed");
         goto out;

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -108,8 +108,15 @@ static twist encrypt_parts_to_twist(CK_BYTE tag[16], CK_BYTE iv[12], CK_BYTE_PTR
      * create a buffer with enough space for hex encoded <iv>:<tag>:<ctext>
      * (note + 3 is for 2 : delimiters and a NULL byte.
      */
-    size_t constructed_len = twist_len(taghex) + twist_len(ivhex)
-            + twist_len(ctexthex) + 3;
+    size_t a = twist_len(taghex);
+    size_t b = twist_len(ivhex);
+    size_t c = twist_len(ctexthex);
+
+    size_t constructed_len = 0;
+    safe_add(constructed_len, a, b);
+    safe_adde(constructed_len, c);
+    safe_adde(constructed_len, 3);
+
     constructed = twist_calloc(constructed_len);
     if (!constructed) {
         LOGE("oom");
@@ -213,7 +220,7 @@ twist aes256_gcm_decrypt(const twist key, const twist objauth) {
 
     objcopy = twist_dup(objauth);
     if (!objcopy) {
-        LOGE("oom");
+        LOGE("oom0");
         return NULL;
     }
 
@@ -423,7 +430,7 @@ CK_RV ec_params_to_nid(CK_ATTRIBUTE_PTR ecparams, int *nid) {
         return CKR_ATTRIBUTE_VALUE_INVALID;
     }
 
-    * nid = OBJ_obj2nid(a);
+    *nid = OBJ_obj2nid(a);
     ASN1_OBJECT_free(a);
 
     return CKR_OK;

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -293,7 +293,7 @@ twist aes256_gcm_decrypt(const twist key, const twist objauth) {
         goto out;
     }
 
-    ret = EVP_DecryptFinal_ex(ctx, ((CK_BYTE_PTR )plaintext) + len, &len);
+    ret = EVP_DecryptFinal_ex(ctx, &((CK_BYTE_PTR )plaintext)[len], &len);
     if (!ret) {
         LOGE("AES GCM verification failed!");
         goto out;

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "log.h"
 #include "pkcs11.h"
 #include "twist.h"
 
@@ -83,5 +84,10 @@ CK_RV utils_ctx_wrap_objauth(token *tok, twist objauth, twist *wrapped_auth);
  *  CKR_OK on success.
  */
 CK_RV ec_params_to_nid(CK_ATTRIBUTE_PTR ecparams, int *nid);
+
+#define safe_add(r, a, b) do { if (__builtin_add_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_adde(r, a)   do { if (__builtin_add_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_mul(r, a, b) do { if (__builtin_mul_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_mule(r, a)   do { if (__builtin_mul_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
 
 #endif /* SRC_PKCS11_UTILS_H_ */

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -85,9 +85,24 @@ CK_RV utils_ctx_wrap_objauth(token *tok, twist objauth, twist *wrapped_auth);
  */
 CK_RV ec_params_to_nid(CK_ATTRIBUTE_PTR ecparams, int *nid);
 
+/*
+ * Work around bugs in clang not including the builtins, and when asan is enabled
+ * ending up in a nightmare of having both the ASAN and BUILTINS defined and linked
+ * properly.
+ *  See:
+ *  - https://bugs.llvm.org/show_bug.cgi?id=16404
+ *  - https://lists.gnu.org/archive/html/bug-gnulib/2019-08/msg00076.html
+ */
+#ifdef DISABLE_OVERFLOW_BUILTINS
+#define safe_add(r, a, b) do { r = a + b; } while(0)
+#define safe_adde(r, a)   do { r += a;    } while(0)
+#define safe_mul(r, a, b) do { r = a * b; } while(0)
+#define safe_mule(r, a)   do { r *= a;    } while(0)
+#else
 #define safe_add(r, a, b) do { if (__builtin_add_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
 #define safe_adde(r, a)   do { if (__builtin_add_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
 #define safe_mul(r, a, b) do { if (__builtin_mul_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
 #define safe_mule(r, a)   do { if (__builtin_mul_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
+#endif
 
 #endif /* SRC_PKCS11_UTILS_H_ */


### PR DESCRIPTION
Just to help prevent overflows in the code base, use the builtin arithmetic routines that detect overflow conditions.