### PR TITLE
configure: remove superfluous closing bracket from $have_fapi test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AS_IF([test "x$enable_fapi" != "xno"],
 
 AS_IF([test "$have_fapi" = "1"],
     AC_DEFINE([HAVE_FAPI], [1], [Enabled if FAPI >= 3.0 is found])
-])
+)
 AM_CONDITIONAL([HAVE_FAPI], [test "$have_fapi" = "1"])
 
 # START ENABLE UNIT


### PR DESCRIPTION
This typo leads to the (otherwise harmless) [error message](https://travis-ci.org/github/tpm2-software/tpm2-pkcs11/jobs/718688257#L3761)
```
checking for TSS2_FAPI... yes
../configure: line 14383: ]: command not found
checking for CMOCKA... yes
```