### PR TITLE
tpm2_ptool: make link command compatible with tpm2-tss-engine 1.1.0

### DIFF
--- a/.ci/download-deps.sh
+++ b/.ci/download-deps.sh
@@ -6,7 +6,7 @@ function get_deps() {
 	# The list order is important and thus we can't use the keys of the dictionary as order is not preserved.
 	local github_deps=("tpm2-tss" "tpm2-abrmd" "tpm2-tools" "tpm2-tss-engine")
 	declare -A local config_flags=( ["tpm2-tss"]="--disable-doxygen-doc --enable-debug" ["tpm2-abrmd"]="--enable-debug" ["tpm2-tools"]="--disable-hardening --enable-debug" ["tpm2-tss-engine"]="--enable-tctienvvar")
-	declare -A local versions=( ["tpm2-tss"]="3.0.0" ["tpm2-abrmd"]="2.3.3" ["tpm2-tools"]="4.2" ["tpm2-tss-engine"]="v1.0.1")
+	declare -A local versions=( ["tpm2-tss"]="3.0.0" ["tpm2-abrmd"]="2.3.3" ["tpm2-tools"]="4.2" ["tpm2-tss-engine"]="v1.1.0")
 
 	echo "pwd starting: `pwd`"
 	pushd "$1"

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -584,7 +584,8 @@ class LinkCommand(NewKeyCommandBase):
             sys.exit('The primary object (id: {:d}) is persistent and'
                 ' the TSS Engine key does not have a persistent parent,'
                 ' got: 0x{:x}'.format(pid, phandle))
-        elif is_transient and phandle != 0:
+        elif is_transient and not (phandle == tpm2.TPM2_RH_OWNER or phandle == 0):
+            # tpm2-tss-engine < 1.1.0 used a phandle of 0 instead of tpm2.TPM2_RH_OWNER
             sys.exit('The primary object (id: {:d}) is transient and'
                 ' the TSS Engine key has a parent handle,'
                 ' got: 0x{:x}'.format(pid, phandle))


### PR DESCRIPTION
Since upstream commit https://github.com/tpm2-software/tpm2-tss-engine/commit/06f57a300c0a60bdf9c5583f78af7f4335732eb0, tpm2-tss-engine uses `TPM2_RH_OWNER` instead of `0` as the value for the parent. This leads to a failure in the integration test `ptool-link.sh`:
```
+ tpm2_ptool link --label=linktokentransient --userpin=myuserpin --key-label=tss2rsa2048transient --path=/tmp/tmp.lSWQdwB0pe /tmp/tmp.lSWQdwB0pe/tss2-rsa-2048-transient.pem
The primary object (id: 2) is transient and the TSS Engine key has a parent handle, got: 0x40000001
```