### PR TITLE
Fix "tpm2_ptool verify --sopin" without "--userpin"

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -133,8 +133,11 @@ class VerifyCommand(Command):
 
             verify_output['wrappingkey'] = {
                 'hex' : bytes.hex(wrappingkeyauth),
-                'auth' : usersealauth['hash']
             }
+            if userpin != None:
+                verify_output['wrappingkey']['auth'] = usersealauth['hash']
+            if sopin != None:
+                verify_output['wrappingkey']['soauth'] = sosealauth['hash']
 
             wrapper = AESAuthUnwrapper(wrappingkeyauth)
 


### PR DESCRIPTION
When using option `--sopin` in `tpm2_ptool verify`, `usersealauth` is not initialized but is being used. In practise, the value in `verify_output['wrappingkey']['auth']` is the same as the one in `verify_output['pin']['user']`, so make sure this is set only when the user PIN is really used.

Fixes: https://github.com/tpm2-software/tpm2-pkcs11/issues/624