### PR TITLE
configure: autodetect if FAPI is enabled

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -64,7 +64,7 @@ fi
 # avoid error checking or cause make distcheck to fail. So run a
 # pure check with gcc before adding those flags.
 if [[ "$CC" != clang* ]]; then
-    ./configure --enable-esapi-session-manage-flags
+    ./configure --enable-esapi-session-manage-flags --disable-fapi
     make distcheck
     make distclean
 fi
@@ -83,7 +83,7 @@ if [[ "$CC" != clang* ]]; then
     # rebuild after running scan-build.
 fi
 
-../configure --enable-unit --enable-integration --enable-esapi-session-manage-flags $config_flags
+../configure --enable-unit --enable-integration --enable-esapi-session-manage-flags --enable-fapi $config_flags
 make -j$(nproc)
 make -j check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   * Support C_SetAttributeValue.
   * Support for selectable backend using TPM2_PKCS11_BACKEND=esysdb being current version.
   * Support for backend fapi that uses the tss2-fapi keystore instead of an sqlite db.
+    - This is auto-detected based on tss2-fapi being installed at configure time, and can be controlled
+      via --enable/disable-fapi.
   * C_CreateObject: Support for CKO_DATA objects only with CKA_PRIVATE set to CK_TRUE. Token
     defaults to CK_TRUE.
   * Fix: src/lib/ssl_util.c:555:54: error: passing argument 3 of ‘EVP_PKEY_verify_recover’ from incompatible pointer type

--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -3,18 +3,22 @@ TEST_EXTENSIONS = .sh .int .nosetup .java .fapi
 integration_scripts = \
     test/integration/pkcs11-tool.sh \
     test/integration/pkcs11-tool-init.sh.nosetup \
-    test/integration/pkcs11-tool-init-fapi.sh.fapi \
     test/integration/p11-tool.sh.nosetup \
-    test/integration/p11-tool-fapi.sh.fapi \
     test/integration/pkcs11-dbup.sh.nosetup \
     test/integration/tls-tests.sh \
     test/integration/openssl.sh \
     test/integration/pkcs11-javarunner.sh.java \
     test/integration/nss-tests.sh \
     test/integration/ptool-link.sh.nosetup
+
 # Note that -fapi.sh.fapi is symlinked to .sh.nosetup
 # If we'd use the .fapi extension then .nosetup and .fapi overwrite each others .log
 # thus we use -fapi.sh.fapi as suffix.
+if HAVE_FAPI
+integration_scripts += \
+    test/integration/p11-tool-fapi.sh.fapi \
+    test/integration/pkcs11-tool-init-fapi.sh.fapi
+endif
 
 EXTRA_DIST += \
     $(integration_scripts) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,9 +98,16 @@ else
     ASAN_ENABLED=""
 endif
 
+if HAVE_FAPI
+    FAPI_ENABLED="true"
+else
+    FAPI_ENABLED=""
+endif
+
 # test harness configuration
 AM_TESTS_ENVIRONMENT = \
     ASAN_ENABLED=$(ASAN_ENABLED) \
+    FAPI_ENABLED=$(FAPI_ENABLED) \
     T=$(abs_top_srcdir) \
     PYTHON_INTERPRETER=@PYTHON_INTERPRETER@ \
     TEST_FUNC_LIB=$(srcdir)/test/integration/scripts/int-test-funcs.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,6 @@ AC_CONFIG_FILES([Makefile lib/tpm2-pkcs11.pc])
 AC_CONFIG_HEADERS([src/lib/config.h])
 
 # test for TSS dependecies
