### PR TITLE
Fix and test C_SetAttributeValue via label

### DIFF
--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -264,7 +264,6 @@ CK_RV backend_update_tobject_attrs(token *tok, tobject *tobj, attr_list *attrs) 
 
     switch (tok->type) {
     case token_type_esysdb:
-        LOGV("Adding object to token using esysdb backend.");
         return backend_esysdb_update_tobject_attrs(tobj, attrs);
     case token_type_fapi:
         return backend_fapi_update_tobject_attrs(tok, tobj, attrs);

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -834,7 +834,7 @@ CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs) {
         LOGE("Could not emit tobject attributes");
         return CKR_GENERAL_ERROR;
     }
-
+LOGE("XXXXX %s\n\n", attr_str);
     const char *sql =
           "UPDATE tobjects SET"
             " attrs=?"      // index: 1 type: TEXT (JSON)

--- a/test/integration/p11-tool.sh.nosetup
+++ b/test/integration/p11-tool.sh.nosetup
@@ -125,6 +125,13 @@ p11_tool --generate-rsa --bits 2048 --login --label="myrsakey" --outfile="${temp
 p11_tool --list-all ${TOKENURL}
 echo "RSA Keypair generated"
 
+echo "Change the keypair label"
+GNUTLS_PIN=mynewuserpin \
+p11_tool --login --label="myrsakey" --set-label="myrsakey2" ${TOKENURL}
+p11_tool --list-all ${TOKENURL}
+p11_tool --login --label="myrsakey2" --set-label="myrsakey" ${TOKENURL}
+echo "RSA Keypair generated"
+
 echo "Testing signing via openssl"
 osslconf="$tempdir/ossl.cnf"
 cat << EOF > "$osslconf"

--- a/test/integration/p11-tool.sh.nosetup
+++ b/test/integration/p11-tool.sh.nosetup
@@ -122,14 +122,17 @@ echo "Userpin initialized"
 echo "Generating RSA keypair"
 GNUTLS_PIN=mynewuserpin \
 p11_tool --generate-rsa --bits 2048 --login --label="myrsakey" --outfile="${tempdir}/pubkey.pem" ${TOKENURL}
-p11_tool --list-all ${TOKENURL}
+GNUTLS_PIN=mynewuserpin \
+p11_tool --login --list-all ${TOKENURL}
 echo "RSA Keypair generated"
 
 echo "Change the keypair label"
 GNUTLS_PIN=mynewuserpin \
-p11_tool --login --label="myrsakey" --set-label="myrsakey2" ${TOKENURL}
-p11_tool --list-all ${TOKENURL}
-p11_tool --login --label="myrsakey2" --set-label="myrsakey" ${TOKENURL}
+p11_tool --login --set-label="myrsakey2" "${TOKENURL};object=myrsakey;object-type=private"
+GNUTLS_PIN=mynewuserpin \
+p11_tool --login --list-all ${TOKENURL}
+GNUTLS_PIN=mynewuserpin \
+p11_tool --login --set-label="myrsakey" "${TOKENURL};object=myrsakey2;object-type=private"
 echo "RSA Keypair generated"
 
 echo "Testing signing via openssl"


### PR DESCRIPTION
So this fixes the C_SetAttributeValue handling of the FAPI backend and adds a test using p11tool.

Problem is, that the esysdb backend fails now.
The problem is that the label is not changed.
I could trace as far as db_update_tobject_attrs() being correct; i.e. containing the correct attributes.

No idea where to search next ?

P.S. The successful runners are those that skip p11tool tests.
PP.S. The error shows in the list-all where the private key is still called "myrsakey" instead of "myrsakey2"