### PR TITLE
test_db: remove unused variables

### DIFF
--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -94,6 +94,7 @@ int __wrap_sqlite3_column_int(sqlite3_stmt *stmt, int i) {
 }
 
 int __wrap_sqlite3_finalize(sqlite3_stmt *pStmt) {
+    UNUSED(pStmt);
 
 	will_return_data *d = mock_type(will_return_data *);
 	return d->rc;
@@ -1138,8 +1139,6 @@ void test_init_sealobjects_bad_col_name_fail(void **state) {
 void test_db_get_tokens_calloc_fail(void **state) {
     UNUSED(state);
 
-    sealobject sobj = { 0 };
-
     will_return_data d[] = {
         { .data = NULL        }, /* calloc */
     };
@@ -1156,8 +1155,6 @@ void test_db_get_tokens_calloc_fail(void **state) {
 void test_db_get_tokens_sqlite3_prepare_v2_fail(void **state) {
     UNUSED(state);
 
-    sealobject sobj = { 0 };
-
     will_return_data d[] = {
         { .call_real = true           }, /* calloc */
         { .rc = SQLITE_ERROR          }, /* sqlite3_prepare_v2 */
@@ -1172,8 +1169,6 @@ void test_db_get_tokens_sqlite3_prepare_v2_fail(void **state) {
 
 void test_db_get_tokens_token_overcount_fail(void **state) {
     UNUSED(state);
-
-    sealobject sobj = { 0 };
 
     will_return_data d[] = {
         { .call_real = true           }, /* calloc */
@@ -1199,8 +1194,6 @@ void test_db_get_tokens_token_overcount_fail(void **state) {
 
 void test_db_get_tokens_init_seal_objects_fail(void **state) {
     UNUSED(state);
-
-    sealobject sobj = { 0 };
 
     token t = {
         .config = {
@@ -1234,8 +1227,6 @@ void test_db_get_tokens_init_seal_objects_fail(void **state) {
 
 void test_db_get_tokens_init_tobjects_fail(void **state) {
     UNUSED(state);
-
-    sealobject sobj = { 0 };
 
     token t = {
         .config = {
@@ -1356,6 +1347,7 @@ void test_db_update_for_pinchange_sqlite3_bind_text_fail(void **state) {
 }
 
 void test_db_update_for_pinchange_sqlite3_bind_private_blob_fail(void **state) {
+    UNUSED(state);
 
     will_return_data d[] = {
         { .rc = SQLITE_OK                }, /* sqlite3_exec (BEGIN TRANSACTION)*/
@@ -1410,7 +1402,7 @@ void test_db_update_for_pinchange_sqlite3_bind_public_blob_fail(void **state) {
     twist twist_data  = twist_new("pubdata");
     assert_non_null(twist_data);
 
-    CK_RV rv = db_update_for_pinchange(
+    db_update_for_pinchange(
             NULL,
             true,
             NULL,
@@ -1447,7 +1439,7 @@ void test_db_update_for_pinchange_sqlite3_bind_int_fail(void **state) {
     twist twist_data  = twist_new("pubdata");
     assert_non_null(twist_data);
 
-    CK_RV rv = db_update_for_pinchange(
+    db_update_for_pinchange(
             &t,
             true,
             NULL,
@@ -1486,7 +1478,7 @@ void test_db_update_for_pinchange_sqlite3_step_fail(void **state) {
     twist twist_data  = twist_new("pubdata");
     assert_non_null(twist_data);
 
-    CK_RV rv = db_update_for_pinchange(
+    db_update_for_pinchange(
             &t,
             true,
             NULL,
@@ -1525,7 +1517,7 @@ void test_db_update_for_pinchange_sqlite3_finalize_fail(void **state) {
     twist twist_data  = twist_new("pubdata");
     assert_non_null(twist_data);
 
-    CK_RV rv = db_update_for_pinchange(
+    db_update_for_pinchange(
             &t,
             true,
             NULL,
@@ -1564,7 +1556,7 @@ void test_db_update_for_pinchange_commit_fail(void **state) {
     twist twist_data  = twist_new("pubdata");
     assert_non_null(twist_data);
 
-    CK_RV rv = db_update_for_pinchange(
+    db_update_for_pinchange(
             &t,
             true,
             NULL,


### PR DESCRIPTION
Compilation with GCC 10.2.0 fails with
```
test/unit/test_db.c: In function ‘__wrap_sqlite3_finalize’:
test/unit/test_db.c:96:43: error: unused parameter ‘pStmt’ [-Werror=unused-parameter]
   96 | int __wrap_sqlite3_finalize(sqlite3_stmt *pStmt) {
      |                             ~~~~~~~~~~~~~~^~~~~
test/unit/test_db.c: In function ‘test_db_get_tokens_calloc_fail’:
test/unit/test_db.c:1141:16: error: unused variable ‘sobj’ [-Werror=unused-variable]
 1141 |     sealobject sobj = { 0 };
      |                ^~~~
test/unit/test_db.c: In function ‘test_db_get_tokens_sqlite3_prepare_v2_fail’:
test/unit/test_db.c:1159:16: error: unused variable ‘sobj’ [-Werror=unused-variable]
 1159 |     sealobject sobj = { 0 };
      |                ^~~~
test/unit/test_db.c: In function ‘test_db_get_tokens_token_overcount_fail’:
test/unit/test_db.c:1176:16: error: unused variable ‘sobj’ [-Werror=unused-variable]
 1176 |     sealobject sobj = { 0 };
      |                ^~~~
test/unit/test_db.c: In function ‘test_db_get_tokens_init_seal_objects_fail’:
test/unit/test_db.c:1203:16: error: unused variable ‘sobj’ [-Werror=unused-variable]
 1203 |     sealobject sobj = { 0 };
      |                ^~~~
test/unit/test_db.c: In function ‘test_db_get_tokens_init_tobjects_fail’:
test/unit/test_db.c:1238:16: error: unused variable ‘sobj’ [-Werror=unused-variable]
 1238 |     sealobject sobj = { 0 };
      |                ^~~~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_sqlite3_bind_private_blob_fail’:
test/unit/test_db.c:1358:73: error: unused parameter ‘state’ [-Werror=unused-parameter]
 1358 | void test_db_update_for_pinchange_sqlite3_bind_private_blob_fail(void **state) {
      |                                                                  ~~~~~~~^~~~~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_sqlite3_bind_public_blob_fail’:
test/unit/test_db.c:1413:11: error: unused variable ‘rv’ [-Werror=unused-variable]
 1413 |     CK_RV rv = db_update_for_pinchange(
      |           ^~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_sqlite3_bind_int_fail’:
test/unit/test_db.c:1450:11: error: unused variable ‘rv’ [-Werror=unused-variable]
 1450 |     CK_RV rv = db_update_for_pinchange(
      |           ^~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_sqlite3_step_fail’:
test/unit/test_db.c:1489:11: error: unused variable ‘rv’ [-Werror=unused-variable]
 1489 |     CK_RV rv = db_update_for_pinchange(
      |           ^~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_sqlite3_finalize_fail’:
test/unit/test_db.c:1528:11: error: unused variable ‘rv’ [-Werror=unused-variable]
 1528 |     CK_RV rv = db_update_for_pinchange(
      |           ^~
test/unit/test_db.c: In function ‘test_db_update_for_pinchange_commit_fail’:
test/unit/test_db.c:1567:11: error: unused variable ‘rv’ [-Werror=unused-variable]
 1567 |     CK_RV rv = db_update_for_pinchange(
      |           ^~
```