### PR TITLE
tpm2_ptool: add link cmd for tss keygen key

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -4,9 +4,9 @@
 function get_deps() {
 
 	# The list order is important and thus we can't use the keys of the dictionary as order is not preserved.
-	local github_deps=("tpm2-tss" "tpm2-abrmd" "tpm2-tools")
-	declare -A local config_flags=( ["tpm2-tss"]="--disable-doxygen-doc --enable-debug" ["tpm2-abrmd"]="--enable-debug" ["tpm2-tools"]="--disable-hardening --enable-debug")
-	declare -A local versions=( ["tpm2-tss"]="master" ["tpm2-abrmd"]="2.1.0" ["tpm2-tools"]="master")
+	local github_deps=("tpm2-tss" "tpm2-abrmd" "tpm2-tools" "tpm2-tss-engine")
+	declare -A local config_flags=( ["tpm2-tss"]="--disable-doxygen-doc --enable-debug" ["tpm2-abrmd"]="--enable-debug" ["tpm2-tools"]="--disable-hardening --enable-debug" ["tpm2-tss-engine"]="")
+	declare -A local versions=( ["tpm2-tss"]="master" ["tpm2-abrmd"]="2.1.0" ["tpm2-tools"]="master" ["tpm2-tss-engine"]="master")
 
 	echo "pwd starting: `pwd`"
 	pushd "$1"

--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -10,7 +10,8 @@ integration_scripts = \
     test/integration/tls-tests.sh \
     test/integration/openssl.sh \
     test/integration/pkcs11-javarunner.sh.java \
-    test/integration/nss-tests.sh
+    test/integration/nss-tests.sh \
+    test/integration/ptool-link.sh.nosetup
 # Note that -fapi.sh.fapi is symlinked to .sh.nosetup
 # If we'd use the .fapi extension then .nosetup and .fapi overwrite each others .log
 # thus we use -fapi.sh.fapi as suffix.

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,10 @@ AC_DEFUN([integration_test_checks], [
     AS_IF([test "x$tss2_provision" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but tss2_provision executable not found.])])
 
+  AC_CHECK_PROG([tpm2tss_genkey], [tpm2tss-genkey], [yes], [no])
+    AS_IF([test "x$tpm2tss_genkey" != "xyes"],
+      [AC_MSG_ERROR([Integration tests enabled but tpm2tss-genkey executable not found.])])
+
   AM_PATH_PYTHON([3.7],
     [AC_SUBST([PYTHON_INTERPRETER], [$PYTHON])],
     [AC_MSG_ERROR([Integration tests enabled but python >= 3.7 executable not found.])]

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -260,7 +260,18 @@ twist aes256_gcm_decrypt(const twist key, const twist objauth) {
         goto out;
     }
 
-    plaintext = twist_calloc(twist_len(ctextbin));
+    size_t clen = twist_len(ctextbin);
+    if (!clen) {
+        plaintext = twist_new("");
+        if (!plaintext) {
+            LOGE("oom");
+        } else {
+            ok = 1;
+        }
+        goto out;
+    }
+
+    plaintext = twist_calloc(clen);
     if (!plaintext) {
         LOGE("oom");
         goto out;

--- a/test/integration/fixtures/tss2engine.cnf
+++ b/test/integration/fixtures/tss2engine.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+engines = engine_section
+
+[engine_section]
+tpm2tss = tpm2tss_section
+
+[tpm2tss_section]
+SET_TCTI = ${ENV::TPM2_PKCS11_TCTI}

--- a/test/integration/ptool-link.sh.nosetup
+++ b/test/integration/ptool-link.sh.nosetup
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -x
+
+source "$T/test/integration/scripts/helpers.sh"
+
+tempdir=$(mktemp -d)
+
+function cleanup() {
+	rm -rf "$tempdir"
+}
+trap cleanup EXIT
+
+onerror() {
+  echo "$BASH_COMMAND on line ${BASH_LINENO[0]} failed: $?"
+  exit 1
+}
+trap onerror ERR
+
+setup_asan
+
+if [ -z "$modpath" ]; then
+  modpath="$PWD/src/.libs/libtpm2_pkcs11.so"
+fi
+
+echo "modpath=$modpath"
+
+pkcs11_tool() {
+  pkcs11-tool --module "$modpath" "$@"
+  return $?
+}
+
+export TPM2_PKCS11_STORE="$tempdir"
+
+echo "TPM2_PKCS11_STORE=$TPM2_PKCS11_STORE"
+
+echo "TPM2_PKCS11_TCTI=$TPM2_PKCS11_TCTI"
+export TPM2_PKCS11_TCTI
+
+# Create a primary key at "$handle"
+tpm2_createprimary -c primary.ctx
+handle=$(tpm2_evictcontrol -c primary.ctx | grep persistent-handle | cut -d' ' -f2-2)
+
+# Create a primary object in the store referencing it
+pid=$(tpm2_ptool init --primary-handle="$handle" --path=$TPM2_PKCS11_STORE | grep id | cut -d' ' -f2-2)
+
+# Create a token using that pid
+tpm2_ptool addtoken --pid="$pid" --label=linktoken --sopin=mysopin --userpin=myuserpin \
+    --path=$TPM2_PKCS11_STORE
+
+# Set up the engine for the tpm2tss-genkey tool both for future and older ways of doing it
+export OPENSSL_CONF="$TEST_FIXTURES/tss2engine.cnf"
+export TPM2TSSENGINE_TCTI="$TPM2_PKCS11_TCTI"
+
+# Generate a TSS2 Engine RSA key
+tpm2tss-genkey -P"$handle" -a rsa -s 2048 "$tempdir/tss2-rsa-2048.pem"
+
+unset OPENSSL_CONF
+
+# Link that key into the token
+tpm2_ptool link --label=linktoken --userpin=myuserpin --key-label=tss2rsa2048 \
+    --path=$TPM2_PKCS11_STORE "$tempdir/tss2-rsa-2048.pem"
+
+echo "testdata">${tempdir}/data
+
+echo "Testing RSA signature"
+pkcs11_tool -v --list-objects --login --pin myuserpin
+
+pkcs11_tool -v --sign --login --token-label="linktoken" --label="tss2rsa2048" --pin myuserpin \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism SHA256-RSA-PKCS
+
+pkcs11_tool -v --read-object --token-label="linktoken" --label="tss2rsa2048" \
+            --type pubkey --output-file ${tempdir}/pubkey.der \
+    || exit 77
+#This fails on old pkcs11-tool versions, thus exit-skip here
+
+openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/sig -sha256 \
+             -sigopt rsa_padding_mode:pkcs1 \
+             ${tempdir}/data
+echo "RSA signature tested"
+
+exit 0

--- a/test/integration/ptool-link.sh.nosetup
+++ b/test/integration/ptool-link.sh.nosetup
@@ -50,6 +50,10 @@ tpm2_ptool addtoken --pid="$pid" --label=linktoken --sopin=mysopin --userpin=myu
     --path=$TPM2_PKCS11_STORE
 
 # Set up the engine for the tpm2tss-genkey tool both for future and older ways of doing it
+engdir="$(pkg-config --variable=enginesdir libcrypto)"
+if [ -z "$engdir" ]; then
+  export OPENSSL_ENGINES=/usr/local/lib/engines
+fi
 export OPENSSL_CONF="$TEST_FIXTURES/tss2engine.cnf"
 export TPM2TSSENGINE_TCTI="$TPM2_PKCS11_TCTI"
 
@@ -57,6 +61,7 @@ export TPM2TSSENGINE_TCTI="$TPM2_PKCS11_TCTI"
 tpm2tss-genkey -P"$handle" -a rsa -s 2048 "$tempdir/tss2-rsa-2048.pem"
 
 unset OPENSSL_CONF
+unset OPENSSL_ENGINES
 
 # Link that key into the token
 tpm2_ptool link --label=linktoken --userpin=myuserpin --key-label=tss2rsa2048 \

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -5,11 +5,16 @@ import sys
 from tempfile import mkstemp, NamedTemporaryFile
 import uuid
 
+
 from subprocess import Popen, PIPE
 
 from .utils import str2bytes
 
 class Tpm2(object):
+    TPM2_RH_OWNER = 0x40000001
+    TPM2_HR_SHIFT = 24
+    TPM2_HT_PERSISTENT = 0x81
+
     def __init__(self, tmp):
         self._tmp = tmp
 
@@ -241,7 +246,6 @@ class Tpm2(object):
 
         newpriv = os.path.join(self._tmp, uuid.uuid4().hex + '.priv')
 
-        #tpm2_load -C $file_primary_key_ctx  -u $file_load_key_pub  -r $file_load_key_priv -n $file_load_key_name -o $file_load_key_ctx
         cmd = [
             'tpm2_changeauth',
             '-C',
@@ -258,7 +262,7 @@ class Tpm2(object):
         _, stderr = p.communicate()
         rc = p.wait()
         if rc:
-            raise RuntimeError("Could not execute tpm2_load: %s", stderr)
+            raise RuntimeError("Could not execute tpm2_changeauth: %s", stderr)
 
         return newpriv
 


### PR DESCRIPTION
Allow existing tpm2tss-genkey generated keys to be added into a token
under very specific limitations that the token's associated pobject
and tpm2tss-genkey key parent must be the same primary object.

Example:

tpm2 createprimary -c primary.ctx

tpm2 evictcontrol -c primary.ctx 0x81000003

tpm2tss-genkey -a rsa -s 2048 -P 0x81000003 tss-rsa.key

tpm2_ptool init --primary-handle 0x81000003 --path=~/tmp
action: Added
id: 4

tpm2_ptool addtoken --pid=4 --sopin=mysopin --userpin=myuserpin --label=linktoken --path=~/tmp

tpm2_ptool link --label=linktoken --userpin=myuserpin --path=/home/wcrobert/tmp /home/wcrobert/workspace/tpm2-tss-engine/tss-rsa.key

Follow on work to support tpm2tss-genkey with transient EC parents will
be next.

Progresses: #485

Signed-off-by: William Roberts <william.c.roberts@intel.com>