### PR TITLE
C_Login: test for segfault when user pin not setup

### DIFF
--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -105,4 +105,16 @@ fi
 pkcs11_tool --slot-index=0 --login --pin=mynewuserpin --read-object --type data --label dataobj1 -o objdata2
 cmp objdata objdata2
 
+#
+# Negative test, ensure that this fails
+#
+trap - ERR
+
+# Reproduce https://github.com/tpm2-software/tpm2-pkcs11/issues/563
+pkcs11_tool --slot-index=1 --init-token --label tpmhsm --so-pin foo --pin bar
+if [ $? -eq 0 ]; then
+  echo "Expected login to fail without user pin set"
+  exit 1
+fi
+
 exit 0


### PR DESCRIPTION
A command like:
pkcs11-tool --module /usr/lib/libtpm2_pkcs11.so --init-token --label tpmhsm --so-pin foo --pin bar

Will cause a C_Login even because --pin is specified. However, C_InitPIN
has not been called to initialize the userpin. This causes a NPD when
trying to load the user sealobjects public and private blobs.

Related-to: #563

Signed-off-by: William Roberts <william.c.roberts@intel.com>