### PR TITLE
python-pkcs11: fix 5.2 style returns and add tests

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -9,7 +9,8 @@ integration_scripts = \
     test/integration/openssl.sh \
     test/integration/pkcs11-javarunner.sh.java \
     test/integration/nss-tests.sh \
-    test/integration/ptool-link.sh.nosetup
+    test/integration/ptool-link.sh.nosetup \
+    test/integration/python-pkcs11.sh
 
 # Note that -fapi.sh.fapi is symlinked to .sh.nosetup
 # If we'd use the .fapi extension then .nosetup and .fapi overwrite each others .log

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,17 @@ AS_IF([test "x$enable_unit" = "xyes" -o "x$enable_integration" = "xyes" -o "x$en
 
 # END ENABLE UNIT
 
+# Macro that checks for existence of a python module
+AC_DEFUN([AC_PYTHON_MODULE],
+[AC_MSG_CHECKING([for module $2 in python])
+  echo "import $2" | $1 - 2>/dev/null
+  if test $? -ne 0 ; then
+    AC_MSG_ERROR([not found])
+  else
+    AC_MSG_RESULT(found)
+  fi
+])
+
 # START ENABLE INTEGRATION
 #
 # enable integration tests and check for simulator binary
@@ -321,6 +332,8 @@ AC_DEFUN([integration_test_checks], [
     [AC_SUBST([PYTHON_INTERPRETER], [$PYTHON])],
     [AC_MSG_ERROR([Integration tests enabled but python >= 3.7 executable not found.])]
   )
+
+  AC_PYTHON_MODULE([$PYTHON], [pkcs11])
 
   AS_IF([test "$have_fapi" = "1"], [
     AC_CHECK_PROG([tss2_provision], [tss2_provision], [yes], [no])

--- a/src/lib/ssl_util.c
+++ b/src/lib/ssl_util.c
@@ -15,6 +15,9 @@
 #include "ssl_util.h"
 #include "twist.h"
 
+#if defined(LIB_TPM2_OPENSSL_OPENSSL_POST111)
+#include <openssl/evperr.h>
+#endif
 
 #if defined(LIB_TPM2_OPENSSL_OPENSSL_PRE11)
 
@@ -117,8 +120,6 @@ EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) {
 
     return pkey->pkey.ec;
 }
-#else
-#include <openssl/evperr.h>
 #endif
 
 static CK_RV convert_pubkey_RSA(RSA **outkey, attr_list *attrs) {

--- a/src/lib/ssl_util.c
+++ b/src/lib/ssl_util.c
@@ -294,6 +294,11 @@ CK_RV ssl_util_encrypt(EVP_PKEY *pkey,
 
     CK_RV rv = CKR_GENERAL_ERROR;
 
+    if (!ctext) {
+        *ctextlen = EVP_PKEY_size(pkey);
+        return CKR_OK;
+    }
+
     EVP_PKEY_CTX *pkey_ctx = EVP_PKEY_CTX_new(pkey, NULL);
     if (!pkey_ctx) {
         LOGE("OOM");

--- a/src/lib/ssl_util.h
+++ b/src/lib/ssl_util.h
@@ -17,6 +17,9 @@
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L) /* OpenSSL 1.1.0 */
 #define LIB_TPM2_OPENSSL_OPENSSL_PRE11
+/* LibreSSL does not appear to have evperr.h, so their is no need to define this otherwise */
+#elif (OPENSSL_VERSION_NUMBER >= 0x1010100fL) /* OpenSSL 1.1.1 */
+#define LIB_TPM2_OPENSSL_OPENSSL_POST111 0x1010100f
 #endif
 
 /* OpenSSL Backwards Compat APIs */

--- a/test/integration/PKCS11JavaTests.java
+++ b/test/integration/PKCS11JavaTests.java
@@ -40,13 +40,16 @@ public class PKCS11JavaTests {
 		String cwd = System.getProperty("user.dir");
 		Path libPath = Paths.get(cwd, "src/.libs/libtpm2_pkcs11.so.0.0.0");
 
-		try {
+                String version = System.getProperty("java.version");
+                String [] chunks = version.split("\\.");
+                int major = Integer.parseInt(chunks[0]);
+                if (major >= 9) {
 			/* Java >= 9 */
 			Method configure = Provider.class.getMethod("configure", String.class);
 			String pkcs11Config = "--name = TPM2\nlibrary = " + libPath;
 			PROV = Security.getProvider("SunPKCS11");
 			PROV = (Provider) configure.invoke(PROV, pkcs11Config);
-		} catch (NoSuchMethodException e) {
+		} else {
 			/* Java <= 8 */
 			Constructor SunPKCS11 = Class.forName("sun.security.pkcs11.SunPKCS11").getConstructor(InputStream.class);
 			String pkcs11Config = "name = TPM2\nlibrary = " + libPath;

--- a/test/integration/openssl.sh
+++ b/test/integration/openssl.sh
@@ -33,7 +33,7 @@ echo "modpath=$modpath"
 
 function yaml_get_id() {
 
-python << pyscript
+"${PYTHON_INTERPRETER:-python3}" << pyscript
 from __future__ import print_function
 
 import sys
@@ -58,7 +58,7 @@ function yaml_get_kv() {
         third_arg=$3
     fi
 
-python << pyscript
+"${PYTHON_INTERPRETER:-python3}" << pyscript
 from __future__ import print_function
 
 import sys

--- a/test/integration/python-pkcs11.sh
+++ b/test/integration/python-pkcs11.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -exo pipefail
+
+source "$T/test/integration/scripts/helpers.sh"
+
+setup_asan
+
+"${PYTHON_INTERPRETER:-python3}" - <<'_SCRIPT_'
+import os
+import unittest
+
+import pkcs11
+
+class TestPKCS11(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.getenv('TPM2_PKCS11_MODULE', os.path.join(os.getcwd(), 'src/.libs/libtpm2_pkcs11.so'))
+        lib = pkcs11.lib(path)
+        cls._token = lib.get_token(token_label='label')
+
+    def test_CKM_PKCS11(self):
+        with self._token.open(rw=False, user_pin='myuserpin') as session:
+
+            public = session.get_key(label='rsa0',object_class=pkcs11.constants.ObjectClass.PUBLIC_KEY)
+            private = session.get_key(label='rsa0',object_class=pkcs11.constants.ObjectClass.PRIVATE_KEY)
+
+            original = plaintext = b'1234567890123456'
+            ciphertext = public.encrypt(plaintext, mechanism=pkcs11.mechanisms.Mechanism.RSA_PKCS)
+            self.assertNotEqual(plaintext, ciphertext)
+
+            plaintext = 'notdecrypted'
+            plaintext = private.decrypt(ciphertext, mechanism=pkcs11.mechanisms.Mechanism.RSA_PKCS)
+            # strip padding
+            p2 = plaintext[-len(original):]
+            self.assertEqual(p2, original)
+
+if __name__ == '__main__':
+    unittest.main()
+_SCRIPT_
+
+exit $?


### PR DESCRIPTION
- Fix issue #567, C_Decrypt wasn't doing the 5.2 style returns for public keys when getting output buffer size, so fix it.
- Add a C integration test for that bug
- Add a python-pkcs11 integration test for that bug

Fixes: #567