### PR TITLE
configure: fix --enable-asan env variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,8 +92,15 @@ src_libtpm2_test_internal_la_SOURCES = $(LIB_PKCS11_INTERNAL_LIB_SRC)
 
 noinst_LTLIBRARIES = $(libtpm2_test_pkcs11) $(libtpm2_test_internal)
 
+if ENABLE_ASAN
+    ASAN_ENABLED="true"
+else
+    ASAN_ENABLED=""
+endif
+
 # test harness configuration
 AM_TESTS_ENVIRONMENT = \
+    ASAN_ENABLED=$(ASAN_ENABLED) \
     T=$(abs_top_srcdir) \
     PYTHON_INTERPRETER=@PYTHON_INTERPRETER@ \
     TEST_FUNC_LIB=$(srcdir)/test/integration/scripts/int-test-funcs.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AC_DEFUN([asan_checks],[
 
 AS_IF([test "x$enable_asan" = "xyes"],
     [asan_checks])
+AM_CONDITIONAL([ENABLE_ASAN],[test "x$enable_asan" = "xyes"])
 
 AC_DEFUN([unit_test_checks],[
 


### PR DESCRIPTION
configure option --enable-asan depends on the tests properly setting up
the ASAN environment via helpers.sh. That depends on the ASAN_ENABLED
environment variable set to true.

Signed-off-by: William Roberts <william.c.roberts@intel.com>