### PR TITLE
pkcs11: transient pobjects for tss2-keygen compat

### DIFF
--- a/docs/INITIALIZING.md
+++ b/docs/INITIALIZING.md
@@ -77,6 +77,16 @@ The output of the command to *stdout* is important. It describes the id of the p
 that one can associate subsequent commands to. Again, to create N > 1 slots, just run this command
 N times.
 
+### Transient Primary Keys
+
+By default, and suitable for most users, primary keys are persistent objects in TPM non-volatile memory. However,
+under certain situations, one may wish to use a transient primary key. The upside is that this consumes no
+non-volatile memory in the TPM. So this would be suitable in situations where all NV space is consumed. The downside
+is that initialization of the token will be slower and that it requires authentication to the owner hierarchy. `tpm2_ptool`
+commands that need to leverage a transient primary object have been augmented to take the `--hierarchy-auth` option to
+supply this. However, token initialization will need this in tools consuming the pkcs11 library. This can be supplied
+via the environment variable `TPM2_PKCS11_OWNER_AUTH`.
+
 ### Step 2 - Creating a Token
 
 After creating a slot or slots, now one needs to create a token. This is accomplished with the `addtoken` command for `tpm2-ptool`,

--- a/docs/INTEROPERABILITY.md
+++ b/docs/INTEROPERABILITY.md
@@ -1,0 +1,71 @@
+# Interoperability with Existing TPM2 Objects
+
+A user may have existing TPM2 objects created with the [tpm2-tss-engine](https://github.com/tpm2-software/tpm2-tss-engine) project.
+In order to use these objects in a token one can use the tpm2_ptool link commandlet. Below is an example of doing so.
+
+### Linking a TPM2 TSS Engine Key with a persistent primary object
+
+tpm2-tss-engine's *tpm2tss-genkey* command has the ability to create TPM2 objects using an existing primary key. The only requirement
+that the tpm2-pkcs11 project requires is that the handle be persistent. The example below creates a persistent primary key and creates
+a tpm2-tss-engine key under the persistent primary key to use. Many TPM's come provisioned with what is known as the storage root key (SRK).
+This is a key defined by the [provisioning guidance](https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf).
+This is a particularly useful key, and is set to an empty auth value. Thus owner authorization is not needed.
+
+Also in the examples below we use specific primary key handles, but if one has existing objects, just substitute the values.
+
+```bash
+#
+# Note: below we create/use a store in ~/tmp, however one can use a store wherever they would like.
+#
+
+# Create a primary key
+tpm2_createprimary -c primary.ctx
+
+# Persistent primary key at handle 0x81000001
+tpm2_evictcontrol -c primary.ctx 0x81000001
+
+# Create the tpm2-tss-engine key under the persistent primary key
+tpm2tss-genkey -P 0x81000001 tss2key-rsa2048.pem
+
+# Create a primary object in a store compatible for this key
+pid="$(tpm2_ptool init --primary-handle=0x81000001 --path=~/tmp | grep id | cut -d' ' -f 2-2)"
+
+# Create a token associated with the primary object
+# Note: in production set userpin and sopin to other values.
+tpm2_ptool addtoken --pid=$pid --sopin=mysopin --userpin=myuserpin --label=mytoken --path=~/tmp
+
+# Link the key
+tpm2_ptool link --label=mytoken --userpin=myuserpin --key-label="link-key" tss2key-rsa2048.pem
+```
+
+From there, one can use that key as they would in other tutorials.
+
+
+## Linking a TPM2 TSS Engine Key with a transient primary object
+
+It may be desirable to use the transient primary key that *tpm2tss-genkey* utilizes by default. Either as
+a way to avoid using Non-Volatile memory with a persistent key, or for interoperability with existing
+*tpm2tss-genkey* generated keys using this default parent.
+
+Also in the examples below we create tpm2-tss-engine key, existing keys may also be used.
+
+```bash
+#
+# Note: below we create/use a store in ~/tmp, however one can use a store wherever they would like.
+#
+
+# Create the tpm2-tss-engine key under the default transient primary key or use existing similar key
+tpm2tss-genkey tss2key-rsa2048.pem
+
+# Create a token associated with a transient primary object that is compatible with tpm2-tss-engine
+pid="$(tpm2_ptool init --transient-parent=tss2-engine-key --path=~/tmp | grep id | cut -d' ' -f 2-2)"
+
+# Create a token associated with the primary object
+# Note: in production set userpin and sopin to other values.
+tpm2_ptool addtoken --pid=$pid --sopin=mysopin --userpin=myuserpin --label=mytoken --path=~/tmp
+
+# Link the key
+tpm2_ptool link --label=mytoken --userpin=myuserpin --key-label="link-key" tss2key-rsa2048.pem
+```
+
+From there, one can use that key as they would in other tutorials.

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -46,7 +46,7 @@ CK_RV db_delete_object(tobject *tobj);
 
 CK_RV db_get_first_pid(unsigned *id);
 
-CK_RV db_add_primary(twist blob, unsigned *pid);
+CK_RV db_add_primary(pobject *pobj, unsigned *pid);
 
 CK_RV db_add_token(token *tok);
 

--- a/src/lib/emitter.h
+++ b/src/lib/emitter.h
@@ -11,4 +11,6 @@ char *emit_attributes_to_string(attr_list *attrs);
 
 char *emit_config_to_string(token *tok);
 
+char *emit_pobject_to_conf_string(pobject_config *pobj);
+
 #endif /* SRC_LIB_EMITTER_H_ */

--- a/src/lib/mech.h
+++ b/src/lib/mech.h
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+#include <stdbool.h>
 
 #include <openssl/evp.h>
 

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -14,4 +14,7 @@ bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
 bool parse_token_config_from_string(const unsigned char *yaml, size_t size,
         token_config *config);
 
+bool parse_pobject_config_from_string(const unsigned char *yaml, size_t size,
+        pobject_config *config);
+
 #endif /* SRC_LIB_PARSER_H_ */

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -219,6 +219,20 @@ static void sealobject_free(sealobject *sealobj) {
     sealobj->userpriv = NULL;
 }
 
+static void pobject_free(pobject *pobj) {
+
+    twist_free(pobj->objauth);
+    pobj->objauth = NULL;
+
+    pobject_config *c = &pobj->config;
+
+    if (c->is_transient) {
+        free(c->template_name);
+    } else {
+        twist_free(c->blob);
+    }
+}
+
 void token_free(token *t) {
 
     /*
@@ -228,8 +242,7 @@ void token_free(token *t) {
     session_table_free(t->s_table);
     t->s_table = NULL;
 
-    twist_free(t->pobject.objauth);
-    t->pobject.objauth = NULL;
+    pobject_free(&t->pobject);
 
     if (t->type == token_type_esysdb) {
         sealobject_free(&t->esysdb.sealobject);

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -38,10 +38,20 @@ enum token_login_state {
 
 typedef struct tobject tobject;
 
+typedef struct pobject_config pobject_config;
+struct pobject_config {
+    bool is_transient;
+    union {
+        char *template_name;
+        twist blob;
+    };
+};
+
 typedef struct pobject pobject;
 struct pobject {
-    uint32_t handle;
     twist objauth;
+    uint32_t handle;
+    pobject_config config;
 };
 
 typedef struct sealobject sealobject;

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -170,7 +170,11 @@ CK_RV tpm2_getmechanisms(tpm_ctx *ctx, CK_MECHANISM_TYPE *mechanism_list, CK_ULO
 
 CK_RV tpm_get_existing_primary(tpm_ctx *tpm, uint32_t *primary_handle, twist *primary_blob);
 
-CK_RV tpm_create_primary(tpm_ctx *tpm, uint32_t *primary_handle, twist *primary_blob);
+CK_RV tpm_create_persistent_primary(tpm_ctx *tpm, uint32_t *primary_handle, twist *primary_blob);
+
+CK_RV tpm_create_transient_primary_from_template(tpm_ctx *tpm,
+        const char *template_name, const char *pobj_auth,
+        uint32_t *primary_handle);
 
 CK_RV tpm_get_pss_sig_state(tpm_ctx *tctx, tobject *tobj, bool *pss_sigs_good);
 

--- a/test/fuzz/db-token-label.fuzz32.c
+++ b/test/fuzz/db-token-label.fuzz32.c
@@ -52,9 +52,11 @@ static int setup(void **state) {
     db_debug_set_db(_db);
 
     unsigned int pid = 0;
-    twist blob = twist_new("aabbccdd");
-    rv = db_add_primary(blob, &pid);
-    twist_free(blob);
+    pobject pobj = { 0 };
+    pobj.config.blob = twist_new("aabbccdd");
+    assert_non_null(pobj.config.blob);
+    rv = db_add_primary(&pobj, &pid);
+    twist_free(pobj.config.blob);
     assert_int_equal(rv, CKR_OK);
 
     /* create and add a dummy token */

--- a/test/integration/ptool-link.sh.nosetup
+++ b/test/integration/ptool-link.sh.nosetup
@@ -31,6 +31,39 @@ pkcs11_tool() {
   return $?
 }
 
+tpm2tss_genkey() {
+  export OPENSSL_CONF="$TEST_FIXTURES/tss2engine.cnf"
+  export TPM2TSSENGINE_TCTI="$TPM2_PKCS11_TCTI"
+
+  # Generate a TSS2 Engine RSA key
+  tpm2tss-genkey "$@"
+
+  unset OPENSSL_CONF
+  unset OPENSSL_ENGINES
+}
+
+rsa_verify() {
+
+  echo "testdata">${tempdir}/data
+
+  echo "Testing RSA signature"
+  pkcs11_tool -v --list-objects --login --pin myuserpin
+
+  pkcs11_tool -v --sign --login --token-label="$1" --label="$2" --pin myuserpin \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism SHA256-RSA-PKCS
+
+  pkcs11_tool -v --read-object --token-label="$1" --label="$2" \
+            --type pubkey --output-file "${tempdir}/$2.der" \
+    || exit 77
+  #This fails on old pkcs11-tool versions, thus exit-skip here
+
+  openssl dgst -verify "${tempdir}/$2.der" -keyform DER -signature ${tempdir}/sig -sha256 \
+             -sigopt rsa_padding_mode:pkcs1 \
+             ${tempdir}/data
+  echo "RSA signature tested"
+}
+
 export TPM2_PKCS11_STORE="$tempdir"
 
 echo "TPM2_PKCS11_STORE=$TPM2_PKCS11_STORE"
@@ -54,36 +87,49 @@ engdir="$(pkg-config --variable=enginesdir libcrypto)"
 if [ -z "$engdir" ]; then
   export OPENSSL_ENGINES=/usr/local/lib/engines
 fi
-export OPENSSL_CONF="$TEST_FIXTURES/tss2engine.cnf"
-export TPM2TSSENGINE_TCTI="$TPM2_PKCS11_TCTI"
 
-# Generate a TSS2 Engine RSA key
-tpm2tss-genkey -P"$handle" -a rsa -s 2048 "$tempdir/tss2-rsa-2048.pem"
-
-unset OPENSSL_CONF
-unset OPENSSL_ENGINES
+tpm2tss_genkey -P"$handle" -a rsa -s 2048 "$tempdir/tss2-rsa-2048.pem"
 
 # Link that key into the token
 tpm2_ptool link --label=linktoken --userpin=myuserpin --key-label=tss2rsa2048 \
     --path=$TPM2_PKCS11_STORE "$tempdir/tss2-rsa-2048.pem"
 
-echo "testdata">${tempdir}/data
+rsa_verify "linktoken" "tss2rsa2048"
 
-echo "Testing RSA signature"
-pkcs11_tool -v --list-objects --login --pin myuserpin
+#
+# Test transient primary keys that the TSS Engine uses
+#
+pid=$(tpm2_ptool init --transient-parent="tss2-engine-key" --path=$TPM2_PKCS11_STORE | grep id | cut -d' ' -f2-2)
 
-pkcs11_tool -v --sign --login --token-label="linktoken" --label="tss2rsa2048" --pin myuserpin \
-            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
-            --mechanism SHA256-RSA-PKCS
+tpm2_ptool addtoken --pid="$pid" --label=linktokentransient --sopin=mysopin --userpin=myuserpin \
+    --path=$TPM2_PKCS11_STORE
 
-pkcs11_tool -v --read-object --token-label="linktoken" --label="tss2rsa2048" \
-            --type pubkey --output-file ${tempdir}/pubkey.der \
-    || exit 77
-#This fails on old pkcs11-tool versions, thus exit-skip here
+tpm2tss_genkey "$tempdir/tss2-rsa-2048-transient.pem"
 
-openssl dgst -verify ${tempdir}/pubkey.der -keyform DER -signature ${tempdir}/sig -sha256 \
-             -sigopt rsa_padding_mode:pkcs1 \
-             ${tempdir}/data
-echo "RSA signature tested"
+# Link that key into the token
+tpm2_ptool link --label=linktokentransient --userpin=myuserpin --key-label=tss2rsa2048transient \
+    --path=$TPM2_PKCS11_STORE "$tempdir/tss2-rsa-2048-transient.pem"
+
+rsa_verify "linktokentransient" "tss2rsa2048transient"
+
+# Now test with owner auth and primary object passwords set to something
+rm -rf "$tempdir"/*
+
+tpm2_changeauth -c o "newpass"
+
+pid=$(tpm2_ptool init --transient-parent="tss2-engine-key" --hierarchy-auth=newpass --primary-auth=1234 \
+    --path=$TPM2_PKCS11_STORE | grep id | cut -d' ' -f2-2)
+
+tpm2_ptool addtoken --hierarchy-auth=newpass --pid="$pid" --label=linktokentransient --sopin=mysopin --userpin=myuserpin \
+    --path=$TPM2_PKCS11_STORE
+
+tpm2tss_genkey -o newpass "$tempdir/tss2-rsa-2048-transient.pem"
+
+# Link that key into the token
+tpm2_ptool link --hierarchy-auth=newpass --label=linktokentransient --userpin=myuserpin --key-label=tss2rsa2048transient \
+    --path=$TPM2_PKCS11_STORE "$tempdir/tss2-rsa-2048-transient.pem"
+
+export TPM2_PKCS11_OWNER_AUTH=newpass
+rsa_verify "linktokentransient" "tss2rsa2048transient"
 
 exit 0


### PR DESCRIPTION
This bumps the DB version to 4.

Invocations of plain tpm2tss-keygen result in a transient primary
object. Add support for the libraries and tooling to support tokens
with transient primary objects so existing tpm2tss-keygen generated
keys can be linked into a token. In theory one could make a compatible
primary object persistent, but this will provide a simple mechanism
and remove all requirements of non-volatile memory.

Signed-off-by: William Roberts <william.c.roberts@intel.com>