### PR TITLE
C_CreateObject: Support CKO_DATA object

### DIFF
--- a/src/lib/attrs.c
+++ b/src/lib/attrs.c
@@ -3,6 +3,8 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <openssl/crypto.h>
+
 #include "attrs.h"
 #include "log.h"
 #include "pkcs11.h"
@@ -115,7 +117,9 @@ static attr_handler2 attr_handlers[] = {
     ADD_ATTR_HANDLER(CKA_TOKEN, TYPE_BYTE_BOOL),
     ADD_ATTR_HANDLER(CKA_PRIVATE, TYPE_BYTE_BOOL),
     ADD_ATTR_HANDLER(CKA_LABEL, TYPE_BYTE_HEX_STR),
+    ADD_ATTR_HANDLER(CKA_APPLICATION, TYPE_BYTE_HEX_STR),
     ADD_ATTR_HANDLER(CKA_VALUE, TYPE_BYTE_HEX_STR),
+    ADD_ATTR_HANDLER(CKA_OBJECT_ID, TYPE_BYTE_HEX_STR),
     ADD_ATTR_HANDLER(CKA_CERTIFICATE_TYPE, TYPE_BYTE_INT),
     ADD_ATTR_HANDLER(CKA_ISSUER, TYPE_BYTE_HEX_STR),
     ADD_ATTR_HANDLER(CKA_SERIAL_NUMBER, TYPE_BYTE_HEX_STR),
@@ -215,6 +219,16 @@ CK_ATTRIBUTE_PTR attr_list_get_ptr(attr_list *l) {
     return l->attrs;
 }
 
+void attr_pfree_cleanse(CK_ATTRIBUTE_PTR attr) {
+    if (attr && attr->pValue) {
+        /* Don't use clear_free because OSSL is not used for alloc */
+        OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
+        free(attr->pValue);
+        attr->pValue = NULL;
+        attr->ulValueLen = 0;
+    }
+}
+
 void attr_list_free(attr_list *attrs) {
 
     if (!attrs) {
@@ -224,7 +238,7 @@ void attr_list_free(attr_list *attrs) {
     CK_ULONG i;
     for (i=0; i < attrs->count; i++) {
         const CK_ATTRIBUTE_PTR a = &attrs->attrs[i];
-        free(a->pValue);
+        attr_pfree_cleanse(a);
     }
 
     free(attrs->attrs);
@@ -434,16 +448,10 @@ static CK_RV attr_common_add_storage(attr_list **storage_attrs) {
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
-    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(*storage_attrs, CKA_CLASS);
-    if (!a) {
+    CK_OBJECT_CLASS cka_class = attr_list_get_CKA_CLASS(*storage_attrs, CK_OBJECT_CLASS_BAD);
+    if (cka_class == CK_OBJECT_CLASS_BAD) {
         LOGE("Expected object to have CKA_CLASS");
         return CKR_GENERAL_ERROR;
-    }
-
-    CK_ULONG v;
-    rv = attr_CK_ULONG(a, &v);
-    if (rv != CKR_OK) {
-        return rv;
     }
 
     attr_list *new_attrs = attr_list_new();
@@ -463,10 +471,12 @@ static CK_RV attr_common_add_storage(attr_list **storage_attrs) {
     goto_error_false(r);
 
     /* defaults */
-    CK_BBOOL defpriv = ((v == CKO_PRIVATE_KEY) || (v == CKO_SECRET_KEY)) ?
-            CK_TRUE : CK_FALSE;
+    CK_BBOOL defpriv = ((cka_class == CKO_PRIVATE_KEY) ||
+            (cka_class == CKO_SECRET_KEY)              ||
+            (cka_class == CKO_DATA)) ?
+                CK_TRUE : CK_FALSE;
 
-    a = attr_get_attribute_by_type(*storage_attrs, CKA_PRIVATE);
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(*storage_attrs, CKA_PRIVATE);
     if (!a) {
         r = attr_list_add_bool(new_attrs, CKA_PRIVATE, defpriv);
         goto_error_false(r);
@@ -489,6 +499,51 @@ error:
     return rv;
 }
 
+CK_RV attr_common_add_data(attr_list **data_attrs) {
+
+    CK_RV rv = CKR_HOST_MEMORY;
+
+    /* expected */
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(*data_attrs, CKA_VALUE);
+    if (!a) {
+        LOGE("Expected object to have CKA_VALUE");
+        return CKR_TEMPLATE_INCOMPLETE;
+    } else  if (!a->ulValueLen || !a->pValue) {
+        LOGE("CKA_VALUE bad, got len: %lu, pValue: %s", a->ulValueLen,
+                a->pValue ? "(set)" : "(null)");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    attr_list *new_attrs = attr_list_new();
+    if (!new_attrs) {
+        LOGE("oom");
+        return CKR_HOST_MEMORY;
+    }
+
+    a = attr_get_attribute_by_type(*data_attrs, CKA_OBJECT_ID);
+    if (!a) {
+        bool r = attr_list_add_buf(new_attrs, CKA_APPLICATION, NULL, 0);
+        goto_error_false(r);
+    }
+
+    a = attr_get_attribute_by_type(*data_attrs, CKA_APPLICATION);
+    if (!a) {
+        bool r = attr_list_add_buf(new_attrs, CKA_APPLICATION, NULL, 0);
+        goto_error_false(r);
+    }
+
+    *data_attrs = attr_list_append_attrs(*data_attrs,
+            &new_attrs);
+    goto_error_false(*data_attrs);
+
+    return attr_common_add_storage(data_attrs);
+
+error:
+    attr_list_free(new_attrs);
+
+    return rv;
+}
+
 static CK_RV attr_common_add_key(attr_list **key_attrs) {
 
     CK_RV rv = CKR_HOST_MEMORY;
@@ -503,12 +558,6 @@ static CK_RV attr_common_add_key(attr_list **key_attrs) {
     a = attr_get_attribute_by_type(*key_attrs, CKA_LOCAL);
     if (!a) {
         LOGE("Expected object to have CKA_LOCAL");
-        return CKR_GENERAL_ERROR;
-    }
-
-    a = attr_get_attribute_by_type(*key_attrs, CKA_KEY_GEN_MECHANISM);
-    if (!a) {
-        LOGE("Expected object to have CKA_KEY_GEN_MECHANISM");
         return CKR_GENERAL_ERROR;
     }
 
@@ -1281,3 +1330,17 @@ UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_ULONG);
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_BBOOL);
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_OBJECT_CLASS);
 UTILS_GENERIC_ATTR_TYPE_CONVERT(CK_KEY_TYPE);
+
+#define UTILS_GENERIC_EXTRACTOR(type, T) \
+    T attr_list_get_##type(attr_list *attrs, T defvalue) { \
+	    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(attrs, type); \
+	    if (!a) { \
+	        return defvalue; \
+	    } \
+	    T x = defvalue; \
+		CK_RV rv = attr_##T(a, &x); \
+		return rv != CKR_OK ? defvalue : x; \
+    }
+
+UTILS_GENERIC_EXTRACTOR(CKA_PRIVATE, CK_BBOOL);
+UTILS_GENERIC_EXTRACTOR(CKA_CLASS,   CK_OBJECT_CLASS);

--- a/src/lib/attrs.h
+++ b/src/lib/attrs.h
@@ -14,6 +14,11 @@
 #define CKA_TPM2_OBJAUTH_ENC (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x1UL)
 #define CKA_TPM2_PUB_BLOB    (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x2UL)
 #define CKA_TPM2_PRIV_BLOB   (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x3UL)
+#define CKA_TPM2_ENC_BLOB    (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x4UL)
+
+/* Invalid values for error detection */
+#define CK_OBJECT_CLASS_BAD (~(CK_OBJECT_CLASS)0)
+#define CKA_KEY_TYPE_BAD    (~(CK_KEY_TYPE)0)
 
 /**
  * The heart of any PKCS11 object is it's attribute list. This list
@@ -124,6 +129,16 @@ CK_ATTRIBUTE_PTR attr_list_get_ptr(attr_list *l);
  *  The attribute list to free.
  */
 void attr_list_free(attr_list *attrs);
+
+/**
+ * Scrubs the memory pointed to by the pValue pointer and frees it.
+ * The attribute pointer is expected to be contained within in attr_list.
+ * The attribute is NOT REMOVED from the list and type remains unchanged.
+ * Sets ulValueLen to 0.
+ * @param attr
+ *  The attr to free.
+ */
+void attr_pfree_cleanse(CK_ATTRIBUTE_PTR attr);
 
 /**
  * Given a raw attribute list, perhaps from a client caller,
@@ -247,6 +262,10 @@ CK_RV attr_CK_OBJECT_CLASS(CK_ATTRIBUTE_PTR attr, CK_OBJECT_CLASS *x);
 
 CK_RV attr_CK_KEY_TYPE(CK_ATTRIBUTE_PTR attr, CK_KEY_TYPE *x);
 
+CK_BBOOL attr_list_get_CKA_PRIVATE(attr_list *attrs, CK_BBOOL defvalue);
+
+CK_OBJECT_CLASS attr_list_get_CKA_CLASS(attr_list *attrs, CK_OBJECT_CLASS defvalue);
+
 /**
  * Searches an attr_list for an attribute specified by type.
  * @param haystack
@@ -277,6 +296,8 @@ CK_RV attr_list_append_entry(attr_list **attrs, CK_ATTRIBUTE_PTR untrusted_attr)
 CK_RV attr_list_update_entry(attr_list *attrs, CK_ATTRIBUTE_PTR untrusted_attr);
 
 CK_RV attr_common_add_RSA_publickey(attr_list **public_attrs);
+
+CK_RV attr_common_add_data(attr_list **storage_attrs);
 
 CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs);
 

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -427,6 +427,129 @@ CK_RV object_find_final(session_ctx *ctx) {
     return CKR_OK;
 }
 
+/**
+ * given an attribute list with CKA_TPM2_ENC_BLOB, will unwrap it with the token wrapping
+ * key and store it in CKA_VALUE.
+ * @param tok
+ *  The token
+ * @param attrs
+ *  The attribute list to modify.
+ * @return
+ *  CKR_OK on success.
+ */
+static CK_RV unwrap_protected_cka_value(token *tok, attr_list *attrs) {
+    /* Caller wants CKA_VALUE in their template and it's not found, we need to fetch it, do we have
+     * the wrapped value in the DB? */
+    assert(tok->wrappingkey);
+
+    CK_ATTRIBUTE_PTR ciphertext_attr = attr_get_attribute_by_type(attrs, CKA_TPM2_ENC_BLOB);
+    if (ciphertext_attr) {
+
+        twist plaintext = NULL;
+        size_t len = 0;
+        if (ciphertext_attr->ulValueLen) {
+            twist ciphertext = twistbin_new(ciphertext_attr->pValue, ciphertext_attr->ulValueLen);
+            if (!ciphertext) {
+                LOGE("oom");
+                return CKR_HOST_MEMORY;
+            }
+
+            CK_RV rv = utils_ctx_unwrap_objauth(tok->wrappingkey, ciphertext, &plaintext);
+            twist_free(ciphertext);
+            if (rv != CKR_OK) {
+                LOGE("Could not unwrap CKA_VALUE");
+                return rv;
+            }
+
+            len = twist_len(plaintext);
+        }
+
+        CK_ATTRIBUTE temp = {
+            .type = CKA_VALUE,
+            .pValue = (void *)plaintext,
+            .ulValueLen = len
+        };
+
+        /*
+         * Add the unwrapped value back to CKA_VALUE
+         *  - Append if not in the list
+         *  - Update if it's in the list
+         */
+        CK_ATTRIBUTE_PTR found = attr_get_attribute_by_type(attrs, CKA_TPM2_ENC_BLOB);
+        CK_RV rv = found ?
+                attr_list_update_entry(attrs, &temp) : attr_list_append_entry(&attrs, &temp);
+        twist_free(plaintext);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+
+    } else {
+        // TODO: Fetch from TPM to support more object types?
+        // TODO: set CKA_VALUE to 0?
+        LOGW("Needed CKA_VALUE but didn't find encrypted blob");
+    }
+
+    return CKR_OK;
+}
+
+/**
+ * given an attribute list with CKA_VALUE, will wrap it with the token wrapping
+ * key and store it in CKA_TPM2_ENC_BLOB. A zero length CKA_VALUE attribute will
+ * clear the CKA_TPM2_ENC_BLOB attribute.
+ * @param tok
+ *  The token
+ * @param attrs
+ *  The attribute list to modify
+ * @return
+ *  CKR_OK on success.
+ */
+static CK_RV wrap_protected_cka_value(token *tok, attr_list *attrs) {
+    assert(tok->wrappingkey);
+
+    /* this may or maynot exist */
+    CK_ATTRIBUTE_PTR enc_blob_attr = attr_get_attribute_by_type(attrs, CKA_TPM2_ENC_BLOB);
+
+    CK_ATTRIBUTE_PTR plaintext_attr = attr_get_attribute_by_type(attrs, CKA_VALUE);
+    if (!plaintext_attr) {
+        LOGE("Expected vendor attribute CKA_VALUE");
+        return CKR_GENERAL_ERROR;
+    }
+
+    twist ciphertext = NULL;
+    size_t len = 0;
+    if (plaintext_attr->ulValueLen) {
+        twist plaintext = twistbin_new(plaintext_attr->pValue, plaintext_attr->ulValueLen);
+        if (!plaintext) {
+            LOGE("oom");
+            return CKR_HOST_MEMORY;
+        }
+
+        CK_RV rv = utils_ctx_wrap_objauth(tok->wrappingkey, plaintext, &ciphertext);
+        twist_free(plaintext);
+        if (rv != CKR_OK) {
+            LOGE("Could not wrap CKA_VALUE");
+            return rv;
+        }
+        len = twist_len(ciphertext);
+    }
+
+    CK_ATTRIBUTE temp = {
+        .type = CKA_TPM2_ENC_BLOB,
+        .pValue = (void *)ciphertext,
+        .ulValueLen = len
+    };
+
+    /* add the wrapped value back to CKA_TPM2_ENC_BLOB */
+    CK_RV rv = enc_blob_attr ? attr_list_update_entry(attrs, &temp) :
+            attr_list_append_entry(&attrs, &temp);
+    twist_free(ciphertext);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    return CKR_OK;
+}
+
 CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIBUTE *templ, CK_ULONG count) {
 
     token *tok = session_ctx_get_token(ctx);
@@ -444,6 +567,16 @@ CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
     }
 
     /*
+     * If the object is SENSITIVE AND EXTRACTABLE we can reveal CKA_VALUE. We set the
+     * defaults as extractable and not sensitive because only non-tpm objects have
+     * the CKA_VALUE field (certs and public keys). However, we are adding secret
+     * keys, that are created through C_CreateObject(). The user *must* be logged
+     * in to do this or tok->wrappingkey is NULL.
+     */
+    CK_BBOOL cka_private = attr_list_get_CKA_PRIVATE(tobj->attrs, CK_FALSE);
+    bool is_user_logged_in = token_is_user_logged_in (tok);
+
+    /*
      * For each item requested in the template, find if the request has a match
      * and copy the size and possibly data (if allocated).
      */
@@ -454,6 +587,12 @@ CK_RV object_get_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
         CK_ATTRIBUTE_PTR t = &templ[i];
 
         CK_ATTRIBUTE_PTR found = attr_get_attribute_by_type(tobj->attrs, t->type);
+        if (cka_private && t->type == CKA_VALUE && is_user_logged_in &&
+                (!found || !found->ulValueLen)) {
+            rv = unwrap_protected_cka_value(tok, tobj->attrs);
+            /* continue on processing */
+        }
+
         if (found) {
             if (!t->pValue) {
                 /* only populate size if the buffer is null */
@@ -503,6 +642,15 @@ CK_RV object_set_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
         return rv;
     }
 
+    CK_OBJECT_CLASS clazz = attr_list_get_CKA_CLASS(tobj->attrs, CK_OBJECT_CLASS_BAD);
+    if (clazz == CK_OBJECT_CLASS_BAD) {
+        LOGE("Expect ALL objects to contain attribute CKA_CLASS");
+        rv = CKR_GENERAL_ERROR;
+        goto out;
+    }
+
+    CK_BBOOL cka_private = attr_list_get_CKA_PRIVATE(tobj->attrs, CK_FALSE);
+
     /* create a temp copy to work on so we have transactional atomicity */
     attr_list *tmp = NULL;
     rv = attr_list_dup(tobj->attrs, &tmp);
@@ -526,6 +674,14 @@ CK_RV object_set_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
 
         CK_ATTRIBUTE_PTR t = &templ[i];
 
+        /* CKA_VALUE fields are encrypted for CKO_DATA objects */
+        if (t->type == CKA_VALUE && clazz == CKO_DATA && cka_private) {
+            rv = wrap_protected_cka_value(tok, tmp);
+            if (rv != CKR_OK) {
+                goto error;
+            }
+        }
+
         CK_ATTRIBUTE_PTR found = attr_get_attribute_by_type(tmp, t->type);
         rv = found ? attr_list_update_entry(tmp, t) :
             attr_list_append_entry(&tmp, t);
@@ -534,10 +690,27 @@ CK_RV object_set_attributes(session_ctx *ctx, CK_OBJECT_HANDLE object, CK_ATTRIB
         }
     }
 
+    /* We don't want to emit CKA_VALUE for CKA_PRIVATE objects to the backend store */
+    bool is_backed_up = false;
+    CK_ATTRIBUTE backup = { 0 };
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tmp, CKA_VALUE);
+    if (cka_private && a && a->ulValueLen) {
+        backup.pValue = a->pValue;
+        backup.ulValueLen = a->ulValueLen;
+        a->pValue = NULL;
+        a->ulValueLen = 0;
+        is_backed_up = true;
+    }
+
     /* in memory is updated, so update the persistent store */
     rv = backend_update_tobject_attrs(tok, tobj, tmp);
     if (rv != CKR_OK) {
         goto error;
+    }
+
+    if (is_backed_up) {
+        a->pValue = backup.pValue;
+        a->ulValueLen = backup.ulValueLen;
     }
 
     /*
@@ -698,11 +871,9 @@ CK_RV object_destroy(session_ctx *ctx, CK_OBJECT_HANDLE object) {
     return rv;
 }
 
-static CK_RV handle_rsa_public(token *tok, CK_ATTRIBUTE_PTR templ, CK_ULONG count, tobject **tobj) {
+static CK_RV handle_rsa_public(CK_ATTRIBUTE_PTR templ, CK_ULONG count, attr_list **new_attrs) {
 
     CK_RV rv = CKR_GENERAL_ERROR;
-
-    tobject *obj = NULL;
 
     /* RSA Public keys should have a modulus and exponent, verify */
     CK_ATTRIBUTE_PTR a_modulus = attr_get_attribute_by_type_raw(templ, count, CKA_MODULUS);
@@ -794,37 +965,53 @@ static CK_RV handle_rsa_public(token *tok, CK_ATTRIBUTE_PTR templ, CK_ULONG coun
         goto out;
     }
 
+    /* transfer ownership to caller */
+    *new_attrs = tmp_attrs;
+    tmp_attrs = NULL;
+
+out:
+    attr_list_free(tmp_attrs);
+
+    return rv;
+}
+
+static CK_RV handle_data_object(token *tok, CK_ATTRIBUTE_PTR templ, CK_ULONG count, attr_list **new_attrs) {
+
+    CK_RV rv = CKR_GENERAL_ERROR;
     /*
-     * Now that everything is verified, create a new tobject
-     * and populate the fields that matter.
+     * Create a new typed attr list
      */
-    obj = tobject_new();
-    if (!obj) {
-        LOGE("oom");
-        rv = CKR_HOST_MEMORY;
+    attr_list *tmp_attrs = NULL;
+    bool res = attr_typify(templ, count, &tmp_attrs);
+    if (!res) {
+        return CKR_GENERAL_ERROR;
+    }
+    assert(tmp_attrs);
+
+    CK_BBOOL cka_private = attr_list_get_CKA_PRIVATE(tmp_attrs, CK_TRUE);
+    if (!cka_private) {
+        LOGE("CKA_PRIVATE cannot be CK_FALSE");
+        rv = CKR_ATTRIBUTE_VALUE_INVALID;
         goto out;
     }
 
-    obj->attrs = tmp_attrs;
-    tmp_attrs = NULL;
-
-    /* add the object to the db */
-    rv = backend_add_object(tok, obj);
+    rv = wrap_protected_cka_value(tok, tmp_attrs);
     if (rv != CKR_OK) {
         goto out;
     }
 
-    /* assign temp tobject to callee provided pointer */
-    *tobj = obj;
+    /* Set any defaults and do error checking */
+    rv = attr_common_add_data(&tmp_attrs);
+    if (rv != CKR_OK) {
+        goto out;
+    }
 
-    /* callee now takes owenership */
-    obj = NULL;
-
-    rv = CKR_OK;
+    /* transfer ownership to caller */
+    *new_attrs = tmp_attrs;
+    tmp_attrs = NULL;
 
 out:
     attr_list_free(tmp_attrs);
-    tobject_free(obj);
 
     return rv;
 }
@@ -852,6 +1039,9 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
 
     /*
      * If CKA_LOCAL is specified, it can never be CK_TRUE
+     * TODO: At somepoint these attr_get_attribute_by_type_raw() calls
+     * could be done by general extractors and default error values ala
+     * attr_list_get_CKA_PRIVATE() type calls for raw attr lists.
      */
     CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type_raw(templ, count, CKA_LOCAL);
     if (a) {
@@ -868,7 +1058,10 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
     }
 
     /*
-     * We only support RSA Public objects, so verify it.
+     * We only support:
+     * - CKK_RSA - CKO_PUBLIC_KEY
+     * - CKO_DATA
+     *  so verify it.
      */
     a = attr_get_attribute_by_type_raw(templ, count, CKA_CLASS);
     if (!a) {
@@ -883,45 +1076,93 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
         return CKR_TEMPLATE_INCOMPLETE;
     }
 
+    /* Not all objects have a key type, only KEY Objects do */
+    CK_KEY_TYPE key_type = CKA_KEY_TYPE_BAD;
     a = attr_get_attribute_by_type_raw(templ, count, CKA_KEY_TYPE);
-    if (!a) {
-        LOGE("Expected attribute CKA_KEY_TYPE");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-
-    CK_KEY_TYPE key_type;
-    rv = attr_CK_KEY_TYPE(a, &key_type);
-    if (rv != CKR_OK) {
-        LOGE("Error converting attribute CKA_KEY_TYPE");
-        return rv;
-    }
-
-    if (key_type != CKK_RSA ||
-            clazz != CKO_PUBLIC_KEY) {
-        LOGE("Can only create RSA Public key objects, "
-                "CKA_CLASS(%lu), CKA_KEY_TYPE(%lu)",
-                clazz, key_type);
-        return CKR_ATTRIBUTE_VALUE_INVALID;
+    if (a) {
+        rv = attr_CK_KEY_TYPE(a, &key_type);
+        if (rv != CKR_OK) {
+            LOGE("Error converting attribute CKA_KEY_TYPE");
+            return rv;
+        }
     }
 
     token *tok = session_ctx_get_token(ctx);
     assert(tok);
+    attr_list *new_attrs = NULL;
 
-    tobject *new_tobj = NULL;
-    rv = handle_rsa_public(tok, templ, count, &new_tobj);
+    if (key_type == CKK_RSA ||
+            clazz == CKO_PUBLIC_KEY) {
+        rv = handle_rsa_public(templ, count, &new_attrs);
+    } else if (clazz == CKO_DATA) {
+        rv = handle_data_object(tok, templ, count, &new_attrs);
+    } else {
+        LOGE("Can only create RSA Public key objects or"
+                "data objects, CKA_CLASS(%lu), CKA_KEY_TYPE(%lu)",
+                clazz, key_type);
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
     if (rv != CKR_OK) {
-        LOGE("Error creating rsa public key: %lu", rv);
+        LOGE("Error creating object, "
+                "CKA_CLASS(%lu), CKA_KEY_TYPE(%lu) rv: %lu",
+                clazz, key_type, rv);
         return rv;
     }
 
+    /* ok create the new tobject */
+    tobject *new_tobj = tobject_new();
+    if (!new_tobj) {
+        LOGE("oom");
+        rv = CKR_HOST_MEMORY;
+        goto out;
+    }
+
+    new_tobj->attrs = new_attrs;
+    new_attrs = NULL;
+
+    bool is_backed_up = false;
+    CK_ATTRIBUTE backup = { 0 };
+
+    /* if it's a private object we can't expose the CKA_VALUE attribute */
+    CK_BBOOL cka_private = attr_list_get_CKA_PRIVATE(new_tobj->attrs, CK_FALSE);
+    a = attr_get_attribute_by_type(new_tobj->attrs, CKA_VALUE);
+    if (cka_private && a && a->ulValueLen) {
+        backup.ulValueLen = a->ulValueLen;
+        backup.pValue = a->pValue;
+        a->ulValueLen = 0;
+        a->pValue = NULL;
+        is_backed_up = true;
+    }
+
+    /* add the object to the db */
+    rv = backend_add_object(tok, new_tobj);
+    if (rv != CKR_OK) {
+        goto out;
+    }
+
+    if (is_backed_up) {
+        a->ulValueLen = backup.ulValueLen;
+        a->pValue = backup.pValue;
+    }
+
+    /* add the object to the token */
     rv = token_add_tobject(tok, new_tobj);
     if (rv != CKR_OK) {
         return rv;
     }
 
+    /* assign temp tobject to callee provided pointer */
     *object = new_tobj->obj_handle;
+    new_tobj = NULL;
 
-    return CKR_OK;
+    rv = CKR_OK;
+
+out:
+    attr_list_free(new_attrs);
+    tobject_free(new_tobj);
+
+    return rv;
 }
 
 CK_RV object_init_from_attrs(tobject *tobj) {

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -298,13 +298,25 @@ CK_RV session_ctx_logout(session_ctx *ctx) {
      */
     tpm_ctx *tpm = tok->tctx;
 
-    // Evict the keys
+    /*
+     * For each object:
+     *   - Evict the TPM Handles
+     *   - Cleanse CKA_VALUE fields for private values.
+     */
     if (tok->tobjects.head) {
 
         list *cur = &tok->tobjects.head->l;
         while(cur) {
             tobject *tobj = list_entry(cur, tobject, l);
             cur = cur->next;
+
+            /* if it's CKA_PRIVATE == CK_TRUE and it has a CKA_VALUE field, clear it */
+            CK_BBOOL cka_private = attr_list_get_CKA_PRIVATE(tobj->attrs, CK_FALSE);
+            CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_VALUE);
+            if (cka_private && a && a->pValue && a->ulValueLen) {
+                attr_pfree_cleanse(a);
+            }
+
             if (tobj->tpm_handle) {
                 bool result = tpm_flushcontext(tpm, tobj->tpm_handle);
                 assert(result);

--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -971,9 +971,113 @@ static void test_create_obj_rsa_public_key(void **state) {
     assert_memory_equal(plaintext, p2, sizeof(plaintext));
 }
 
+/*
+ * Place this test here so we don't have to take the test time hit of another
+ * test setup.
+ */
+static void test_create_data_object_private (void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE session = ti->handle;
+
+    user_login(session);
+
+    CK_BBOOL _false = CK_FALSE;
+    CK_BBOOL _true = CK_TRUE;
+
+    char label[] = "data object";
+    char application[] = "my application";
+
+    CK_OBJECT_CLASS object_class = CKO_DATA;
+
+    CK_BYTE id[] = { '1', '2', '3' };
+    CK_BYTE value[] = "my data object";
+
+    CK_ATTRIBUTE data_template[] = {
+      { CKA_CLASS,       &object_class, sizeof(object_class)    },
+      { CKA_TOKEN,       &_true,        sizeof(_true)           },
+      { CKA_PRIVATE,     &_true,        sizeof(_true)           },
+      { CKA_LABEL,       label,         sizeof(label) - 1       },
+      { CKA_MODIFIABLE,  &_false,       sizeof(_false)          },
+      { CKA_APPLICATION, &application,  sizeof(application) - 1 },
+      { CKA_OBJECT_ID,   &id,           sizeof(id)              },
+      { CKA_VALUE,       value,         sizeof(value)           }
+    };
+
+    CK_OBJECT_HANDLE obj = 0;
+
+    CK_RV rv = C_CreateObject(session, data_template, ARRAY_LEN(data_template), &obj);
+    assert_int_equal(rv, CKR_OK);
+
+    CK_BYTE buf[64];
+
+    CK_ATTRIBUTE data_template2[] = {
+      { CKA_VALUE, buf, sizeof(buf) },
+    };
+
+    rv = C_GetAttributeValue (session, obj,
+            data_template2, ARRAY_LEN(data_template2));
+    assert_int_equal(rv, CKR_OK);
+
+    assert_int_equal(sizeof(value), data_template2[0].ulValueLen);
+    assert_memory_equal(value, buf, sizeof(value));
+
+    logout(session);
+
+    CK_BYTE buf2[64] = { 0 };
+    CK_ATTRIBUTE data_template3[] = {
+      { CKA_VALUE, buf2, sizeof(buf2) },
+    };
+
+    rv = C_GetAttributeValue (session, obj,
+            data_template3, ARRAY_LEN(data_template3));
+    assert_int_equal(rv, CKR_OK);
+
+    assert_int_equal(data_template3[0].ulValueLen, 0);
+}
+
+static void test_create_data_object_public (void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE session = ti->handle;
+
+    user_login(session);
+
+    CK_BBOOL _false = CK_FALSE;
+    CK_BBOOL _true = CK_TRUE;
+
+    char label[] = "public data object";
+    char application[] = "my application";
+
+    CK_OBJECT_CLASS object_class = CKO_DATA;
+
+    CK_BYTE id[] = { '1', '2', '3', '4' };
+    CK_BYTE value[] = "my public data object";
+
+    CK_ATTRIBUTE data_template[] = {
+      { CKA_CLASS,       &object_class, sizeof(object_class)    },
+      { CKA_TOKEN,       &_true,        sizeof(_true)           },
+      { CKA_PRIVATE,     &_false,        sizeof(_false)          },
+      { CKA_LABEL,       label,         sizeof(label) - 1       },
+      { CKA_MODIFIABLE,  &_false,       sizeof(_false)          },
+      { CKA_APPLICATION, &application,  sizeof(application) - 1 },
+      { CKA_OBJECT_ID,   &id,           sizeof(id)              },
+      { CKA_VALUE,       value,         sizeof(value)           }
+    };
+
+    CK_OBJECT_HANDLE obj = 0;
+
+    CK_RV rv = C_CreateObject(session, data_template, ARRAY_LEN(data_template), &obj);
+    assert_int_equal(rv, CKR_ATTRIBUTE_VALUE_INVALID);
+}
+
 int main() {
 
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_create_data_object_public,
+            test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_create_data_object_private,
+            test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_create_obj_rsa_public_key,
             test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_rsa_keygen_missing_attributes,

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -89,4 +89,20 @@ pkcs11_tool --list-objects --slot-index=0
 pkcs11_tool --delete-object --slot-index=0 --label="myrsakey" --pin=mynewuserpin --login --type=pubkey
 pkcs11_tool --list-objects --slot-index=0
 
+#
+# Test creating data objects
+#
+echo "hello world" > objdata
+pkcs11_tool --slot-index=0 --login --pin=mynewuserpin --write-object objdata --type data --label dataobj1 --private
+
+# whitebox test to make sure secret is not in store
+if [ "$TPM2_PKCS11_BACKEND" != "fapi" ]; then
+  sqlite3 "$TPM2_PKCS11_STORE/tpm2_pkcs11.sqlite3" 'select attrs from tobjects;' | grep -qiv "$(cat objdata)"
+  # and check for the hex encoded version too
+  sqlite3 "$TPM2_PKCS11_STORE/tpm2_pkcs11.sqlite3" 'select attrs from tobjects;' | grep -qiv "$(xxd -p objdata)"
+fi
+
+pkcs11_tool --slot-index=0 --login --pin=mynewuserpin --read-object --type data --label dataobj1 -o objdata2
+cmp objdata objdata2
+
 exit 0

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -411,7 +411,8 @@ class ObjMod(Command):
 
         with Db(path) as db:
             obj = db.getobject(tid)
-
+            if obj is None:
+                sys.exit('Not found, object with id: {}'.format(tid))
         s = obj['attrs']
         obj_attrs = yaml.safe_load(s)
 

--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -621,10 +621,12 @@ class ListObjectsCommand(Command):
             y = yaml.safe_load(o['attrs'])
             d = {
                 'id': o['id'],
-                'CKA_ID' : y[CKA_ID],
                 'CKA_LABEL' : binascii.unhexlify(y[CKA_LABEL]).decode(),
                 'CKA_CLASS' : pkcs11_cko_to_str(y[CKA_CLASS]),
             }
+
+            if CKA_ID in y:
+                d['CKA_ID'] = y[CKA_ID],
 
             if CKA_KEY_TYPE in y:
                 d['CKA_KEY_TYPE'] = pkcs11_ckk_to_str(y[CKA_KEY_TYPE])


### PR DESCRIPTION
Support storing secrets in the DB wrapped with the token wrapping key.
Since the wrapping key can unwrap all object authorizations, using the
TPM seal interface adds nothing. If you have the wrapping key, or can
brute force it, you can use the object. An object with a sealed value
means you can also release the secret. Also, a downside when using the
TPM for sealing is speed and the data cannot be bigger than 128 bytes.
Using the token wrapping key has none of these limitations.
    
Note: Only CKA_PRIVATE CK_TRUE objects are supported. Since the library
can make no guarentees about the attributes, an accidental or malicious
change to the CKA_PRIVATE value from CK_TRUE to CK_FALSE could cause
the plaintext value to be persisted to the store. Thus *ONLY* support
CKA_PRIVATE CKA_TRUE CKO_DATA objects for now.
    
Test it by using pkcs11-tool as well as a C integration test and probe
the sqlite3 db for the secret to ensure it is not leaked.