-PKG_CHECK_MODULES([TSS2_FAPI],   [tss2-fapi >= 3.0])
 PKG_CHECK_MODULES([TSS2_ESYS],   [tss2-esys >= 2.0])
 PKG_CHECK_MODULES([TSS2_MU],     [tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
@@ -71,6 +70,29 @@ AC_ARG_ENABLE(
   [esapi_sf=$enableval])
 AS_IF([test "x$esapi_sf" = "xyes"],
        [do_esapi_manage_flags])
+
+AC_ARG_ENABLE(
+  [fapi],
+  [AS_HELP_STRING([--with-fapi],
+    [enable or disable the fapi backend. Default is "auto" to autodetect])],
+    [enable_fapi=$enableval],
+    [enable_fapi=auto])
+
+AC_DEFUN([do_fapi_configure], [
+
+  AS_IF([test "x$enable_fapi" = "xauto"],
+      [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0], [have_fapi=1], [have_fapi=0]) ],
+	  [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0], [have_fapi=1]) ]
+  )
+])
+
+AS_IF([test "x$enable_fapi" != "xno"],
+    [do_fapi_configure])
+
+AS_IF([test "$have_fapi" = "1"],
+    AC_DEFINE([HAVE_FAPI], [1], [Enabled if FAPI >= 3.0 is found])
+])
+AM_CONDITIONAL([HAVE_FAPI], [test "$have_fapi" = "1"])
 
 # START ENABLE UNIT
 #
@@ -288,14 +310,6 @@ AC_DEFUN([integration_test_checks], [
     AS_IF([test "x$sqlite3" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but sqlite3 executable not found.])])
 
-  AC_CHECK_PROG([tss2_provision], [tss2_provision], [yes], [no])
-    AS_IF([test "x$tss2_provision" != "xyes"],
-      [AC_MSG_ERROR([Integration tests enabled but tss2_provision executable not found.])])
-
-  AC_CHECK_PROG([tpm2tss_genkey], [tpm2tss-genkey], [yes], [no])
-    AS_IF([test "x$tpm2tss_genkey" != "xyes"],
-      [AC_MSG_ERROR([Integration tests enabled but tpm2tss-genkey executable not found.])])
-
   AC_CHECK_PROG([tpm2_abrmd], [tpm2-abrmd], [yes], [no])
     AS_IF([test "x$tpm2_abrmd" != "xyes"],
       [AC_MSG_ERROR([Integration tests enabled but tpm2-abrmd executable not found.])])
@@ -304,6 +318,16 @@ AC_DEFUN([integration_test_checks], [
     [AC_SUBST([PYTHON_INTERPRETER], [$PYTHON])],
     [AC_MSG_ERROR([Integration tests enabled but python >= 3.7 executable not found.])]
   )
+
+  AS_IF([test "$have_fapi" = "1"], [
+    AC_CHECK_PROG([tss2_provision], [tss2_provision], [yes], [no])
+      AS_IF([test "x$tss2_provision" != "xyes"],
+        [AC_MSG_ERROR([Integration tests enabled but tss2_provision executable not found.])])
+
+    AC_CHECK_PROG([tpm2tss_genkey], [tpm2tss-genkey], [yes], [no])
+      AS_IF([test "x$tpm2tss_genkey" != "xyes"],
+        [AC_MSG_ERROR([Integration tests enabled but tpm2tss-genkey executable not found.])])
+  ])
 
   AS_IF([test "x$have_javac" = "xno"],
     [AC_MSG_ERROR([Integration tests enabled but no Java compiler was found])])

--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -1,12 +1,16 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
-
 #include "config.h"
+
+#ifdef HAVE_FAPI
+#include <tss2/tss2_fapi.h>
+#endif
+
 #include "backend_fapi.h"
 #include "emitter.h"
 #include "parser.h"
 #include "utils.h"
-#include <tss2/tss2_fapi.h>
 
+#ifdef HAVE_FAPI
 FAPI_CONTEXT *fctx = NULL;
 unsigned maxobjectid = 0;
 
@@ -923,3 +927,101 @@ out:
 
     return rv;
 }
