### PR TITLE
token: remove non-needed routine

### DIFF
--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -222,7 +222,7 @@ void token_rm_tobject(token *tok, tobject *t) {
     t->l.next = t->l.prev = NULL;
 }
 
-void token_free_ex(token *t, bool keep_lock) {
+void token_free(token *t) {
 
     /*
      * for each session remove them
@@ -249,19 +249,12 @@ void token_free_ex(token *t, bool keep_lock) {
     tpm_ctx_free(t->tctx);
     t->tctx = NULL;
 
-    if (!keep_lock) {
-        mutex_destroy(t->mutex);
-        t->mutex = NULL;
-    }
+    mutex_destroy(t->mutex);
+    t->mutex = NULL;
 
     free(t->config.tcti);
 
     memset(&t->config, 0, sizeof(t->config));
-}
-
-void token_free(token *t) {
-
-    token_free_ex(t, false);
 }
 
 CK_RV token_get_info (token *t, CK_TOKEN_INFO *info) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -87,15 +87,6 @@ struct token {
 void token_free(token *t);
 
 /**
- * Free the token internals, but keep the lock
- * @param t
- *  The token to free
- * @param keep_lock
- *  Whether or not to free the mutex.
- */
-void token_free_ex(token *t, bool keep_lock);
-
-/**
  * Free's a list of tokens
  * @param t
  *  The token list to free


### PR DESCRIPTION
token_fre_ex is not needed, revert back to just token_free.

Signed-off-by: William Roberts <william.c.roberts@intel.com>