### PR TITLE
test: add support for swtpm simulator

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -13,7 +13,6 @@ source $TRAVIS_BUILD_DIR/.ci/download-deps.sh
 get_deps "$WORKSPACE"
 
 export LD_LIBRARY_PATH=/usr/local/lib/
-export PATH=/root/.local/bin/:/ibmtpm974/src:$PATH
 
 # Unfortunately, p11tool unlearned the option for $HOME/.config/pkcs11/modules
 # This is true for Fedora 30 container and upstream

--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -45,18 +45,19 @@ check_PROGRAMS += \
 # add test scripts
 check_SCRIPTS += $(integration_scripts)
 
+AM_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 LOG_COMPILER = $(srcdir)/test/integration/scripts/int-test-setup.sh
 
-AM_INT_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
+AM_INT_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI) --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
 INT_LOG_COMPILER=$(LOG_COMPILER)
 
-AM_SH_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
+AM_SH_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI) --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
 SH_LOG_COMPILER=$(LOG_COMPILER)
 
-AM_NOSETUP_LOG_FLAGS = --tabrmd-tcti=mssim
+AM_NOSETUP_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 NOSETUP_LOG_COMPILER=$(LOG_COMPILER)
 
-AM_FAPI_LOG_FLAGS = --tabrmd-tcti=mssim
+AM_FAPI_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 FAPI_LOG_COMPILER=env TPM2_PKCS11_BACKEND=fapi $(LOG_COMPILER)
 
 test_integration_pkcs_find_objects_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
@@ -106,7 +107,7 @@ test_integration_pkcs_lockout_int_SOURCES = test/integration/pkcs-lockout.int.c 
 #
 # Java Tests
 #
-AM_JAVA_LOG_FLAGS = --tabrmd-tcti=mssim --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
+AM_JAVA_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI) --tsetup-script=$(top_srcdir)/test/integration/scripts/create_pkcs_store.sh
 JAVA_LOG_COMPILER=$(LOG_COMPILER)
 dist_noinst_JAVA = test/integration/PKCS11JavaTests.java
 CLEANFILES += test/integration/PKCS11JavaTests.class

