### PR TITLE
Refactoring token ids and empty tokens plus more fapi testing

### DIFF
--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -129,9 +129,6 @@ CK_RV backend_fapi_create_token_seal(token *t, const twist hexwrappingkey,
                        const twist newauth, const twist newsalthex) {
     TSS2_RC rc;
 
-    /* Prefixing fapi_ids in order to avoid collisions with esysdb */
-    t->id += 0x80;
-
     char *path = tss_path_from_id(t->id, "so");
     if (!path) {
         LOGE("No path constructed.");
@@ -291,6 +288,8 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
         memcpy(&t->label[0], label, strlen(label));
         Fapi_Free(label);
 
+        LOGV("Parsing objects for token %i:%s", t->id, &t->label[0]);
+
         uint8_t *appdata;
         size_t appdata_len;
 
@@ -354,7 +353,7 @@ CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
                 goto error;
             }
 
-            rv = token_add_tobject_last(tok, tobj);
+            rv = token_add_tobject_last(t, tobj);
             if (rv != CKR_OK) {
                 LOGE("Failed to initialize tobject from FAPI");
                 free(tobj);
@@ -489,7 +488,7 @@ CK_RV backend_fapi_init_user(token *t, const twist sealdata,
 CK_RV backend_fapi_add_object(token *t, tobject *tobj) {
     TSS2_RC rc;
 
-    LOGE("Adding object to fapi token %i", t->id);
+    LOGV("Adding object to fapi token %i", t->id);
 
     char *path = tss_path_from_id(t->id, "so");
     if (!path) {

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -333,7 +333,6 @@ CK_RV db_get_tokens(token **tok, size_t *len) {
         return rc;
     }
 
-    bool has_uninit_token = false;
     size_t row = 0;
     while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
 
@@ -389,7 +388,6 @@ CK_RV db_get_tokens(token **tok, size_t *len) {
         }
 
         if (!t->config.is_initialized) {
-            has_uninit_token = true;
             LOGV("skipping further initialization of token tid: %u", t->id);
             continue;
         }
@@ -406,21 +404,6 @@ CK_RV db_get_tokens(token **tok, size_t *len) {
 
         /* token initialized, bump cnt */
         cnt++;
-    }
-
-    /* if their was no unitialized token in the db, add it */
-    if (!has_uninit_token) {
-        if (cnt >= MAX_TOKEN_CNT) {
-            LOGE("Too many tokens, must have less than %d", MAX_TOKEN_CNT);
-            goto error;
-        }
-
-        token *t = &tmp[cnt++];
-        t->id = cnt;
-        CK_RV rv = token_min_init(t);
-        if (rv != CKR_OK) {
-            goto error;
-        }
     }
 
     *tok = tmp;

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -316,6 +316,7 @@ CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count)
     assert(tok);
 
     if (!tok->tobjects.head) {
+        LOGV("Token %i contains no objects.", tok->id);
         goto empty;
     }
 

--- a/test/integration/p11-tool.sh.nosetup
+++ b/test/integration/p11-tool.sh.nosetup
@@ -119,12 +119,31 @@ GNUTLS_PIN=mynewuserpin \
 p11_tool --initialize-pin ${TOKENURL}
 echo "Userpin initialized"
 
+echo "Initializing token2"
+GNUTLS_SO_PIN=mynewsopin \
+p11_tool --initialize --label=mynewtoken2 $(p11_tool --list-token-urls | grep "SW%20%20%20TPM" | tail -n 1)
+TOKENURL2=$(p11_tool --list-token-urls | grep "mynewtoken2")
+echo "Token2 initialized"
+
+echo "Initializing user pin2"
+GNUTLS_SO_PIN=mynewsopin \
+GNUTLS_PIN=mynewuserpin \
+p11_tool --initialize-pin ${TOKENURL2}
+echo "Userpin2 initialized"
+
 echo "Generating RSA keypair"
 GNUTLS_PIN=mynewuserpin \
 p11_tool --generate-rsa --bits 2048 --login --label="myrsakey" --outfile="${tempdir}/pubkey.pem" ${TOKENURL}
 GNUTLS_PIN=mynewuserpin \
 p11_tool --login --list-all ${TOKENURL}
 echo "RSA Keypair generated"
+
+echo "Generating RSA keypair2"
+GNUTLS_PIN=mynewuserpin \
+p11_tool --generate-rsa --bits 2048 --login --label="my2rsakey" --outfile="${tempdir}/pubkey2.pem" ${TOKENURL2}
+GNUTLS_PIN=mynewuserpin \
+p11_tool --login --list-all ${TOKENURL2}
+echo "RSA Keypair2 generated"
 
 echo "Change the keypair label"
 GNUTLS_PIN=mynewuserpin \


### PR DESCRIPTION
- Unify the numberspace of tok->id between esysdb and fapi
- Move the empty token creation out of db into backend
- Add tests for multiple fapi tokens (makes used of the previous changes)