### PR TITLE
various fixes

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -935,7 +935,7 @@ out:
 error:
     rc = sqlite3_finalize(stmt);
     if (rc != SQLITE_OK) {
-        LOGW("Could not finalize stmt: %d", rc);
+        LOGW("Could not finalize stmt: %s", sqlite3_errmsg(global.db));
     }
 
     rollback();

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -27,12 +27,7 @@ static void sealobject_free(sealobject *sealobj) {
     twist_free(sealobj->userauthsalt);
     twist_free(sealobj->userpub);
     twist_free(sealobj->userpriv);
-    sealobj->soauthsalt = NULL;
-    sealobj->sopriv = NULL;
-    sealobj->sopub = NULL;
-    sealobj->userauthsalt = NULL;
-    sealobj->userpub = NULL;
-    sealobj->userpriv = NULL;
+    memset(sealobj, 0, sizeof(*sealobj));
 }
 
 CK_RV token_min_init(token *t) {

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -342,6 +342,14 @@ CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label)
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
+    /* Bug:
+     * https://github.com/tpm2-software/tpm2-pkcs11/issues/576
+     */
+    if (t->config.is_initialized) {
+        LOGE("Tokens cannot be re-initialized");
+        return CKR_DEVICE_ERROR;
+    }
+
     twist newauth = NULL;
     twist newsalthex = NULL;
 

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -87,6 +87,15 @@ struct token {
 void token_free(token *t);
 
 /**
+ * Free the token internals, but keep the lock
+ * @param t
+ *  The token to free
+ * @param keep_lock
+ *  Whether or not to free the mutex.
+ */
+void token_free_ex(token *t, bool keep_lock);
+
+/**
  * Free's a list of tokens
  * @param t
  *  The token list to free
@@ -174,6 +183,7 @@ void token_unlock(token *t);
 CK_RV token_load_object(token *tok, CK_OBJECT_HANDLE key, tobject **loaded_tobj);
 
 CK_RV token_min_init(token *t);
+void token_reset(token *t);
 
 CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label);
 

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -693,7 +693,13 @@ static void test_init_token(void **state) {
 
     /* Initialize a token */
     unsigned char sopin[] = GOOD_SOPIN;
+
     CK_BYTE label[32 + 1] = "mynewtoken42                    ";
+    CK_BYTE bad_label[32 + 1] = "myne\0wtoken42                   ";
+
+    rv = C_InitToken(slot, sopin, sizeof(sopin) - 1, bad_label);
+    assert_int_equal(rv, CKR_ARGUMENTS_BAD);
+
     rv = C_InitToken(slot, sopin, sizeof(sopin) - 1, label);
     assert_int_equal(rv, CKR_OK);
 

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -723,6 +723,13 @@ static void test_init_token(void **state) {
 
     user_login(session);
     logout(session);
+
+    /*
+     * Try to initialize a token of the same name to verify DB UNIQUE constraint error path
+     * We know that slot + 1 brings us to the next unitialized slot...
+     */
+    rv = C_InitToken(slot + 1, sopin, sizeof(sopin) - 1, label);
+    assert_int_equal(rv, CKR_GENERAL_ERROR);
 }
 
 int main() {

--- a/test/integration/pkcs-login-logout.int.c
+++ b/test/integration/pkcs-login-logout.int.c
@@ -650,6 +650,17 @@ static void test_so_state_pin_init_good(void **state) {
     logout(handle);
 }
 
+static void test_double_init_token(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SLOT_ID slot = ti->slots[0].slot_id;
+
+    unsigned char sopin[] = GOOD_SOPIN;
+    CK_BYTE label[32 + 1] = "doubleinittoken                 ";
+	CK_RV rv = C_InitToken(slot, sopin, sizeof(sopin) - 1, label);
+	assert_int_equal(rv, CKR_DEVICE_ERROR);
+}
+
 int main() {
 
     const struct CMUnitTest tests[] = {
@@ -705,6 +716,10 @@ int main() {
          */
         cmocka_unit_test_setup_teardown(test_so_state_pin_init_good,
                 test_setup_rw, test_teardown),
+
+        /* These work on new tokens via slots and thus don't matter the order */
+        cmocka_unit_test_setup_teardown(test_double_init_token,
+                test_setup_ro, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, _group_setup_locking, _group_teardown);


### PR DESCRIPTION
A command like:
pkcs11-tool --module /usr/lib/libtpm2_pkcs11.so --init-token --label tpmhsm --so-pin foo --pin bar

Will cause a C_Login even because --pin is specified. However, C_InitPIN
has not been called to initialize the userpin. This causes a NPD when
trying to load the user sealobjects public and private blobs.

Their's also a bug when a token is inserted with the same name and UNIQUE db constraint fails. This causes the cleanup code to free a mutex that is currently being held. Fix that too.

Add a check to make sure the label doesn't have an embedded null byte, per the spec.

Add tests for everything

Fixes: #563