--- a/configure.ac
+++ b/configure.ac
@@ -288,9 +288,12 @@ AC_DEFUN([integration_test_checks], [
 
   PKG_CHECK_MODULES([TSS2_TCTI_TABRMD],[tss2-tcti-tabrmd])
 
+  AC_CHECK_PROG([swtpm], [swtpm], [yes], [no])
   AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
-  AS_IF([test "x$tpm_server" != "xyes"],
-    [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])
+  AS_IF([test "$swtpm" = yes], [TABRMD_TCTI=swtpm],
+        [AS_IF([test "$tpm_server" = yes], [TABRMD_TCTI=mssim],
+               [AC_MSG_ERROR([Integration tests enabled but swtpm (or tpm_server) executable not found.])])])
+  AC_SUBST([TABRMD_TCTI])
 
   AC_CHECK_PROG([ss], [ss], [yes], [no])
     AS_IF([test "x$ss" != "xyes"],

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -33,9 +33,10 @@ in known package managers are likely too old.
 
 ### Optional Dependencies for Enabling Testing
 1. [CMocka](https://cmocka.org/)
-2. [TPM 2.0 Simulator](https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1563.tar.gz/download): **Tested with version 1563**
-4. [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd)
-5. Dependencies for [tpm2-ptool](# Optional Dependencies for tpm2_ptool)
+2. [swtpm](https://github.com/stefanberger/swtpm) or
+   [tpm_server](https://sourceforge.net/projects/ibmswtpm2/) TPM 2.0 simulator
+3. [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd)
+4. Dependencies for [tpm2-ptool](# Optional Dependencies for tpm2_ptool)
 
 ## Step 2 - Bootstrapping
 
@@ -66,7 +67,7 @@ that *are outside of normal autoconf/automake options*, which are documented [he
     ```sh
     export PATH="/home/wcrobert/workspace/tpm2-tools/tools:/home/wcrobert/workspace/tpm2-pkcs11/tools:$HOME/workspace/ibmtpm974/src:$PATH"
     ```
-    **Normally** only tpm2-tools, IBM TPM Simulator and tpm2-ptool need to be added to `PATH`. Most other things, like CMocka and ss, are already
+    **Normally** only tpm2-tools, swtpm/tpm_server and tpm2-ptool need to be added to `PATH`. Most other things, like CMocka and ss, are already
     installed and thus on `PATH`. Your results will very based on what you build from source and/or install in non-standard locations.
 3. `--disable-hardening` - Compiler flag hardening options, this is enabled by default. Disabling hardening is **NOT RECOMMENDED FOR PRODUCTION BUILDS**,
       however, is often useful when adding in compiler flags for testing via `CFLAGS`. For example, one would need to disable this if configuring

--- a/docs/INITIALIZING.md
+++ b/docs/INITIALIZING.md
@@ -46,7 +46,7 @@ The store itself defaults to `$HOME/.tpm2_pkcs11` unless specified via the envir
 * For all the illustrations below, we create a store under `~/tmp`.
 * We assume some working TPM connection. Under the hood the `tpm2_ptool` command calls `tpm2-tools`
   binaries. Thus configuring the `TCTI` is important. The easiest way to do this for testing is
-  to use the IBM TPM Simulator and tpm2-abrmd as documented in
+  to use a TPM Simulator and tpm2-abrmd as documented in
   [dependencies](BUILDING.md#step-1---satisfy-dependencies).
 
   Their is no requirement to use the simulator and abrmd, this is all configuration dependent.

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -165,8 +165,8 @@ void test_get_mechanism_info_good(void **state) {
         rv = C_GetMechanismInfo(slot_id, ecc_mechs[i].mech, &mech_info);
         assert_int_equal(rv, CKR_OK);
 
-        assert_int_equal(mech_info.ulMinKeySize, 256);
-        assert_int_equal(mech_info.ulMaxKeySize, 384);
+        assert_in_range(mech_info.ulMinKeySize, 192, 256);
+        assert_in_range(mech_info.ulMaxKeySize, 384, 638);
         assert_int_equal(mech_info.flags, ecc_mechs[i].flags);
     }
 

--- a/test/integration/scripts/int-test-funcs.sh
+++ b/test/integration/scripts/int-test-funcs.sh
@@ -63,8 +63,15 @@ simulator_start ()
     # simulator port is a random port between 1024 and 65535
 
     cd ${sim_tmp_dir}
-    daemon_start "${sim_bin}" "-port ${sim_port}" "${sim_log_file}" \
-        "${sim_pid_file}" ""
+    case "$sim_bin" in
+        *swtpm) daemon_start "$sim_bin" "socket --tpm2 --server port=$sim_port \
+                             --ctrl type=tcp,port=$((sim_port + 1)) \
+                             --flags not-need-init --tpmstate dir=$PWD" \
+                             "$sim_log_file" "$sim_pid_file";;
+        *tpm_server) daemon_start "$sim_bin" "-port $sim_port" \
+                                  "$sim_log_file" "$sim_pid_file";;
+        *) echo "Unknown TPM simulator $sim_bin"; return 1;;
+    esac
     local ret=$?
     cd -
     return $ret


### PR DESCRIPTION
tpm2-tss supports the [swtpm](https://github.com/stefanberger/swtpm) TPM simulator since version 3.0.0. One small change in [` test/integration/pkcs-get-mechanism.int.c`](https://github.com/tpm2-software/tpm2-pkcs11/compare/master...diabonas:add-swtpm?expand=1#diff-c9fd97e9e9ba72d316720e723fcea5c104ebb2e8b3810e49c401d8045725769a) was necessary because swtpm supports more elliptic curves than ibmswtpm, other than that everything worked out of the box.

Support for ibmswtpm (aka `tpm_server`) is kept for backwards compatibility, but swtpm is preferred if it is available. Since the Docker images come with swtpm preinstalled, this means that this PR switches CI testing from ibmswtpm to swtpm as well.