### PR TITLE
tpm2_ptool: prefer 0x81000001 to store primary key objects

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -99,7 +99,14 @@ class InitCommand(Command):
                     if not use_existing_primary:
                         pobj_ctx = create_primary(tpm2, hierarchyauth, pobjauth, transient_parent)
                         if not transient_parent:
-                            pobj_ctx = tpm2.evictcontrol(hierarchyauth, pobj_ctx)
+                            # Check if the default handle 0x81000001 is available
+                            handle = 0x81000001
+                            handles_persistent = yaml.safe_load(tpm2.getcap('handles-persistent'))
+                            if handles_persistent and handle in handles_persistent:
+                                # Automatically find the first free handle
+                                handle = None
+
+                            pobj_ctx = tpm2.evictcontrol(hierarchyauth, pobj_ctx, handle)
                             shall_evict = True
                     else:
                         # get the primary object auth value and convert it to hex

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -81,7 +81,7 @@ class Tpm2(object):
                                stderr)
         return ctx
 
-    def evictcontrol(self, hierarchyauth, ctx):
+    def evictcontrol(self, hierarchyauth, ctx, handle=None):
 
         tr_file = os.path.join(self._tmp, "primary.handle")
 
@@ -89,6 +89,9 @@ class Tpm2(object):
 
         if hierarchyauth and len(hierarchyauth) > 0:
             cmd.extend(['-P', hierarchyauth])
+
+        if handle:
+            cmd.append(str(handle))
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         stdout, stderr = p.communicate()


### PR DESCRIPTION
According to the [TCG TPM v2.0 Provisioning Guidance](https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-v2.0-Provisioning-Guidance-Published-v1r1.pdf#page=29), the SRK should be stored at 0x81000001. Check whether this handle is available and store the primary key object there during `tpm2_ptool init`, falling back to the current behaviour of looking for the first available handle if it is already occupied.