### PR TITLE
FAPI: Decoupling for esysdb & implement changeauth

### DIFF
--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -77,9 +77,12 @@ CK_RV backend_destroy(void) {
 }
 
 CK_RV backend_ctx_new(token *t) {
-    CK_RV rv = backend_fapi_ctx_new(t);
-    if (rv) {
-        return rv;
+    bool is_fapi_preview = is_fapi_preview_enabled();
+    if (is_fapi_preview) {
+        CK_RV rv = backend_fapi_ctx_new(t);
+        if (rv) {
+            return rv;
+        }
     }
     return backend_esysdb_ctx_new(t);
 }

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -292,3 +292,27 @@ CK_RV backend_rm_tobject(token *tok, tobject *tobj) {
         return CKR_GENERAL_ERROR;
     }
 }
+
+/** Unseal a token's wrapping key.
+ *
+ * Unseal a token's wrapping key as part of the Login process.
+ * The wrapping key is then used to decrypt the individual tobjects'
+ * auth values.
+ *
+ * @param[in,out] tok The token to remove from.
+ * @param[in] user Whether to unseal from the user or so seal.
+ * @param[in] tpin The pin value to use for unsealing.
+ * @return CKR_OK on success, anything else is an error.
+ */
+CK_RV backend_token_unseal_wrapping_key(token *tok, bool user, twist tpin) {
+
+    switch (tok->type) {
+    case token_type_esysdb:
+        return backend_esysdb_token_unseal_wrapping_key(tok, user, tpin);
+    case token_type_fapi:
+        return backend_fapi_token_unseal_wrapping_key(tok, user, tpin);
+    default:
+        assert(1);
+        return CKR_GENERAL_ERROR;
+    }
+}

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -319,3 +319,23 @@ CK_RV backend_token_unseal_wrapping_key(token *tok, bool user, twist tpin) {
         return CKR_GENERAL_ERROR;
     }
 }
+
+/** Change the authValue of a token's seal blob.
+ *
+ * @param[in,out] tok The token to remove from.
+ * @param[in] user Whether to unseal from the user or so seal.
+ * @param[in] tpin The pin value to use for unsealing.
+ * @return CKR_OK on success, anything else is an error.
+ */
+CK_RV backend_token_changeauth(token *tok, bool user, twist toldpin, twist tnewpin) {
+
+    switch (tok->type) {
+    case token_type_esysdb:
+        return backend_esysdb_token_changeauth(tok, user, toldpin, tnewpin);
+    case token_type_fapi:
+        return backend_fapi_token_changeauth(tok, user, toldpin, tnewpin);
+    default:
+        assert(1);
+        return CKR_GENERAL_ERROR;
+    }
+}

--- a/src/lib/backend.h
+++ b/src/lib/backend.h
@@ -30,4 +30,6 @@ CK_RV backend_update_tobject_attrs(token *tok, tobject *tobj, attr_list *attrs);
 
 CK_RV backend_rm_tobject(token *tok, tobject *tobj);
 
+CK_RV backend_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
+
 #endif /* SRC_LIB_BACKEND_H_ */

--- a/src/lib/backend.h
+++ b/src/lib/backend.h
@@ -32,4 +32,6 @@ CK_RV backend_rm_tobject(token *tok, tobject *tobj);
 
 CK_RV backend_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
 
+CK_RV backend_token_changeauth(token *tok, bool user, twist toldpin, twist tnewpin);
+
 #endif /* SRC_LIB_BACKEND_H_ */

--- a/src/lib/backend_esysdb.c
+++ b/src/lib/backend_esysdb.c
@@ -229,3 +229,79 @@ CK_RV backend_esysdb_rm_tobject(tobject *tobj) {
 
     return db_delete_object(tobj);
 }
