### PR TITLE
ssl_util: let openssl verify output buffer length

### DIFF
--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -1135,25 +1135,6 @@ static void test_create_obj_rsa_public_key(void **state) {
     CK_BYTE *p2 = &plaintext2[sizeof(plaintext2) - sizeof(plaintext)];
 
     assert_memory_equal(plaintext, p2, sizeof(plaintext));
-
-    rv = C_EncryptInit(session, &mech, privkey);
-    assert_int_equal(rv, CKR_OK);
-
-    unsigned char padded_plaintext[256] = { 0 };
-    memcpy(padded_plaintext, plaintext, sizeof(plaintext));
-
-    rv = C_Encrypt(session, padded_plaintext, sizeof(padded_plaintext), ciphertext, &ciphertext_len);
-    assert_int_equal(rv, CKR_OK);
-
-    rv = C_DecryptInit(session, &mech, pubkey);
-    assert_int_equal(rv, CKR_OK);
-
-    rv = C_Decrypt(session, ciphertext, ciphertext_len, plaintext2, &plaintext2_len);
-    assert_int_equal(rv, CKR_OK);
-
-    p2 = &plaintext2[sizeof(plaintext2) - sizeof(plaintext)];
-
-    assert_memory_equal(plaintext, p2, sizeof(plaintext));
 }
 
 /*


### PR DESCRIPTION
When calling EVP_PKEY_encrypt, let OpenSSL determine if the buffer
length is too small. Per the manpage, the required minimum output buffer
sizes are quite nuanced, and I quote from:
  - https://www.openssl.org/docs/man1.1.1/man3/RSA_public_encrypt.html

"to must point to a memory section large enough to hold the maximal possible decrypted data (which is equal to RSA_size(rsa) for RSA_NO_PADDING, RSA_size(rsa) - 11 for the PKCS #1 v1.5 based padding modes and RSA_size(rsa) - 42 for RSA_PKCS1_OAEP_PADDING). padding is the padding mode that was used to encrypt the data. to and from may overlap."

Signed-off-by: William Roberts <william.c.roberts@intel.com>