### PR TITLE
FAPI: SRK

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -50,7 +50,7 @@ AM_NOSETUP_LOG_FLAGS = --tabrmd-tcti=mssim
 NOSETUP_LOG_COMPILER=$(LOG_COMPILER)
 
 AM_FAPI_LOG_FLAGS = --tabrmd-tcti=mssim
-FAPI_LOG_COMPILER=env FAPI_PREVIEW=true $(LOG_COMPILER)
+FAPI_LOG_COMPILER=env TPM2_PKCS11_BACKEND=fapi $(LOG_COMPILER)
 
 test_integration_pkcs_find_objects_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_find_objects_int_LDADD   = $(TESTS_LDADD)

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AC_CONFIG_FILES([Makefile lib/tpm2-pkcs11.pc])
 AC_CONFIG_HEADERS([src/lib/config.h])
 
 # test for TSS dependecies
-PKG_CHECK_MODULES([TSS2_FAPI],   [tss2-fapi])
+PKG_CHECK_MODULES([TSS2_FAPI],   [tss2-fapi >= 3.0])
 PKG_CHECK_MODULES([TSS2_ESYS],   [tss2-esys >= 2.0])
 PKG_CHECK_MODULES([TSS2_MU],     [tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])

--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -10,6 +10,51 @@
 FAPI_CONTEXT *fctx = NULL;
 unsigned maxobjectid = 0;
 
+static CK_RV get_key(FAPI_CONTEXT *fctx, tpm_ctx *tctx, const char *path, uint32_t *esysHandle, uint32_t *tpmHandle) {
+
+    bool ret;
+    TSS2_RC rc;
+    uint8_t type;
+    uint8_t *data;
+    size_t length;
+
+    rc = Fapi_GetEsysBlob(fctx, path, &type, &data, &length);
+    if (rc != TSS2_RC_SUCCESS) {
+        LOGE("Cannot get Esys blob for key %s", path);
+        return CKR_GENERAL_ERROR;
+    }
+
+    twist twistdata = twistbin_new(data, length);
+    Fapi_Free(data);
+    if (!twistdata) {
+        return CKR_HOST_MEMORY;
+    }
+
+    switch(type) {
+    case FAPI_ESYSBLOB_CONTEXTLOAD:
+        ret = tpm_contextload_handle(tctx, twistdata, esysHandle);
+        if (!ret) {
+            LOGE("Error on contextload");
+            return CKR_GENERAL_ERROR;
+        }
+        if (tpmHandle) {
+            *tpmHandle = 0;
+        }
+        return CKR_OK;
+    case FAPI_ESYSBLOB_DESERIALIZE:
+        ret = tpm_deserialize_handle(tctx, twistdata, esysHandle, tpmHandle);
+        if (!ret) {
+            LOGE("Error on deserialize");
+            return CKR_GENERAL_ERROR;
+        }
+        return CKR_OK;
+    default:
+        LOGE("Unknown FAPI type for ESYS blob.");
+        twist_free(twistdata);
+        return CKR_GENERAL_ERROR;
+    }
+}
+
 CK_RV backend_fapi_init(void) {
     if (fctx) {
         LOGW("Backend FAPI already initialized.");
@@ -51,7 +96,7 @@ void backend_fapi_ctx_free(token *t) {
 
 #define PREFIX "/HS/SRK/tpm2-pkcs11-token-"
 
-static char * tss_path_from_id(unsigned id, const char *type) {
+static char *tss_path_from_id(unsigned id, const char *type) {
     /* Allocate for PREFIX + type + "-" + id + '\0' */
     size_t size = 0;
     safe_add(size, strlen(PREFIX), strlen(type));
@@ -66,6 +111,14 @@ static char * tss_path_from_id(unsigned id, const char *type) {
     sprintf(&path[0], PREFIX "%s-%08x", type, id);
 
     return path;
+}
+
+static char *path_get_parent(const char *path) {
+    char *end = rindex(path, '/');
+    if (!end) {
+        return NULL;
+    }
+    return strndup(path, end - path);
 }
 
 /** Create a new token in fapi backend.
@@ -140,19 +193,22 @@ CK_RV backend_fapi_create_token_seal(token *t, const twist hexwrappingkey,
 
     t->type = token_type_fapi;
 
-    /* TODO get TCTI config from ENV var and use throughout this process */
     t->config.is_initialized = true;
 
     assert(t->id);
 
-    /* FIXME Manually setting SRK handle here */
-    t->pid = 0x81000001;
-    twist blob;
-    CK_RV rv = tpm_get_existing_primary(t->tctx, &t->pobject.handle, &blob);
+    char *parentpath = path_get_parent(path);
+    free(path);
+    if (!parentpath) {
+        return CKR_HOST_MEMORY;
+    }
+
+    CK_RV rv = get_key(t->fapi.ctx, t->tctx, parentpath, &t->pobject.handle, &t->pid);
+    free(parentpath);
     if (rv != CKR_OK) {
+        LOGE("Error getting parent key");
         return rv;
     }
-    twist_free(blob);
 
     return CKR_OK;
 }
@@ -214,6 +270,18 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
         //FIXME
         t->fapi.ctx = fctx;
 
+        char *parentpath = path_get_parent(path);
+        if (!parentpath) {
+            rv = CKR_HOST_MEMORY;
+            goto error;
+        }
+
+        rv = get_key(t->fapi.ctx, t->tctx, parentpath, &t->pobject.handle, &t->pid);
+        free(parentpath);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+
         char *label;
         rc = Fapi_GetDescription(t->fapi.ctx, path, &label);
         if (rc) {
@@ -222,9 +290,6 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
         }
         memcpy(&t->label[0], label, strlen(label));
         Fapi_Free(label);
-
-        /* FIXME Manually setting SRK handle here */
-        t->pid = 0x81000001;
 
         uint8_t *appdata;
         size_t appdata_len;
@@ -303,13 +368,6 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
             LOGV("\nCurrent next is: %zi / %zi", yaml - appdata, appdata_len);
         }
         Fapi_Free(appdata);
-
-        twist blob;
-        rv = tpm_get_existing_primary(t->tctx, &t->pobject.handle, &blob);
-        if (rv != CKR_OK) {
-            return rv;
-        }
-        twist_free(blob);
 
         t->config.is_initialized = true;
 

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -210,7 +210,7 @@ static int init_pobject(unsigned pid, pobject *pobj, tpm_ctx *tpm) {
     }
 
 
-    bool res = tpm_deserialize_handle(tpm, blob, &pobj->handle);
+    bool res = tpm_deserialize_handle(tpm, blob, &pobj->handle, NULL);
     twist_free(blob);
     if (!res) {
         /* just set a general error as rc could be success right now */

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -93,7 +93,9 @@ bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle);
 
 twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth);
 
-bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
+bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle, uint32_t *tpmHandle);
+
+bool tpm_contextload_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
 
 CK_RV tpm_sign(tpm_op_data *opdata, CK_BYTE_PTR data, CK_ULONG datalen, CK_BYTE_PTR sig, CK_ULONG_PTR siglen);
 


### PR DESCRIPTION
This adds the last missing piece for the fapi backend, which is SRK handling.
Thus, also changes the logic for backend selection a little, introducing a `TPM2_PKCS11_BACKEND=fapi` option.
Once https://github.com/tpm2-software/tpm2-tss/pull/1716 is done this should also pass.