### PR TITLE
Explicitly linking to docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,21 +13,21 @@ as the cryptographic token.
 
 # Getting Started
 
-* [Building](BUILDING.md) - How to get it to build
-* [Initializing](INITIALIZING.md) - How to configure it
-* [Installing](INSTALL.md) - How to install it
+* [Building](/docs/BUILDING.md) - How to get it to build
+* [Initializing](/docs/INITIALIZING.md) - How to configure it
+* [Installing](/docs/INSTALL.md) - How to install it
 
 # Example Usages
-* [SSH](SSH.md) - How to configure and use it with SSH.
-* [P11](P11.md) - How to configure and use it with various P11 components.
-* [PKCS11-TOOL](PKCS11_TOOL.md) - How to configure and use it with OpenSC's pkcs11-tool.
-* [EAP-TLS](EAP-TLS.md) - How to configure and use it for Wi-Fi authentication using EAP-TLS.
-* [INTEROPERABILITY](INTEROPERABILITY.md) - Configuration details for interoperability with
+* [SSH](/docs/SSH.md) - How to configure and use it with SSH.
+* [P11](/docs/P11.md) - How to configure and use it with various P11 components.
+* [PKCS11-TOOL](/docs/PKCS11_TOOL.md) - How to configure and use it with OpenSC's pkcs11-tool.
+* [EAP-TLS](/docs/EAP-TLS.md) - How to configure and use it for Wi-Fi authentication using EAP-TLS.
+* [INTEROPERABILITY](/docs/INTEROPERABILITY.md) - Configuration details for interoperability with
   [tss2-engine](https://github.com/tpm2-software/tpm2-tss-engine) and
   [tpm2-tools](https://github.com/tpm2-software/tpm2-tools) projects. Note, the *tpm2-tools* interoperability
   could cover other projects that use raw *marshalled* TPM 2.0 structures.
 
 # Advanced Knowledge
-* [Architecture](ARCHITECTURE.md) - Internal Overview
-* [DB Upgrades](DB_UPGRADE.md) - What happens on a DB Version Upgrade
-* [Release Process](RELEASE.md) - How releases are conducted
+* [Architecture](/docs/ARCHITECTURE.md) - Internal Overview
+* [DB Upgrades](/docs/DB_UPGRADE.md) - What happens on a DB Version Upgrade
+* [Release Process](/docs/RELEASE.md) - How releases are conducted


### PR DESCRIPTION
The absolute links ensure that they work also when followed from the README file in the root directory.

Currently, following links from the README presented in the main page results in 404s, because they link to documents in the same directory, i.e. in the root.