### PR TITLE
db: code cov increase

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -48,8 +48,8 @@ if [[ "$CC" == clang* ]]; then
   # for things like __builtin_mul (undefined references to __muloti4)
   major_ver=$(echo $clang_version | cut -d'.' -f 1-1)
   if [ "$major_ver" -lt 9 ]; then
-    echo "Detecting clang less than version 9, enabling --disable-overflow"
-    config_flags="$config_flags --disable-overflow"
+    echo "Detecting clang less than version 9, enabling --enable-debug --disable-overflow"
+    config_flags="$config_flags --enable-debug --disable-overflow"
     echo "config_flags: $config_flags"
   fi
 else

--- a/Makefile-unit.am
+++ b/Makefile-unit.am
@@ -7,7 +7,8 @@ check_PROGRAMS += \
     test/unit/test_twist\
     test/unit/test_log \
     test/unit/test_parser \
-    test/unit/test_attr
+    test/unit/test_attr \
+    test/unit/test_db
 
 test_unit_test_twist_CFLAGS    = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_twist_LDADD     = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
@@ -18,6 +19,14 @@ test_unit_test_parser_LDADD    = $(CMOCKA_LIBS) $(YAML_LIBS) $(libtpm2_test_inte
 test_unit_test_attr_CFLAGS     = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_attr_LDADD      = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
 
+test_unit_test_db_CFLAGS       = $(AM_CFLAGS) $(CMOCKA_CFLAGS) $(SQLITE3_CFLAGS)
+test_unit_test_db_LDADD        = $(CMOCKA_LIBS) $(SQLITE3_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
+test_unit_test_db_LDFLAGS      = -Wl,--wrap=sqlite3_column_bytes \
+                                 -Wl,--wrap=sqlite3_column_blob \
+                                 -Wl,--wrap=sqlite3_data_count \
+                                 -Wl,--wrap=sqlite3_column_name \
+                                 -Wl,--wrap=sqlite3_column_bytes \
+                                 -Wl,--wrap=sqlite3_column_text
 endif
 # END UNIT
 

--- a/Makefile-unit.am
+++ b/Makefile-unit.am
@@ -26,7 +26,9 @@ test_unit_test_db_LDFLAGS      = -Wl,--wrap=sqlite3_column_bytes \
                                  -Wl,--wrap=sqlite3_data_count \
                                  -Wl,--wrap=sqlite3_column_name \
                                  -Wl,--wrap=sqlite3_column_bytes \
-                                 -Wl,--wrap=sqlite3_column_text
+                                 -Wl,--wrap=sqlite3_column_text \
+                                 -Wl,--wrap=sqlite3_column_int \
+                                 -Wl,--wrap=strdup
 endif
 # END UNIT
 

--- a/Makefile-unit.am
+++ b/Makefile-unit.am
@@ -15,8 +15,8 @@ test_unit_test_log_CFLAGS      = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_log_LDADD       = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
 test_unit_test_parser_CFLAGS   = $(AM_CFLAGS) $(YAML_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_parser_LDADD    = $(CMOCKA_LIBS) $(YAML_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
-test_unit_test_attr_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
-test_unit_test_attr_LDADD    = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
+test_unit_test_attr_CFLAGS     = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_attr_LDADD      = $(CMOCKA_LIBS) $(libtpm2_test_internal) $(libtpm2_test_pkcs11)
 
 endif
 # END UNIT

--- a/Makefile.am
+++ b/Makefile.am
@@ -80,7 +80,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --with-p11kitconfigdir='$$(datarootdir)/p11kitcon
 # UNIT, INTEGRATION and/or FUZZ can use this library.
 #
 
-# src/lib stuff as a seperate archive
+# src/lib stuff as a separate archive
 libtpm2_test_pkcs11 = src/libtpm2_test_pkcs11.la
 src_libtpm2_test_pkcs11_la_LIBADD =  $(AM_LDFLAGS) $(libtpm2_test_internal)
 src_libtpm2_test_pkcs11_la_SOURCES = $(LIB_PKCS11_SRC)

--- a/configure.ac
+++ b/configure.ac
@@ -434,6 +434,8 @@ AM_CONDITIONAL([HAVE_P11KIT], [test "x$have_p11kit" = "xyes"])
 
 # END P11 CONFIG
 
+AC_C_BIGENDIAN()
+
 # Good information on adding flags, and dealing with compilers can be found here:
 #   https://github.com/zcash/zcash/issues/1832
 #   https://github.com/kmcallister/autoharden/

--- a/src/lib/config.h.in
+++ b/src/lib/config.h.in
@@ -1,5 +1,8 @@
 /* src/lib/config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
 /* Define to disable built in overflow math */
 #undef DISABLE_OVERFLOW_BUILTINS
 
@@ -98,3 +101,15 @@
 
 /* Version number of package */
 #undef VERSION
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -44,14 +44,6 @@
 #define goto_error(x, l) if (x) { goto l; }
 #define gotobinderror(rc, msg) do { if (rc) { LOGE("cannot bind "msg); goto error; } } while(0)
 
-#ifdef FUZZING
-#define WEAK __attribute__((weak))
-#define FUZZING_VISIBILITY
-#else
-#define WEAK
-#define FUZZING_VISIBILITY static
-#endif
-
 typedef struct pobject_v3 pobject_v3;
 struct pobject_v3 {
     int id;
@@ -516,7 +508,7 @@ error:
     return rc;
 }
 
-FUZZING_VISIBILITY WEAK void db_get_label(token *t, sqlite3_stmt *stmt, int iCol) {
+DEBUG_VISIBILITY WEAK void db_get_label(token *t, sqlite3_stmt *stmt, int iCol) {
     snprintf((char *)t->label, sizeof(t->label), "%s",
                         sqlite3_column_text(stmt, iCol));
 }
@@ -2149,7 +2141,7 @@ out:
     return rv;
 }
 
-FUZZING_VISIBILITY WEAK
+DEBUG_VISIBILITY WEAK
 CK_RV db_new(sqlite3 **db) {
 
     char dbpath[PATH_MAX];

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -66,16 +66,17 @@ static struct {
 
 static int _get_blob(sqlite3_stmt *stmt, int i, bool can_be_null, twist *blob) {
 
+	/* This cannot return < 0 */
     int size = sqlite3_column_bytes(stmt, i);
-    if (size < 0) {
-        return 1;
-    }
+    assert(size >= 0);
 
     if (size == 0) {
         return can_be_null ? SQLITE_OK : SQLITE_ERROR;
     }
 
+    /* 0 length is the only way it will return NULL */
     const void *data = sqlite3_column_blob(stmt, i);
+    assert(data);
     *blob = twistbin_new(data, size);
     if (!*blob) {
         LOGE("oom");
@@ -85,12 +86,12 @@ static int _get_blob(sqlite3_stmt *stmt, int i, bool can_be_null, twist *blob) {
     return SQLITE_OK;
 }
 
-static int get_blob_null(sqlite3_stmt *stmt, int i, twist *blob) {
+DEBUG_VISIBILITY int get_blob_null(sqlite3_stmt *stmt, int i, twist *blob) {
 
     return _get_blob(stmt, i, true, blob);
 }
 
-static int get_blob(sqlite3_stmt *stmt, int i, twist *blob) {
+DEBUG_VISIBILITY int get_blob(sqlite3_stmt *stmt, int i, twist *blob) {
 
     return _get_blob(stmt, i, false, blob);
 }
@@ -102,7 +103,7 @@ struct token_get_cb_ud {
     token *tokens;
 };
 
-static tobject *db_tobject_new(sqlite3_stmt *stmt) {
+DEBUG_VISIBILITY tobject *db_tobject_new(sqlite3_stmt *stmt) {
 
     tobject *tobj = tobject_new();
     if (!tobj) {

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -45,22 +45,6 @@
 #define goto_error(x, l) if (x) { goto l; }
 #define gotobinderror(rc, msg) do { if (rc) { LOGE("cannot bind "msg); goto error; } } while(0)
 
-typedef struct pobject_v3 pobject_v3;
-struct pobject_v3 {
-    int id;
-    char *hierarchy;
-    twist handle;
-    char *objauth;
-};
-
-typedef struct pobject_v4 pobject_v4;
-struct pobject_v4 {
-    int id;
-    char *hierarchy;
-    char *config;
-    char *objauth;
-};
-
 static struct {
     sqlite3 *db;
 } global;
@@ -211,11 +195,17 @@ static void pobject_v4_free(pobject_v4 *new_pobj) {
     free(new_pobj->objauth);
 }
 
-static int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj) {
+DEBUG_VISIBILITY int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj) {
 
     old_pobj->id = sqlite3_column_int(stmt, 0);
 
-    old_pobj->hierarchy = strdup((char *)sqlite3_column_text(stmt, 1));
+    char *tmp = (char *)sqlite3_column_text(stmt, 1);
+	if (!tmp) {
+		LOGE("Hierarchy is NULL");
+		goto error;
+	}
+
+    old_pobj->hierarchy = strdup(tmp);
     if (!old_pobj->hierarchy) {
         LOGE("oom");
         goto error;
@@ -226,7 +216,13 @@ static int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj) {
         goto error;
     }
 
-    old_pobj->objauth = strdup((char *)sqlite3_column_text(stmt, 3));
+    tmp = (char *)sqlite3_column_text(stmt, 3);
+	if (!tmp) {
+		LOGE("objauth is NULL");
+		goto error;
+	}
+
+    old_pobj->objauth = strdup(tmp);
     if (!old_pobj->objauth) {
         LOGE("oom");
         goto error;

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -21,6 +21,7 @@
 #include <sqlite3.h>
 
 #include "db.h"
+#include "debug.h"
 #include "emitter.h"
 #include "log.h"
 #include "mutex.h"

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -6,9 +6,11 @@
 #include <sqlite3.h>
 
 #include "attrs.h"
+#include "debug.h"
 #include "pkcs11.h"
 #include "token.h"
 #include "twist.h"
+#include "utils.h"
 
 /*
  * This HAS to be smaller than 1 byte, as this is embedded
@@ -55,7 +57,7 @@ CK_RV db_update_token_config(token *tok);
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
 /* Debug testing */
-#if !defined(NDEBUG) || defined(UNIT_TESTING)
+#ifdef TESTING
 #include "twist.h"
 
 int get_blob_null(sqlite3_stmt *stmt, int i, twist *blob);

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -54,4 +54,14 @@ CK_RV db_update_token_config(token *tok);
 
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
+/* Debug testing */
+#if !defined(NDEBUG) || defined(UNIT_TESTING)
+#include "twist.h"
+
+int get_blob_null(sqlite3_stmt *stmt, int i, twist *blob);
+int get_blob(sqlite3_stmt *stmt, int i, twist *blob);
+tobject *db_tobject_new(sqlite3_stmt *stmt);
+
+#endif
+
 #endif /* SRC_PKCS11_LIB_DB_H_ */

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -18,6 +18,22 @@
  */
 #define MAX_TOKEN_CNT 255
 
+typedef struct pobject_v3 pobject_v3;
+struct pobject_v3 {
+    int id;
+    char *hierarchy;
+    twist handle;
+    char *objauth;
+};
+
+typedef struct pobject_v4 pobject_v4;
+struct pobject_v4 {
+    int id;
+    char *hierarchy;
+    char *config;
+    char *objauth;
+};
+
 CK_RV db_init(void);
 CK_RV db_destroy(void);
 
@@ -63,6 +79,7 @@ CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 int get_blob_null(sqlite3_stmt *stmt, int i, twist *blob);
 int get_blob(sqlite3_stmt *stmt, int i, twist *blob);
 tobject *db_tobject_new(sqlite3_stmt *stmt);
+int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj);
 
 #endif
 

--- a/src/lib/debug.h
+++ b/src/lib/debug.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifndef SRC_LIB_DEBUG_H_
+#define SRC_LIB_DEBUG_H_
+#include "config.h"
+
+#if defined(FUZZING) || defined(UNIT_TESTING) || !defined(NDEBUG)
+#define WEAK __attribute__((weak))
+#define DEBUG_VISIBILITY
+#define TESTING 1
+#else
+#define WEAK
+#define DEBUG_VISIBILITY static
+#endif
+
+#endif /* SRC_LIB_DEBUG_H_ */

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -732,15 +732,19 @@ error:
     goto out;
 }
 
-tobject *tobject_new(void) {
+DEBUG_VISIBILITY tobject *__real_tobject_new(void) {
 
-    tobject *tobj = calloc(1, sizeof(tobject));
+	tobject *tobj = calloc(1, sizeof(tobject));
     if (!tobj) {
         LOGE("oom");
         return NULL;
     }
 
     return tobj;
+}
+
+WEAK tobject *tobject_new(void) {
+	return __real_tobject_new();
 }
 
 CK_RV tobject_set_blob_data(tobject *tobj, twist pub, twist priv) {

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -128,6 +128,10 @@ CK_RV object_destroy(session_ctx *ctx, CK_OBJECT_HANDLE object);
 
 CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *object);
 
-CK_RV object_init_from_attrs(tobject *tobj);
+WEAK CK_RV object_init_from_attrs(tobject *tobj);
+
+#if defined(UNIT_TESTING) || !defined(NDEBUG)
+tobject *__real_tobject_new(void);
+#endif
 
 #endif /* SRC_PKCS11_OBJECT_H_ */

--- a/src/lib/object.h
+++ b/src/lib/object.h
@@ -7,10 +7,10 @@
 #include <stdint.h>
 
 #include "attrs.h"
+#include "debug.h"
 #include "list.h"
 #include "pkcs11.h"
 #include "twist.h"
-#include "utils.h"
 
 typedef struct session_ctx session_ctx;
 
@@ -130,7 +130,7 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
 
 WEAK CK_RV object_init_from_attrs(tobject *tobj);
 
-#if defined(UNIT_TESTING) || !defined(NDEBUG)
+#ifdef TESTING
 tobject *__real_tobject_new(void);
 #endif
 

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -5,9 +5,9 @@
 #include <stdbool.h>
 
 #include "attrs.h"
+#include "debug.h"
 #include "pkcs11.h"
 #include "token.h"
-#include "utils.h"
 
 WEAK bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
         attr_list **attrs);

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -7,8 +7,9 @@
 #include "attrs.h"
 #include "pkcs11.h"
 #include "token.h"
+#include "utils.h"
 
-bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
+WEAK bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
         attr_list **attrs);
 
 bool parse_token_config_from_string(const unsigned char *yaml, size_t size,

--- a/src/lib/ssl_util.h
+++ b/src/lib/ssl_util.h
@@ -21,6 +21,7 @@
 
 /* OpenSSL Backwards Compat APIs */
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
+#include <string.h>
 size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
                           point_conversion_form_t form,
                           unsigned char **pbuf, BN_CTX *ctx);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -27,7 +27,6 @@
 #include "checks.h"
 #include "digest.h"
 #include "encrypt.h"
-#include "ssl_util.h"
 #include "pkcs11.h"
 #include "log.h"
 #include "mutex.h"

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -27,9 +27,9 @@
 #include "checks.h"
 #include "digest.h"
 #include "encrypt.h"
-#include "pkcs11.h"
 #include "log.h"
 #include "mutex.h"
+#include "pkcs11.h"
 #include "ssl_util.h"
 #include "tpm.h"
 

--- a/src/lib/twist.c
+++ b/src/lib/twist.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "debug.h"
 #include "twist.h"
 #include "utils.h"
 

--- a/src/lib/twist.c
+++ b/src/lib/twist.c
@@ -260,8 +260,7 @@ bool twist_eq(twist x, twist y) {
 	return !memcmp(x, y, twist_len(x));
 }
 
-WEAK twist twistbin_new(const void *data, size_t size) {
-
+DEBUG_VISIBILITY twist __real_twistbin_new(const void *data, size_t size) {
 	if (!data) {
 		return NULL ;
 	}
@@ -269,6 +268,11 @@ WEAK twist twistbin_new(const void *data, size_t size) {
 	const struct binarybuffer things[1] = { { .size = size, .data = data } };
 
 	return internal_create(things, LEN(things));
+}
+
+WEAK twist twistbin_new(const void *data, size_t size) {
+
+	return __real_twistbin_new(data, size);
 }
 
 twist twist_append(twist old_str, const char *new_str) {

--- a/src/lib/twist.c
+++ b/src/lib/twist.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "twist.h"
+#include "utils.h"
 
 #ifdef UNIT_TESTING
     static int _next_alloc_fails = 0;
@@ -38,9 +39,6 @@ struct twist_hdr {
 	char data[];
 };
 
-#define safe_add(r, a, b) __builtin_add_overflow(a, b, &r)
-#define safe_mul(r, a, b) __builtin_mul_overflow(a, b, &r)
-
 static inline twist_hdr *from_twist_to_hdr(twist tstring) {
 	return (twist_hdr *) (tstring - sizeof(char *));
 }
@@ -60,13 +58,13 @@ static void *twist_realloc(void *ptr, size_t size) {
 static twist_hdr *internal_realloc(twist old, size_t size) {
 
 	/* add header to size */
-	bool fail = safe_add(size, size, sizeof(twist));
+	bool fail = _safe_add(size, size, sizeof(twist));
 	if (fail) {
 		return NULL ;
 	}
 
 	/* add null byte space */
-	fail = safe_add(size, size, 1);
+	fail = _safe_add(size, size, 1);
 	if (fail) {
 		return NULL ;
 	}
@@ -87,7 +85,7 @@ static twist internal_append(twist orig, const binarybuffer data[],
 			continue;
 		}
 
-		bool fail = safe_add(size, size, b->size);
+		bool fail = _safe_add(size, size, b->size);
 		if (fail) {
 			return NULL ;
 		}
@@ -97,7 +95,7 @@ static twist internal_append(twist orig, const binarybuffer data[],
 	size_t offset = 0;
 	if (orig) {
 		offset = twist_len(orig);
-		bool fail = safe_add(size, size, offset);
+		bool fail = _safe_add(size, size, offset);
 		if (fail) {
 			return NULL ;
 		}
@@ -261,7 +259,7 @@ bool twist_eq(twist x, twist y) {
 	return !memcmp(x, y, twist_len(x));
 }
 
-twist twistbin_new(const void *data, size_t size) {
+WEAK twist twistbin_new(const void *data, size_t size) {
 
 	if (!data) {
 		return NULL ;
@@ -389,7 +387,7 @@ twist twistbin_create(const binarybuffer data[], size_t len) {
 static twist hexlify(const char *data, size_t datalen) {
 
     size_t bytes = 0;
-    bool fail = safe_mul(bytes, datalen, 2);
+    bool fail = _safe_mul(bytes, datalen, 2);
     if (fail) {
         return NULL;
     }

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -100,15 +100,23 @@ CK_RV ec_params_to_nid(CK_ATTRIBUTE_PTR ecparams, int *nid);
  *  - https://lists.gnu.org/archive/html/bug-gnulib/2019-08/msg00076.html
  */
 #ifdef DISABLE_OVERFLOW_BUILTINS
+#define _safe_add(r, a, b) 0; do { r = a + b; } while(0)
+#define _safe_adde(r, a)   0; do { r += a;    } while(0)
+#define _safe_mul(r, a, b) 0; do { r = a * b; } while(0)
+#define _safe_mule(r, a)   0; do { r *= a;    } while(0)
 #define safe_add(r, a, b) do { r = a + b; } while(0)
 #define safe_adde(r, a)   do { r += a;    } while(0)
 #define safe_mul(r, a, b) do { r = a * b; } while(0)
 #define safe_mule(r, a)   do { r *= a;    } while(0)
 #else
-#define safe_add(r, a, b) do { if (__builtin_add_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
-#define safe_adde(r, a)   do { if (__builtin_add_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
-#define safe_mul(r, a, b) do { if (__builtin_mul_overflow(a, b, &r)) { LOGE("overflow"); abort(); } } while(0)
-#define safe_mule(r, a)   do { if (__builtin_mul_overflow(a, r, &r)) { LOGE("overflow"); abort(); } } while(0)
+#define _safe_add(r, a, b) __builtin_add_overflow(a, b, &r)
+#define _safe_adde(r, a)   __builtin_add_overflow(a, r, &r)
+#define _safe_mul(r, a, b) __builtin_mul_overflow(a, b, &r)
+#define _safe_mule(r, a)   __builtin_mul_overflow(a, r, &r)
+#define safe_add(r, a, b) do { if (_safe_add(r, a, b)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_adde(r, a)   do { if (_safe_adde(r, a)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_mul(r, a, b) do { if (_safe_mul(r, a, b)) { LOGE("overflow"); abort(); } } while(0)
+#define safe_mule(r, a)   do { if (_safe_mule(r, a)) { LOGE("overflow"); abort(); } } while(0)
 #endif
 
 #endif /* SRC_PKCS11_UTILS_H_ */

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -23,14 +23,6 @@
 
 #define UNUSED(x) (void)x
 
-#if defined(FUZZING) || defined(UNIT_TESTING) || !defined(NDEBUG)
-#define WEAK __attribute__((weak))
-#define DEBUG_VISIBILITY
-#else
-#define WEAK
-#define DEBUG_VISIBILITY static
-#endif
-
 #define SAFE_CAST(m, r) \
     do { \
         if (!m->pParameter || m->ulParameterLen != sizeof(typeof(*r))) { \

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -23,7 +23,7 @@
 
 #define UNUSED(x) (void)x
 
-#if defined(FUZZING) || !defined(NDEBUG)
+#if defined(FUZZING) || defined(UNIT_TESTING) || !defined(NDEBUG)
 #define WEAK __attribute__((weak))
 #define DEBUG_VISIBILITY
 #else

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -23,6 +23,14 @@
 
 #define UNUSED(x) (void)x
 
+#if defined(FUZZING) || !defined(NDEBUG)
+#define WEAK __attribute__((weak))
+#define DEBUG_VISIBILITY
+#else
+#define WEAK
+#define DEBUG_VISIBILITY static
+#endif
+
 #define SAFE_CAST(m, r) \
     do { \
         if (!m->pParameter || m->ulParameterLen != sizeof(typeof(*r))) { \

--- a/test/fuzz/yaml-parser.fuzz.c
+++ b/test/fuzz/yaml-parser.fuzz.c
@@ -1,5 +1,17 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
-#include <config.h>
+#include "config.h"
+#include "debug.h"
+
+/*
+ * Drop WEAK or the parse_attributes_from_string is NULL
+ * This command below will be empty without this. I am not
+ * 100% sure why its not getting resolved properly, but this
+ * fixes it for now.
+ * nm --defined ./test/fuzz/yaml-parser.fuzz | grep parse
+   00000000005558d0 T parse_attributes_from_string
+ */
+#undef WEAK
+#define WEAK
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -38,6 +38,28 @@ typedef struct test_info test_info;
 #define ADD_ATTR_ARRAY(t, x) { .type = t,   .ulValueLen = ARRAY_LEN(x),  .pValue = x }
 #define ADD_ATTR_STR(t, x)   { .type = t,   .ulValueLen = sizeof(x) - 1, .pValue = x }
 
+/*
+ * If UNIT_TESTING is defined, cmocka will hijack allocation routines to look for memory leaks.
+ * It checks at the end of the test via fail_if_blocks_allocated, and if true will free
+ * the blocks causing any de-allocation/teardown routines defined after the test to access
+ * and free memory already free'd. To remedy this, define some always safe alloc routines.
+ */
+#if defined(calloc)
+  #undef calloc
+#endif
+
+#if defined(free)
+  #undef free
+#endif
+
+#if defined(malloc)
+  #undef malloc
+#endif
+
+#if defined(realloc)
+  #undef realloc
+#endif
+
 test_info *test_info_from_state(void **state);
 
 int group_setup(void **state);

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -1,0 +1,286 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include <sqlite3.h>
+
+#include "db.h"
+#include "object.h"
+#include "twist.h"
+#include "utils.h"
+
+#define BAD_PTR ((void *)0xDEADBEEF)
+
+typedef struct will_return_data will_return_data;
+struct will_return_data {
+	union {
+		int rc;
+		void *data;
+		bool rcb;
+		CK_RV rv;
+	};
+};
+
+static int tobject_setup(void **state) {
+
+	tobject *t = __real_tobject_new();
+	assert_non_null(t);
+	t->id = 42;
+	*state = t;
+	return 0;
+}
+
+int __wrap_sqlite3_column_bytes(sqlite3 *stmt, int i) {
+	UNUSED(stmt);
+	UNUSED(i);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->rc;
+}
+
+void *__wrap_sqlite3_column_blob(sqlite3 *stmt, int i) {
+	UNUSED(stmt);
+	UNUSED(i);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->data;
+}
+
+int __wrap_sqlite3_data_count(sqlite3 *stmt) {
+	UNUSED(stmt);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->rc;
+}
+
+const char *__wrap_sqlite3_column_name(sqlite3 *stmt, int i) {
+	UNUSED(stmt);
+	UNUSED(i);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->data;
+}
+
+const unsigned char *__wrap_sqlite3_column_text(sqlite3_stmt *stmt, int i) {
+	UNUSED(stmt);
+	UNUSED(i);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->data;
+}
+
+/* Override WEAK symbol */
+twist twistbin_new(const void *data, size_t len) {
+	UNUSED(data);
+	UNUSED(len);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->data;
+}
+
+/* weak override */
+tobject *tobject_new(void) {
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->data;
+}
+
+/* weak override */
+bool parse_attributes_from_string(const unsigned char *yaml, size_t size,
+        attr_list **attrs) {
+	UNUSED(yaml);
+	UNUSED(size);
+	UNUSED(attrs);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->rcb;
+}
+
+/* weak override */
+WEAK CK_RV object_init_from_attrs(tobject *tobj) {
+	UNUSED(tobj);
+
+	will_return_data *d = mock_type(will_return_data *);
+	return d->rv;
+}
+
+static void test_db_get_blob_col_bytes_0(void **state) {
+    (void) state;
+
+    will_return_data d = {
+    		.rc = 0
+    };
+
+    will_return(__wrap_sqlite3_column_bytes, &d);
+
+    twist blob = NULL;
+    int rc = get_blob(BAD_PTR, 0, &blob);
+    assert_int_equal(rc, SQLITE_ERROR);
+}
+
+static void test_db_get_blob_null_col_bytes_0(void **state) {
+    (void) state;
+
+    will_return_data d = {
+    		.rc = 0
+    };
+
+    will_return(__wrap_sqlite3_column_bytes, &d);
+
+    twist blob = NULL;
+    int rc = get_blob_null(BAD_PTR, 0, &blob);
+    assert_int_equal(rc, SQLITE_OK);
+}
+
+static void test_db_get_blob_alloc_fail(void **state) {
+    (void) state;
+
+    will_return_data d[] = {
+		{ .rc = 32 },
+		{ .data = "This is 32 bytes, that's cool!!" },
+		{ .data = NULL },
+    };
+
+    will_return(__wrap_sqlite3_column_bytes, &d[0]);
+    will_return(__wrap_sqlite3_column_blob, &d[1]);
+    will_return(twistbin_new, &d[2]);
+
+    twist blob = NULL;
+    int rc = get_blob(BAD_PTR, 0, &blob);
+    assert_int_equal(rc, SQLITE_ERROR);
+}
+
+static void db_tobject_new_tobject_alloc_fail(void **state) {
+    (void) state;
+
+    will_return_data d = {
+		.data = NULL,
+    };
+
+    will_return(tobject_new, &d);
+
+    tobject *t = db_tobject_new(BAD_PTR);
+    assert_null(t);
+}
+
+static void db_tobject_new_tobject_sqlite3_column_unknown_fail(void **state) {
+    (void) state;
+
+    will_return_data d[] = {
+		{ .data = *state },    /* tobject_new */
+		{ .rc = 1 },           /* sqlite3_data_count */
+		{ .data = "unknown" }, /* sqlite3_column_name */
+    };
+
+    will_return(tobject_new,                 &d[0]);
+    will_return(__wrap_sqlite3_data_count,   &d[1]);
+    will_return(__wrap_sqlite3_column_name,  &d[2]);
+
+    tobject *t = db_tobject_new(BAD_PTR);
+    assert_null(t);
+}
+
+static void db_tobject_new_tobject_sqlite3_column_text_fail(void **state) {
+    (void) state;
+
+    will_return_data d[] = {
+		{ .data = *state },  /* tobject_new */
+		{ .rc = 1 },         /* sqlite3_data_count */
+		{ .data = "attrs" }, /* sqlite3_column_name */
+		{ .rc = 0 },         /* sqlite3_column_bytes */
+		{ .data = NULL },    /* sqlite3_column_text */
+    };
+
+    will_return(tobject_new,                 &d[0]);
+    will_return(__wrap_sqlite3_data_count,   &d[1]);
+    will_return(__wrap_sqlite3_column_name,  &d[2]);
+    will_return(__wrap_sqlite3_column_bytes, &d[3]);
+    will_return(__wrap_sqlite3_column_text,  &d[4]);
+
+    tobject *t = db_tobject_new(BAD_PTR);
+    assert_null(t);
+}
+
+static void db_tobject_new_tobject_sqlite3_attrs_text_fail(void **state) {
+    (void) state;
+
+    will_return_data d[] = {
+		{ .data = *state },  /* tobject_new */
+		{ .rc = 1 },         /* sqlite3_data_count */
+		{ .data = "attrs" }, /* sqlite3_column_name */
+		{ .rc = 4 },         /* sqlite3_column_bytes */
+		{ .data = "bad" },   /* sqlite3_column_text */
+		{ .rcb = false },    /* parse_attributes_from_string */
+    };
+
+    will_return(tobject_new,                  &d[0]);
+    will_return(__wrap_sqlite3_data_count,    &d[1]);
+    will_return(__wrap_sqlite3_column_name,   &d[2]);
+    will_return(__wrap_sqlite3_column_bytes,  &d[3]);
+    will_return(__wrap_sqlite3_column_text,   &d[4]);
+    will_return(parse_attributes_from_string, &d[5]);
+
+    tobject *t = db_tobject_new(BAD_PTR);
+    assert_null(t);
+}
+
+static void db_tobject_new_tobject_object_init_from_attrs_fail(void **state) {
+    (void) state;
+
+    will_return_data d[] = {
+		{ .data = *state },         /* tobject_new */
+		{ .rc = 1 },                /* sqlite3_data_count */
+		{ .data = "attrs" },        /* sqlite3_column_name */
+		{ .rc = 3 },                /* sqlite3_column_bytes */
+		{ .data = "good" },         /* sqlite3_column_text */
+		{ .rcb = true },            /* parse_attributes_from_string */
+		{ .rv = CKR_GENERAL_ERROR } /* object_init_from_attrs */
+    };
+
+    will_return(tobject_new,                  &d[0]);
+    will_return(__wrap_sqlite3_data_count,    &d[1]);
+    will_return(__wrap_sqlite3_column_name,   &d[2]);
+    will_return(__wrap_sqlite3_column_bytes,  &d[3]);
+    will_return(__wrap_sqlite3_column_text,   &d[4]);
+    will_return(parse_attributes_from_string, &d[5]);
+    will_return(object_init_from_attrs,       &d[6]);
+
+    tobject *t = db_tobject_new(BAD_PTR);
+    assert_null(t);
+}
+
+int main(int argc, char* argv[]) {
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_db_get_blob_col_bytes_0),
+		cmocka_unit_test(test_db_get_blob_null_col_bytes_0),
+		cmocka_unit_test(test_db_get_blob_alloc_fail),
+		cmocka_unit_test(db_tobject_new_tobject_alloc_fail),
+		cmocka_unit_test_setup(
+			db_tobject_new_tobject_sqlite3_column_unknown_fail,
+			tobject_setup),
+		cmocka_unit_test_setup(
+			db_tobject_new_tobject_sqlite3_column_text_fail,
+			tobject_setup),
+		cmocka_unit_test_setup(
+			db_tobject_new_tobject_sqlite3_attrs_text_fail,
+			tobject_setup),
+		cmocka_unit_test_setup(
+			db_tobject_new_tobject_object_init_from_attrs_fail,
+			tobject_setup),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -15,6 +15,7 @@
 #include <sqlite3.h>
 
 #include "db.h"
+#include "debug.h"
 #include "object.h"
 #include "twist.h"
 #include "utils.h"


### PR DESCRIPTION
Add some additional db tests to cover error paths to increase code
coverage.
    
These tests specifically target:
 - _get_blob
 - get_blob
 - get_blob_null
 - db_tobject_new