### PR TITLE
Test/FAPI: Fix fapi-config

### DIFF
--- a/test/integration/scripts/int-test-funcs.sh
+++ b/test/integration/scripts/int-test-funcs.sh
@@ -132,6 +132,7 @@ cat > $tempdir/fapi_config.json <<EOF
     "system_dir": "$tempdir/${KEYSTORE_SYSTEM}",
     "tcti": "${TPM2_PKCS11_TCTI}",
     "system_pcrs" : [],
+    "ek_cert_less": "yes",
     "log_dir" : "$tempdir/${LOG_DIR}",
 }
 EOF


### PR DESCRIPTION
fapi-config needs ek_cert_less option set to work with latest fapi master branch.

This mirrors this PR from the tools: https://github.com/tpm2-software/tpm2-tools/pull/1969