+
+/** Unseal a token's wrapping key.
+ *
+ * see backend_token_unseal_wrapping_key()
+ */
+CK_RV backend_esysdb_token_unseal_wrapping_key(token *tok, bool user, twist tpin) {
+
+    CK_RV rv = CKR_GENERAL_ERROR;
+    bool on_error_flush_session = false;
+
+    sealobject *sealobj = &tok->sealobject;
+    twist sealpub = user ? sealobj->userpub : sealobj->sopub;
+    twist sealpriv = user ? sealobj->userpriv : sealobj->sopriv;
+
+    if (user && !sealpub && !sealpriv) {
+        return CKR_USER_PIN_NOT_INITIALIZED;
+    }
+
+    assert(sealpub);
+    assert(sealpriv);
+
+    if (!tpm_session_active(tok->tctx)) {
+        LOGV("token parent object handle is 0x%08x", tok->pobject.handle);
+        CK_RV tmp = tpm_session_start(tok->tctx, tok->pobject.objauth, tok->pobject.handle);
+        if (tmp != CKR_OK) {
+            LOGE("Could not start Auth Session with the TPM.");
+            return tmp;
+        }
+
+        on_error_flush_session = true;
+    }
+
+    uint32_t pobj_handle = tok->pobject.handle;
+    twist pobjauth = tok->pobject.objauth;
+    uint32_t sealhandle;
+
+    bool res = tpm_loadobj(tok->tctx, pobj_handle, pobjauth, sealpub, sealpriv, &sealhandle);
+    if (!res) {
+        goto error;
+    }
+
+    twist sealsalt = user ? sealobj->userauthsalt : sealobj->soauthsalt;
+    twist sealobjauth = utils_hash_pass(tpin, sealsalt);
+    if (!sealobjauth) {
+        rv = CKR_HOST_MEMORY;
+        goto error;
+    }
+
+    twist wrappingkeyhex = tpm_unseal(tok->tctx, sealhandle, sealobjauth);
+    twist_free(sealobjauth);
+    tpm_flushcontext(tok->tctx, sealhandle);
+    if (!wrappingkeyhex) {
+        rv = CKR_PIN_INCORRECT;
+        goto error;
+    }
+
+    if (tok->wrappingkey) {
+        twist_free(wrappingkeyhex);
+    } else {
+        tok->wrappingkey = twistbin_unhexlify(wrappingkeyhex);
+        twist_free(wrappingkeyhex);
+        if (!tok->wrappingkey) {
+            LOGE("Expected internal wrapping key in base 16 format");
+            goto error;
+        }
+    }
+
+    return CKR_OK;
+
+error:
+    if (on_error_flush_session) {
+        tpm_session_stop(tok->tctx);
+    }
+
+    return rv;
+}

--- a/src/lib/backend_esysdb.c
+++ b/src/lib/backend_esysdb.c
@@ -90,14 +90,14 @@ CK_RV backend_esysdb_create_token_seal(token *t, const twist hexwrappingkey,
 
     /* we have a primary object, create the seal object underneath it */
     rv = tpm2_create_seal_obj(t->tctx, t->pobject.objauth, t->pobject.handle,
-            newauth, NULL, hexwrappingkey, &t->sealobject.sopub,
-            &t->sealobject.sopriv);
+            newauth, NULL, hexwrappingkey, &t->esysdb.sealobject.sopub,
+            &t->esysdb.sealobject.sopriv);
     if (rv != CKR_OK) {
         LOGE("Could not create SO seal object");
         goto error;
     }
 
-    t->sealobject.soauthsalt = newsalthex;
+    t->esysdb.sealobject.soauthsalt = newsalthex;
 
     /* TODO get TCTI config from ENV var and use throughout this process */
     t->config.is_initialized = true;
