### PR TITLE
test/pkcs-get-mechanism: allow a maximum key size of 3072 bits

### DIFF
--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -148,7 +148,7 @@ void test_get_mechanism_info_good(void **state) {
         assert_int_equal(rv, CKR_OK);
 
         assert_int_equal(mech_info.ulMinKeySize, 1024);
-        assert_int_equal(mech_info.ulMaxKeySize, 2048);
+        assert_in_range(mech_info.ulMaxKeySize, 2048, 3072);
         assert_int_equal(mech_info.flags, rsa_mechs[i].flags);
     }
 


### PR DESCRIPTION
The freshly released ibmswtpm2 version 1628 increases the maximum key
size to 3072 bits, leading to a test failure:
```
[  ERROR   ] --- 0xc00 != 0x800
[   LINE   ] --- test/integration/pkcs-get-mechanism.int.c:151: error: Failure!
[  FAILED  ] test_get_mechanism_info_good
```
Accept the previous key size of 2048 bits as well for backwards compatibility with older versions of the simulator.