+#else
+
+CK_RV backend_fapi_init(void) {
+
+	return CKR_OK;
+}
+
+CK_RV backend_fapi_destroy(void) {
+
+	return CKR_OK;
+}
+
+CK_RV backend_fapi_ctx_new(token *t) {
+
+	UNUSED(t);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+void backend_fapi_ctx_free(token *t) {
+
+	UNUSED(t);
+	LOGE("FAPI NOT ENABLED");
+}
+
+CK_RV backend_fapi_create_token_seal(token *t, const twist hexwrappingkey,
+                       const twist newauth, const twist newsalthex) {
+	UNUSED(t);
+	UNUSED(hexwrappingkey);
+	UNUSED(newauth);
+	UNUSED(newsalthex);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_add_tokens(token *tok, size_t *len) {
+
+	UNUSED(tok);
+	UNUSED(len);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_init_user(token *t, const twist sealdata,
+                        const twist newauthhex, const twist newsalthex) {
+	UNUSED(t);
+	UNUSED(sealdata);
+	UNUSED(newauthhex);
+	UNUSED(newsalthex);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_add_object(token *t, tobject *tobj) {
+
+	UNUSED(t);
+	UNUSED(tobj);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_update_tobject_attrs(token *tok, tobject *tobj, attr_list *attrlist) {
+
+	UNUSED(tok);
+	UNUSED(tobj);
+	UNUSED(attrlist);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_rm_tobject(token *tok, tobject *tobj) {
+
+	UNUSED(tok);
+	UNUSED(tobj);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_token_unseal_wrapping_key(token *tok, bool user, twist tpin) {
+
+	UNUSED(tok);
+	UNUSED(user);
+	UNUSED(tpin);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+CK_RV backend_fapi_token_changeauth(token *tok, bool user, twist toldpin, twist tnewpin) {
+
+	UNUSED(tok);
+	UNUSED(user);
+	UNUSED(toldpin);
+	UNUSED(tnewpin);
+	LOGE("FAPI NOT ENABLED");
+	return CKR_GENERAL_ERROR;
+}
+
+#endif

--- a/src/lib/config.h.in
+++ b/src/lib/config.h.in
@@ -16,6 +16,9 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
+/* Enabled if FAPI >= 3.0 is found */
+#undef HAVE_FAPI
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -10,8 +10,6 @@
 #include "twist.h"
 #include "utils.h"
 
-#include <tss2/tss2_fapi.h>
-
 typedef enum pss_config_state pss_config_state;
 enum pss_config_state {
     pss_config_state_unk = 0,
@@ -91,7 +89,7 @@ struct token {
             sealobject sealobject;
         } esysdb; /* esysdb */
         struct {
-            FAPI_CONTEXT *ctx;
+            void *ctx;
             twist userauthsalt;
             twist soauthsalt;
         } fapi;

--- a/test/integration/scripts/int-test-setup.sh
+++ b/test/integration/scripts/int-test-setup.sh
@@ -175,8 +175,11 @@ echo ${TPM2TOOLS_TCTI}
 export TPM2_PKCS11_TCTI="tabrmd:${TABRMD_TEST_TCTI_CONF}"
 echo ${TPM2_PKCS11_TCTI}
 
-setup_fapi ${SIM_TMP_DIR}
-tss2_provision
+
+if [ "$FAPI_ENABLED" == "true" ]; then
+    setup_fapi ${SIM_TMP_DIR}
+    tss2_provision
+fi
 
 # if provided, run the test script
 if [ -z "${TSETUP_SCRIPT}" ]; then
@@ -202,7 +205,9 @@ else
     fi
 fi
 
-tss2_list
+if [ "$FAPI_ENABLED" == "true" ]; then
+    tss2_list
+fi
 
 # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
 # second after the test finishes the simulator will die too. Bug in the


### PR DESCRIPTION
Don't require that FAPI is installed by default and auto-detect it.
However, keep the requirement in the CI build so nothing unknowingly
breaks.

Fixes: #538

Signed-off-by: William Roberts <william.c.roberts@intel.com>