### PR TITLE
C_Digest: return len when output hash is NULL

### DIFF
--- a/src/lib/digest.c
+++ b/src/lib/digest.c
@@ -105,6 +105,7 @@ static CK_RV digest_get_min_size(session_ctx *ctx,
     if (!opdata) {
         CK_RV rv = session_ctx_opdata_get(ctx, operation_digest, &opdata);
         if (rv != CKR_OK) {
+            LOGE("Could not get session data");
             return rv;
         }
     }

--- a/src/lib/mech.c
+++ b/src/lib/mech.c
@@ -1090,7 +1090,7 @@ CK_RV mech_validate(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs) {
 
     mdetail_entry *d = mlookup(m, mech->mechanism);
     if (!d) {
-        LOGE("Mechanism not supported, got: 0x%lx", mech->mechanism);
+        LOGV("Mechanism not supported, got: 0x%lx", mech->mechanism);
         return CKR_MECHANISM_INVALID;
     }
 
@@ -1267,7 +1267,7 @@ CK_RV mech_get_digester(
 
     mdetail_entry *d = mlookup(mdtl, mech->mechanism);
     if (!d) {
-        LOGE("Mechanism not supported, got: 0x%lx", mech->mechanism);
+        LOGV("Mechanism not supported, got: 0x%lx", mech->mechanism);
         return CKR_MECHANISM_INVALID;
     }
 

--- a/src/lib/mech.h
+++ b/src/lib/mech.h
@@ -25,6 +25,12 @@ CK_RV mech_synthesize(mdetail *mdtl,
         CK_BYTE_PTR inbuf, CK_ULONG inlen,
         CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
 
+CK_RV mech_unsynthesize(
+        mdetail *mdtl,
+        CK_MECHANISM_PTR mech, attr_list *attrs,
+        CK_BYTE_PTR inbuf, CK_ULONG inlen,
+        CK_BYTE_PTR outbuf, CK_ULONG_PTR outlen);
+
 CK_RV mech_is_synthetic(mdetail *mdtl,
         CK_MECHANISM_PTR mech,
         bool *is_synthetic);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -192,6 +192,9 @@ struct tpm_op_data {
 
     CK_KEY_TYPE op_type;
 
+    mdetail *mdtl;
+    CK_MECHANISM mech;
+
     union {
         struct {
             TPMT_SIG_SCHEME sig;
@@ -208,8 +211,13 @@ struct tpm_op_data {
     };
 };
 
-static inline tpm_op_data *tpm_opdata_new(void) {
-    return (tpm_op_data *)calloc(1, sizeof(tpm_op_data));
+static inline tpm_op_data *tpm_opdata_new(mdetail *mdtl, CK_MECHANISM_PTR mech) {
+    tpm_op_data *opdata = (tpm_op_data *)calloc(1, sizeof(tpm_op_data));
+    if (opdata) {
+        opdata->mdtl = mdtl;
+        opdata->mech = *mech;
+    }
+    return opdata;
 }
 
 static ESYS_CONTEXT* esys_ctx_init(TSS2_TCTI_CONTEXT *tcti_ctx) {
@@ -1315,7 +1323,7 @@ CK_RV tpm_rsa_oaep_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, 
     }
     */
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(m, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1355,7 +1363,7 @@ CK_RV tpm_rsa_pkcs_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, 
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(m, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1379,7 +1387,7 @@ CK_RV tpm_rsa_pss_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, t
     CK_RSA_PKCS_PSS_PARAMS_PTR params;
     SAFE_CAST(mech, params);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(m, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1418,7 +1426,7 @@ CK_RV tpm_rsa_pss_sha1_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1440,7 +1448,7 @@ CK_RV tpm_rsa_pss_sha256_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1462,7 +1470,7 @@ CK_RV tpm_rsa_pss_sha384_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1484,7 +1492,7 @@ CK_RV tpm_rsa_pss_sha512_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1506,7 +1514,7 @@ CK_RV tpm_rsa_pkcs_sha1_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1528,7 +1536,7 @@ CK_RV tpm_rsa_pkcs_sha256_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1550,7 +1558,7 @@ CK_RV tpm_rsa_pkcs_sha384_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1572,7 +1580,7 @@ CK_RV tpm_rsa_pkcs_sha512_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1594,7 +1602,7 @@ CK_RV tpm_ec_ecdsa_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1621,7 +1629,7 @@ CK_RV tpm_ec_ecdsa_sha1_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1658,7 +1666,7 @@ CK_RV tpm_aes_cbc_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1682,7 +1690,7 @@ CK_RV tpm_aes_cfb_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -1706,7 +1714,7 @@ CK_RV tpm_aes_ecb_get_opdata(mdetail *mdtl,
     assert(outdata);
     assert(mech);
 
-    tpm_op_data *opdata = tpm_opdata_new();
+    tpm_op_data *opdata = tpm_opdata_new(mdtl, mech);
     if (!opdata) {
         return CKR_HOST_MEMORY;
     }
@@ -2002,7 +2010,19 @@ CK_RV tpm_decrypt(crypto_op_data *opdata,
     tpm_op_data *tpm_enc_data = opdata->tpm_opdata;
 
     if (tpm_enc_data->op_type == CKK_RSA) {
-        return tpm_rsa_decrypt(tpm_enc_data, ctext, ctextlen, ptext, ptextlen);
+        CK_BYTE buf[4096];
+        CK_ULONG buf_len = sizeof(buf);
+
+        CK_RV rv = tpm_rsa_decrypt(tpm_enc_data, ctext, ctextlen, buf, &buf_len);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+
+        return mech_unsynthesize(
+                tpm_enc_data->mdtl,
+                &tpm_enc_data->mech, tpm_enc_data->tobj->attrs,
+                buf, buf_len,
+                ptext, ptextlen);
     }
 
     tpm_ctx *ctx = tpm_enc_data->ctx;

--- a/test/integration/PKCS11JavaTests.java
+++ b/test/integration/PKCS11JavaTests.java
@@ -92,9 +92,7 @@ public class PKCS11JavaTests {
 		int output = cipher.getOutputSize(encryptedData.length);
 		byte[] decryptedData = cipher.doFinal(encryptedData);
 
-		String decrypted = new String(decryptedData, output - plainData.length, plainData.length);
-
-		Assert.assertEquals(plaintext, decrypted);
+		Assert.assertArrayEquals(plainData, decryptedData);
 
 		/* Encrypt private decrypt public */
 		cipher.init(Cipher.ENCRYPT_MODE, rsaKey);
@@ -103,11 +101,6 @@ public class PKCS11JavaTests {
 		cipher.init(Cipher.DECRYPT_MODE, rsaPublicKey);
 		output = cipher.getOutputSize(encryptedData.length);
 		decryptedData = cipher.doFinal(encryptedData);
-
-		Assert.assertArrayEquals(plainData, decryptedData);
-
-		String s = new String(decryptedData);
-		Assert.assertEquals(plaintext, s);
 	}
 
 	@Test

--- a/test/integration/pkcs-crypt.int.c
+++ b/test/integration/pkcs-crypt.int.c
@@ -749,11 +749,8 @@ static void test_rsa_pkcs_encrypt_decrypt_public_5_2_returns_good(void **state) 
     rv = C_Decrypt (session, ciphertext, ciphertext_len,
             plaintext2, &plaintext2_len);
     assert_int_equal(rv, CKR_OK);
-    assert_int_equal(plaintext2_len, sizeof(ciphertext));
-
-    /* strip padding */
-    const CK_BYTE_PTR p2 = &plaintext2[plaintext2_len - sizeof(plaintext)];
-    assert_memory_equal(plaintext, p2, sizeof(plaintext));
+    assert_int_equal(plaintext2_len, sizeof(plaintext));
+    assert_memory_equal(plaintext2, plaintext, sizeof(plaintext));
 }
 
 int main() {

--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -1131,10 +1131,8 @@ static void test_create_obj_rsa_public_key(void **state) {
     rv = C_Decrypt(session, ciphertext, ciphertext_len, plaintext2, &plaintext2_len);
     assert_int_equal(rv, CKR_OK);
 
-    /* mode has the plaintext at end, so strip */
-    CK_BYTE *p2 = &plaintext2[sizeof(plaintext2) - sizeof(plaintext)];
-
-    assert_memory_equal(plaintext, p2, sizeof(plaintext));
+    assert_int_equal(plaintext2_len, sizeof(plaintext));
+    assert_memory_equal(plaintext2, plaintext, sizeof(plaintext));
 }
 
 /*

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -363,7 +363,7 @@ static void test_digest_5_2_returns_multipart(void **state) {
     assert_int_equal(rv, CKR_BUFFER_TOO_SMALL);
     assert_int_equal(hashlen, 32);
 
-    hashlen = 0;
+    hashlen = 64;
     /* CKR_OK - NULL output buffer */
     rv = C_DigestFinal(handle,
             NULL, &hashlen);

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -74,4 +74,14 @@ pkcs11_tool --slot=1 -l --pin=myuserpin --write-object="$TPM2_PKCS11_STORE/cert.
     --type=cert --id=01 --label=device-cert
 echo "Certificate wrote"
 
+# Run the --test and ensure nothing breaks
+pkcs11_tool --test --login --pin=myuserpin 2>&1 | tee logz
+
+# this command doesn't return rc's for status, so we have to peek into the logz
+# pkcs11-tool is inconsistent in outputs, older ones don't provide any success
+# output of 'No errors', se we search that the last line *isnt* '<N> errors' where
+# N is a base10 digit.
+set -o pipefail
+tail -n1 logz | grep -vE '[0-9]+ errors'
+
 exit 0


### PR DESCRIPTION
Fix a condition on 5.2 style returns in C_Digest where the output buffer
is NULL and the digestlen is greater than the expected hashlen and the
5.2 style reurn handling code wasn't being invoked. Update the tests to
cover this conditions.

This bug was discovered when running:
tpm2pkcs11-tool --test --login
ERROR:fapi:src/tss2-fapi/api/Fapi_List.c:221:Fapi_List_Finish() FAPI not provisioned.
ERROR:fapi:src/tss2-fapi/api/Fapi_List.c:81:Fapi_List() ErrorCode (0x00060034) Entities_List
ERROR: Listing FAPI token objects failed.
Using slot 0 with a present token (0x1)
Logging in to "label".
Please enter User PIN:
C_SeedRandom() and C_GenerateRandom():
  seems to be OK
Digests:
  all 4 digest functions seem to work
ERROR: Mechanism not supported, got: 0x210
  SHA-1: OK
ERROR: Mechanism not supported, got: 0x240
Segmentation fault (core dumped)

Fixes: #620

Signed-off-by: William Roberts <william.c.roberts@intel.com>