### PR TITLE
[BACKPORT] C_CreateObject: Support CKO_DATA object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ### 1.3.0 - next
-
+  * C\_CreateObject: Support for CKO\_DATA objects only with CKA\_PRIVATE set to CK\_TRUE.
+    Token defaults to CK\_TRUE.
   * Fix Tests against simulator that support RSA 3072 keys
 
 ### 1.2.0 - 2020-03-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.3.0 - next
+
+  * Fix Tests against simulator that support RSA 3072 keys
+
 ### 1.2.0 - 2020-03-30
   * Fix PSS signatures. Non-FIPS mode TPMs produce PSS signatures with a
     max salt len that poses interoperability issues with verifying clients,

--- a/src/lib/attrs.h
+++ b/src/lib/attrs.h
@@ -14,6 +14,11 @@
 #define CKA_TPM2_OBJAUTH_ENC (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x1UL)
 #define CKA_TPM2_PUB_BLOB    (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x2UL)
 #define CKA_TPM2_PRIV_BLOB   (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x3UL)
+#define CKA_TPM2_ENC_BLOB    (CKA_VENDOR_DEFINED|CKA_VENDOR_TPM2_DEFINED|0x4UL)
+
+/* Invalid values for error detection */
+#define CK_OBJECT_CLASS_BAD (~(CK_OBJECT_CLASS)0)
+#define CKA_KEY_TYPE_BAD    (~(CK_KEY_TYPE)0)
 
 /**
  * The heart of any PKCS11 object is it's attribute list. This list
@@ -113,6 +118,16 @@ CK_ATTRIBUTE_PTR attr_list_get_ptr(attr_list *l);
  *  The attribute list to free.
  */
 void attr_list_free(attr_list *attrs);
+
+/**
+ * Scrubs the memory pointed to by the pValue pointer and frees it.
+ * The attribute pointer is expected to be contained within in attr_list.
+ * The attribute is NOT REMOVED from the list and type remains unchanged.
+ * Sets ulValueLen to 0.
+ * @param attr
+ *  The attr to free.
+ */
+void attr_pfree_cleanse(CK_ATTRIBUTE_PTR attr);
 
 /**
  * Given a raw attribute list, perhaps from a client caller,
@@ -236,6 +251,10 @@ CK_RV attr_CK_OBJECT_CLASS(CK_ATTRIBUTE_PTR attr, CK_OBJECT_CLASS *x);
 
 CK_RV attr_CK_KEY_TYPE(CK_ATTRIBUTE_PTR attr, CK_KEY_TYPE *x);
 
+CK_BBOOL attr_list_get_CKA_PRIVATE(attr_list *attrs, CK_BBOOL defvalue);
+
+CK_OBJECT_CLASS attr_list_get_CKA_CLASS(attr_list *attrs, CK_OBJECT_CLASS defvalue);
+
 /**
  * Searches an attr_list for an attribute specified by type.
  * @param haystack
@@ -262,6 +281,8 @@ CK_ATTRIBUTE_PTR attr_get_attribute_by_type_raw(CK_ATTRIBUTE_PTR haystack, CK_UL
         CK_ATTRIBUTE_TYPE needle);
 
 CK_RV attr_common_add_RSA_publickey(attr_list **public_attrs);
+
+CK_RV attr_common_add_data(attr_list **storage_attrs);
 
 CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs);
 

--- a/src/lib/attrs.h
+++ b/src/lib/attrs.h
@@ -286,4 +286,8 @@ CK_RV attr_common_add_data(attr_list **storage_attrs);
 
 CK_RV rsa_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs);
 
+CK_RV attr_list_append_entry(attr_list **attrs, CK_ATTRIBUTE_PTR untrusted_attr);
+
+CK_RV attr_list_update_entry(attr_list *attrs, CK_ATTRIBUTE_PTR untrusted_attr);
+
 #endif /* SRC_LIB_ATTRS_H_ */

--- a/src/lib/typed_memory.c
+++ b/src/lib/typed_memory.c
@@ -25,22 +25,23 @@ void *type_calloc(size_t nmemb, size_t size, CK_BYTE type) {
     return ptr;
 }
 
