### PR TITLE
tpm2_ptool: fix setup

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 from setuptools import setup
+from textwrap import dedent as DD
 
-# read the contents of your README file
-from os import path
-readme = path.join(path.dirname(__file__), '..', 'docs', 'README.md')
-with open(readme, encoding='utf-8') as f:
-    long_description = f.read()
+long_description = DD('''
+   This tool is used to configure and maniuplate stores for the tpm2-pkcs11
+   cryptographic library.
+''')
 
 setup(
     name='tpm2-pkcs11-tools',


### PR DESCRIPTION
Fixes:
     File "/tmp/pip-req-build-5k2d9765/setup.py", line 7, in <module>
        with open(readme, encoding='utf-8') as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-5k2d9765/../docs/README.md'

That file won't be available in a temp build dir, so just hand-jam the
long description. The README file was too verbose anyways.

Signed-off-by: William Roberts <william.c.roberts@intel.com>