### PR TITLE
lib: fix argument to EVP_PKEY_verify_recover

### DIFF
--- a/src/lib/ssl_util.c
+++ b/src/lib/ssl_util.c
@@ -552,7 +552,7 @@ CK_RV ssl_util_verify_recover(EVP_PKEY *pkey,
         return rv;
     }
 
-    int rc = EVP_PKEY_verify_recover(pkey_ctx, data, data_len,
+    int rc = EVP_PKEY_verify_recover(pkey_ctx, data, (size_t*) data_len,
             signature, signature_len);
     if (rc < 0) {
         SSL_UTIL_LOGE("EVP_PKEY_verify_recover failed");


### PR DESCRIPTION
Fixes:
src/lib/ssl_util.c: In function ‘ssl_util_verify_recover’:
src/lib/ssl_util.c:555:54: error: passing argument 3 of ‘EVP_PKEY_verify_recover’ from incompatible pointer type [-Werror=incompatible-pointer-types]
     int rc = EVP_PKEY_verify_recover(pkey_ctx, data, data_len,
                                                      ^~~~~~~~

In file included from src/lib/ssl_util.c:9:
/usr/include/openssl/evp.h:1393:58: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG_PT
’ {aka ‘long unsigned int *’}
                             unsigned char *rout, size_t *routlen,

Fixes: #527

Signed-off-by: William Roberts <william.c.roberts@intel.com>