### PR TITLE
test: verify that DA lockout occurs

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -33,7 +33,8 @@ check_PROGRAMS += \
     test/integration/pkcs-misc.int \
     test/integration/pkcs-crypt.int \
     test/integration/pkcs-keygen.int \
-    test/integration/pkcs-session-state.int
+    test/integration/pkcs-session-state.int \
+    test/integration/pkcs-lockout.int
 
 # add test scripts
 check_SCRIPTS += $(integration_scripts)
@@ -91,6 +92,10 @@ test_integration_pkcs_keygen_int_SOURCES = test/integration/pkcs-keygen.int.c te
 test_integration_pkcs_session_state_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_session_state_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
 test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-state.c test/integration/test.c
+
+test_integration_pkcs_lockout_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_pkcs_lockout_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+test_integration_pkcs_lockout_int_SOURCES = test/integration/pkcs-lockout.int.c test/integration/test.c
 
 #
 # Java Tests

--- a/src/lib/backend_esysdb.c
+++ b/src/lib/backend_esysdb.c
@@ -265,8 +265,8 @@ CK_RV backend_esysdb_token_unseal_wrapping_key(token *tok, bool user, twist tpin
     twist pobjauth = tok->pobject.objauth;
     uint32_t sealhandle;
 
-    bool res = tpm_loadobj(tok->tctx, pobj_handle, pobjauth, sealpub, sealpriv, &sealhandle);
-    if (!res) {
+    rv = tpm_loadobj(tok->tctx, pobj_handle, pobjauth, sealpub, sealpriv, &sealhandle);
+    if (rv != CKR_OK) {
         goto error;
     }
 
@@ -359,10 +359,9 @@ CK_RV backend_esysdb_token_changeauth(token *tok, bool user, twist toldpin, twis
 
     uint32_t sealhandle;
 
-    bool res = tpm_loadobj(tok->tctx, tok->pobject.handle, tok->pobject.objauth,
+    rv = tpm_loadobj(tok->tctx, tok->pobject.handle, tok->pobject.objauth,
             sealpub, sealpriv, &sealhandle);
-    if (!res) {
-        rv = CKR_GENERAL_ERROR;
+    if (rv != CKR_OK) {
         goto out;
     }
 

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -551,13 +551,13 @@ CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj)
         return CKR_OK;
     }
 
-    bool result = tpm_loadobj(
+    rv = tpm_loadobj(
             tpm,
             tok->pobject.handle, tok->pobject.objauth,
             tobj->pub, tobj->priv,
             &tobj->tpm_handle);
-    if (!result) {
-        return CKR_GENERAL_ERROR;
+    if (rv != CKR_OK) {
+        return rv;
     }
 
     rv = utils_ctx_unwrap_objauth(tok->wrappingkey, tobj->objauth,

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -86,7 +86,7 @@ bool tpm_getrandom(tpm_ctx *ctx, uint8_t *data, size_t size);
 
 CK_RV tpm_stirrandom(tpm_ctx *ctx, unsigned char *seed, unsigned long seed_len);
 
-bool tpm_loadobj(tpm_ctx *ctx, uint32_t phandle, twist auth,
+CK_RV tpm_loadobj(tpm_ctx *ctx, uint32_t phandle, twist auth,
         twist pub_path, twist priv_path, uint32_t *handle);
 
 bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle);

--- a/test/integration/pkcs-lockout.int.c
+++ b/test/integration/pkcs-lockout.int.c
@@ -1,0 +1,247 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include "tpm.h"
+#include "test.h"
+
+/* we need to manage lockout counter for testing bad auths */
+#include <tss2/tss2_esys.h>
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_tctildr.h>
+
+typedef struct test_session_handle test_session_handle;
+struct test_session_handle {
+    CK_SESSION_HANDLE handle; /* the session handle */
+    bool is_rw;               /* true if the session is R/W false if R/O */
+};
+
+/*
+ *  The maximum number of sessions any test expects to use
+ *  Note: The test_setup() routine only populates 2 session
+ *  handles as most tests ONLY need 2. The one test that
+ *  needs more than 2 is test_user_login_logout_time_two(),
+ *  and it manages the sessions itself.
+ */
+#define MAX_TEST_SESSIONS 3
+
+#define C(x) ((CK_UTF8CHAR_PTR)x)
+
+typedef struct test_slot test_slot;
+struct test_slot {
+    CK_SLOT_ID slot_id; /* slot id */
+    test_session_handle sessions[MAX_TEST_SESSIONS]; /* session on that slot */
+};
+
+struct test_info {
+    test_slot slots[2]; /* slots with sessions for use */
+};
+
+ESYS_CONTEXT *_g_ectx = NULL;
+TSS2_TCTI_CONTEXT *_g_tcti = NULL;
+
+//TPM2_PT_MAX_AUTH_FAIL
+static void get_prop(TPM2_PT needle, UINT32 *value) {
+
+    TPMS_CAPABILITY_DATA *cap_data = NULL;
+    TPMI_YES_NO more_data = TPM2_NO;
+    TSS2_RC rc = Esys_GetCapability(_g_ectx,
+            ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+        TPM2_CAP_TPM_PROPERTIES,
+        TPM2_PT_VAR,
+        TPM2_MAX_TPM_PROPERTIES,
+        &more_data, &cap_data);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    UINT32 count = cap_data->data.tpmProperties.count;
+    TPMS_TAGGED_PROPERTY *props = cap_data->data.tpmProperties.tpmProperty;
+
+    UINT32 i;
+    for(i=0; i < count; i++) {
+        TPM2_PT p = props[i].property;
+        UINT32 v =props[i].value;
+        if (p == needle) {
+            *value = v;
+            Esys_Free(cap_data);
+            return;
+        }
+    }
+
+    Esys_Free(cap_data);
+    fail_msg("No property: %" PRIu32, needle);
+}
+
+static int _group_setup_locking(void **state) {
+
+    const char *config = getenv(TPM2_PKCS11_TCTI);
+
+    TSS2_RC rc = Tss2_TctiLdr_Initialize(config, &_g_tcti);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    rc = Esys_Initialize(&_g_ectx, _g_tcti, NULL);
+    assert_int_equal(rc, TSS2_RC_SUCCESS);
+
+    return group_setup_locking(state);
+}
+
+static int _group_teardown(void **state) {
+
+    Esys_Finalize(&_g_ectx);
+    Tss2_TctiLdr_Finalize(&_g_tcti);
+    free(_g_tcti);
+    return group_teardown(state);
+}
+
+/**
+ * Opens a session on a slot
+ * @param slot
+ *  The slot id to open the session on
+ * @param is_rw
+ *  True if it should open the session as R/W via CKF_RW_SESSION, else it's just R/O.
+ * @param tsh
+ *  The test_session_handle to populate
+ */
+static void open_session(CK_SLOT_ID slot, bool is_rw, test_session_handle *tsh) {
+
+    CK_FLAGS flags = CKF_SERIAL_SESSION;
+    if (is_rw) {
+        flags |= CKF_RW_SESSION;
+    }
+
+    CK_RV rv = C_OpenSession(slot, CKF_SERIAL_SESSION | flags, NULL,
+            NULL, &tsh->handle);
+    assert_int_equal(rv, CKR_OK);
+    tsh->is_rw = is_rw;
+}
+
+/**
+ * Creates and populates a test_info structure but
+ * DOESNT open ANY sessions.
+ * @return
+ *  test_info *, asserts on ENOMEM.
+ */
+static test_info *_test_info_new(void) {
+
+    test_info *ti = calloc(1, sizeof(*ti));
+    assert_non_null(ti);
+
+    /* get the slots */
+    CK_SLOT_ID slots[6];
+    CK_ULONG count = ARRAY_LEN(slots);
+    CK_RV rv = C_GetSlotList(true, slots, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, TOKEN_COUNT);
+
+    ti->slots[0].slot_id = slots[0];
+    ti->slots[1].slot_id = slots[1];
+
+    return ti;
+}
+
+/**
+ * Creates a new test_info structure populating:
+ * slot[0]:
+ *   - slot_id    --> slot_id of the token
+ *   - session[0] --> a valid session
+ *   - session[1] --> a valid session
+ * slot[1]:
+ *   - slot_id    --> slot_id of the token
+ *   - session[0] --> a valid session
+ *
+ * @param is_rw
+ *  True if the sessions should be R/W false for R/O
+ * @return
+ *  test_info on success.
+ */
+static test_info *test_info_new(bool is_rw) {
+
+    test_info *ti = _test_info_new();
+
+    CK_SLOT_ID slot_id = ti->slots[0].slot_id;
+    test_session_handle *tsh = &ti->slots[0].sessions[0];
+    /* open two RO sessions on slot 0, and one on slot 1 */
+    open_session(slot_id, is_rw, tsh);
+
+    tsh = &ti->slots[0].sessions[1];
+    open_session(slot_id, is_rw, tsh);
+
+    slot_id = ti->slots[1].slot_id;
+    tsh = &ti->slots[1].sessions[0];
+    open_session(slot_id, is_rw, tsh);
+
+    return ti;
+}
+
+/**
+ * Sets up a test run with read-only sessions
+ * @param state
+ *  The CMOCKA state to populate
+ * @return
+ *  0 on success or asserts on error.
+ */
+static int test_setup_ro(void **state) {
+
+    *state = test_info_new(false);
+    return 0;
+}
+
+/**
+ * Closes all sessions for slots and frees the test_info
+ * structure.
+ * @param state
+ *  Expects *state to be a valid test_info pointer.
+ * @return
+ */
+static int test_teardown(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    unsigned i;
+    for (i=0; i < ARRAY_LEN(ti->slots); i++) {
+        CK_SLOT_ID slot_id = ti->slots[i].slot_id;
+        CK_RV rv = C_CloseAllSessions(slot_id);
+        assert_int_equal(rv, CKR_OK);
+    }
+
+    free(ti);
+
+    return 0;
+}
+
+static void test_user_lockout(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE handle = ti->slots[0].sessions[0].handle;
+
+    /* tpm's are generally configured for 3 attempts you can check
+     * tpm2_getcap properties-variable
+     *   - TPM2_PT_MAX_AUTH_FAIL: 0x3
+     */
+
+    UINT32 max_fail = 0;
+    get_prop(TPM2_PT_MAX_AUTH_FAIL, &max_fail);
+
+    UINT32 count = 0;
+    get_prop(TPM2_PT_LOCKOUT_COUNTER, &count);
+    assert_int_equal(count, 0);
+
+    UINT32 i;
+    for(i=0; i < max_fail; i++) {
+        login_expects(handle, CKU_USER, CKR_PIN_INCORRECT, C(BAD_USERPIN), sizeof(BAD_USERPIN) - 1);
+        get_prop(TPM2_PT_LOCKOUT_COUNTER, &count);
+        assert_int_equal(count, i + 1);
+    }
+
+    get_prop(TPM2_PT_LOCKOUT_COUNTER, &count);
+    assert_int_equal(count, max_fail);
+
+    login_expects(handle, CKU_USER, CKR_PIN_LOCKED, C(GOOD_USERPIN), sizeof(GOOD_USERPIN) - 1);
+}
+
+int main() {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_user_lockout,
+                test_setup_ro, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, _group_setup_locking, _group_teardown);
+}


### PR DESCRIPTION
Write a test to verify that DA lockout occurs after 3 bad pin attempts
and that the return code is CKR_PIN_LOCKED.

Note: this expects DA configuration to be 3, which is what the simulator
is configured for.

Signed-off-by: William Roberts <william.c.roberts@intel.com>