-void *type_realloc(void *orig, size_t size, CK_BYTE type) {
+void *type_zrealloc(void *old_ptr, size_t size, CK_BYTE type) {
 
     assert(size != 0);
 
     // overflow safety here...
-    size_t total = size;
-    total += 1;
+    size_t total = size + 1;
 
-    CK_BYTE_PTR ptr = (CK_BYTE_PTR)realloc(orig, total);
-    if (!ptr) {
+    CK_BYTE_PTR new_ptr = realloc(old_ptr, total);
+    if (!new_ptr) {
         return NULL;
     }
 
-    ptr[total - 1] = type;
+    memset(new_ptr, 0, total);
 
-    return ptr;
+    new_ptr[total - 1] = type;
+
+    return new_ptr;
 }
 
 CK_BYTE type_from_ptr(void *ptr, size_t len) {
@@ -88,4 +89,20 @@ void type_mem_cpy(void *dest, void *in, size_t size) {
     CK_BYTE got = type_from_ptr(dest, size);
     assert(check == got);
 #endif
+}
+
+const char *type_to_str(CK_BYTE type) {
+
+    switch(type) {
+    case TYPE_BYTE_INT:
+        return "int";
+    case TYPE_BYTE_BOOL:
+        return "bool";
+    case TYPE_BYTE_INT_SEQ:
+        return "int-seq";
+    case TYPE_BYTE_HEX_STR:
+        return "hex-str";
+    default:
+        return "unkown";
+    }
 }

--- a/src/lib/typed_memory.h
+++ b/src/lib/typed_memory.h
@@ -14,9 +14,10 @@
 #define TYPE_BYTE_TEMP_SEQ ((CK_BYTE)5)
 
 void *type_calloc(size_t nmemb, size_t size, CK_BYTE type);
-void *type_realloc(void *orig, size_t size, CK_BYTE type);
+void *type_zrealloc(void *orig, size_t size, CK_BYTE type);
 CK_BYTE type_from_ptr(void *ptr, size_t len);
 CK_RV type_mem_dup(void *in, size_t len, void **dup);
 void type_mem_cpy(void *dest, void *in, size_t size);
+const char *type_to_str(CK_BYTE type);
 
 #endif /* SRC_LIB_TYPED_MEMORY_H_ */

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -66,4 +66,20 @@ echo "Generating RSA keypair"
 pkcs11_tool --slot=1 --label="myrsakey" --login --pin=mynewuserpin --keypairgen
 echo "RSA Keypair generated"
 
+#
+# Test creating data objects
+#
+echo "hello world" > objdata
+pkcs11_tool --slot-index=0 --login --pin=mynewuserpin --write-object objdata --type data --label dataobj1 --private
+
+# whitebox test to make sure secret is not in store
+if [ "$TPM2_PKCS11_BACKEND" != "fapi" ]; then
+  sqlite3 "$TPM2_PKCS11_STORE/tpm2_pkcs11.sqlite3" 'select attrs from tobjects;' | grep -qiv "$(cat objdata)"
+  # and check for the hex encoded version too
+  sqlite3 "$TPM2_PKCS11_STORE/tpm2_pkcs11.sqlite3" 'select attrs from tobjects;' | grep -qiv "$(xxd -p objdata)"
+fi
+
+pkcs11_tool --slot-index=0 --login --pin=mynewuserpin --read-object --type data --label dataobj1 -o objdata2
+cmp objdata objdata2
+
 exit 0


### PR DESCRIPTION
Support storing secrets in the DB wrapped with the token wrapping key.
Since the wrapping key can unwrap all object authorizations, using the
TPM seal interface adds nothing. If you have the wrapping key, or can
brute force it, you can use the object. An object with a sealed value
means you can also release the secret. Also, a downside when using the
TPM for sealing is speed and the data cannot be bigger than 128 bytes.
Using the token wrapping key has none of these limitations.
    
Note: Only CKA_PRIVATE CK_TRUE objects are supported. Since the library
can make no guarentees about the attributes, an accidental or malicious
change to the CKA_PRIVATE value from CK_TRUE to CK_FALSE could cause
the plaintext value to be persisted to the store. Thus *ONLY* support
CKA_PRIVATE CKA_TRUE CKO_DATA objects for now.
    
Test it by using pkcs11-tool as well as a C integration test and probe
the sqlite3 db for the secret to ensure it is not leaked.
    
Note: This does not have C_SetAttribute support, so delete and re-create
a CKO_DATA_OBJECT if you need to change CKA_VALUE.