### PR TITLE
ci: enable building unit and integration tests during distcheck

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -64,8 +64,8 @@ fi
 # avoid error checking or cause make distcheck to fail. So run a
 # pure check with gcc before adding those flags.
 if [[ "$CC" != clang* ]]; then
-    ./configure --enable-esapi-session-manage-flags --disable-fapi
-    make distcheck
+    ./configure --enable-esapi-session-manage-flags --disable-fapi --enable-unit --enable-integration
+    make distcheck TESTS=
     make distclean
 fi
 


### PR DESCRIPTION
The main build uses `--disable-hardening` in `$config_flags`, which avoids catching compiler warnings e.g. for unused variables because `-Werror` is not set. Enable compiling the tests during the "pure" distcheck run, but empty `TESTS` to avoid running the entire test suite another time.

CI failures are expected until 583f5773ed4f0e966217be35e7ab864724481a83 is merged so that the `CK_RV rv` variables are no longer unused, see #597 for the corresponding error message. My personal Travis CI shows a successful run of this commit on top of the 1.4.0 release at https://travis-ci.org/github/diabonas/tpm2-pkcs11/builds/723903343.