@@ -130,13 +130,13 @@ static void change_token_mem_data(token *tok, bool is_so,
     twist *pub;
 
     if (is_so) {
-        authsalt = &tok->sealobject.soauthsalt;
-        priv = &tok->sealobject.sopriv;
-        pub = &tok->sealobject.sopub;
+        authsalt = &tok->esysdb.sealobject.soauthsalt;
+        priv = &tok->esysdb.sealobject.sopriv;
+        pub = &tok->esysdb.sealobject.sopub;
     } else {
-        authsalt = &tok->sealobject.userauthsalt;
-        priv = &tok->sealobject.userpriv;
-        pub = &tok->sealobject.userpub;
+        authsalt = &tok->esysdb.sealobject.userauthsalt;
+        priv = &tok->esysdb.sealobject.userpriv;
+        pub = &tok->esysdb.sealobject.userpub;
     }
 
     twist_free(*authsalt);
@@ -167,7 +167,7 @@ CK_RV backend_esysdb_init_user(token *tok, const twist sealdata,
             tok->pobject.objauth,
             tok->pobject.handle,
             newauthhex,
-            tok->sealobject.userpub,
+            tok->esysdb.sealobject.userpub,
             sealdata,
             &newpubblob,
             &newprivblob);
@@ -239,7 +239,7 @@ CK_RV backend_esysdb_token_unseal_wrapping_key(token *tok, bool user, twist tpin
     CK_RV rv = CKR_GENERAL_ERROR;
     bool on_error_flush_session = false;
 
-    sealobject *sealobj = &tok->sealobject;
+    sealobject *sealobj = &tok->esysdb.sealobject;
     twist sealpub = user ? sealobj->userpub : sealobj->sopub;
     twist sealpriv = user ? sealobj->userpriv : sealobj->sopriv;
 

--- a/src/lib/backend_esysdb.h
+++ b/src/lib/backend_esysdb.h
@@ -30,4 +30,6 @@ CK_RV backend_esysdb_rm_tobject(tobject *tobj);
 
 CK_RV backend_esysdb_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
 
+CK_RV backend_esysdb_token_changeauth(token *tok, bool user, twist toldpin, twist tnewpin);
+
 #endif /* SRC_LIB_BACKEND_ESYSDB_H_ */

--- a/src/lib/backend_esysdb.h
+++ b/src/lib/backend_esysdb.h
@@ -28,4 +28,6 @@ CK_RV backend_esysdb_update_tobject_attrs(tobject *tobj, attr_list *attrs);
 
 CK_RV backend_esysdb_rm_tobject(tobject *tobj);
 
+CK_RV backend_esysdb_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
+
 #endif /* SRC_LIB_BACKEND_ESYSDB_H_ */

--- a/src/lib/backend_fapi.h
+++ b/src/lib/backend_fapi.h
@@ -26,4 +26,6 @@ CK_RV backend_fapi_update_tobject_attrs(token *tok, tobject *tobj, attr_list *at
 
 CK_RV backend_fapi_rm_tobject(token *tok, tobject *tobj);
 
+CK_RV backend_fapi_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
+
 #endif /* SRC_LIB_BACKEND_FAPI_H_ */

--- a/src/lib/backend_fapi.h
+++ b/src/lib/backend_fapi.h
@@ -28,4 +28,6 @@ CK_RV backend_fapi_rm_tobject(token *tok, tobject *tobj);
 
 CK_RV backend_fapi_token_unseal_wrapping_key(token *tok, bool user, twist tpin);
 
+CK_RV backend_fapi_token_changeauth(token *tok, bool user, twist toldpin, twist tnewpin);
+
 #endif /* SRC_LIB_BACKEND_FAPI_H_ */

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -387,7 +387,7 @@ CK_RV db_get_tokens(token **tok, size_t *len) {
             continue;
         }
 
-        rc = init_sealobjects(t->id, &t->sealobject);
+        rc = init_sealobjects(t->id, &t->esysdb.sealobject);
         if (rc != SQLITE_OK) {
             goto error;
         }
@@ -984,15 +984,15 @@ CK_RV db_add_token(token *tok) {
     rc = sqlite3_bind_int(stmt, 1, tok->id);
     gotobinderror(rc, "tokid");
 
-    rc = sqlite3_bind_text(stmt, 2, tok->sealobject.soauthsalt, -1, SQLITE_STATIC);
+    rc = sqlite3_bind_text(stmt, 2, tok->esysdb.sealobject.soauthsalt, -1, SQLITE_STATIC);
     gotobinderror(rc, "soauthsalt");
 
-    rc = sqlite3_bind_blob(stmt, 3, tok->sealobject.sopriv,
-            twist_len(tok->sealobject.sopriv), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(stmt, 3, tok->esysdb.sealobject.sopriv,
+            twist_len(tok->esysdb.sealobject.sopriv), SQLITE_STATIC);
     gotobinderror(rc, "sopriv");
 
-    rc = sqlite3_bind_blob(stmt, 4, tok->sealobject.sopub,
-            twist_len(tok->sealobject.sopub), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(stmt, 4, tok->esysdb.sealobject.sopub,
+            twist_len(tok->esysdb.sealobject.sopub), SQLITE_STATIC);
     gotobinderror(rc, "sopub");
 
     rc = sqlite3_step(stmt);

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -233,7 +233,9 @@ void token_free(token *t) {
     twist_free(t->pobject.objauth);
     t->pobject.objauth = NULL;
 
-    sealobject_free(&t->sealobject);
+    if (t->type == token_type_esysdb) {
+        sealobject_free(&t->esysdb.sealobject);
+    }
 
     if (t->tobjects.head) {
         list *cur = &t->tobjects.head->l;
@@ -407,13 +409,13 @@ static void change_token_mem_data(token *tok, bool is_so,
     twist *pub;
 
     if (is_so) {
-        authsalt = &tok->sealobject.soauthsalt;
-        priv = &tok->sealobject.sopriv;
-        pub = &tok->sealobject.sopub;
+        authsalt = &tok->esysdb.sealobject.soauthsalt;
+        priv = &tok->esysdb.sealobject.sopriv;
+        pub = &tok->esysdb.sealobject.sopub;
     } else {
-        authsalt = &tok->sealobject.userauthsalt;
-        priv = &tok->sealobject.userpriv;
-        pub = &tok->sealobject.userpub;
+        authsalt = &tok->esysdb.sealobject.userauthsalt;
+        priv = &tok->esysdb.sealobject.userpriv;
+        pub = &tok->esysdb.sealobject.userpub;
     }
 
     twist_free(*authsalt);
@@ -473,7 +475,7 @@ CK_RV token_setpin(token *tok, CK_UTF8CHAR_PTR oldpin, CK_ULONG oldlen, CK_UTF8C
     /*
      * Step 2 - Generate the current auth value from oldpin
      */
-    twist oldsalt = is_so ? tok->sealobject.soauthsalt : tok->sealobject.userauthsalt;
+    twist oldsalt = is_so ? tok->esysdb.sealobject.soauthsalt : tok->esysdb.sealobject.userauthsalt;
 
     twist oldauth = utils_hash_pass(toldpin, oldsalt);
     if (!oldauth) {
@@ -491,7 +493,7 @@ CK_RV token_setpin(token *tok, CK_UTF8CHAR_PTR oldpin, CK_ULONG oldlen, CK_UTF8C
 
     }
 
-    sealobject *sealobj = &tok->sealobject;
+    sealobject *sealobj = &tok->esysdb.sealobject;
 
     twist sealpub = is_so ? sealobj->sopub : sealobj->userpub;
     twist sealpriv = is_so ? sealobj->sopriv : sealobj->userpriv;

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -72,20 +72,20 @@ struct token {
 
     enum token_type type;
 
-//TODO: uncomment union, once both backends are completely separated.
-//    union { /* anon union for backend data */
+    token_config config;
+
+    pobject pobject;
+
+    union { /* anon union for backend data */
         struct {
-            token_config config;
-
-            pobject pobject;
-
             sealobject sealobject;
-
-        }; /* esysdb */
+        } esysdb; /* esysdb */
         struct {
             FAPI_CONTEXT *ctx;
+            twist userauthsalt;
+            twist soauthsalt;
         } fapi;
-//    };
+    };
 
     /* This context will be filled by fapi for use with esys-only commands. */
     tpm_ctx *tctx;

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -75,6 +75,11 @@ openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/si
              ${tempdir}/data
 echo "RSA signature tested"
 
+echo "Change PIN test"
+pkcs11_tool --change-pin --slot-index=0 --pin=mynewuserpin --login --new-pin=temppin
+pkcs11_tool --change-pin --slot-index=0 --pin=temppin --login --new-pin=mynewuserpin
+echo "PIN change tested"
+
 #
 # Regression test for https://github.com/tpm2-software/tpm2-pkcs11/issues/399
 # Delete Private Key then Public Key.


### PR DESCRIPTION
Decouple esysdb and fapi backend by enabling the union in struct token.
Moving the unsealing into the backend.
Refactor changeauth to be a backend-function.
Implement changeauth for FAPI backend.

build ontop of #493 