### PR TITLE
tpm2_ptool: add rsa3072 keys

### DIFF
--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -19,8 +19,9 @@ class Tpm2(object):
         "|fixedparent|sensitivedataorigin"
 
     ALGS = [
-        'rsa1024', 'rsa2048', 'aes128', 'aes256', 'ecc224', 'ecc256',
-        'ecc384', 'ecc521'
+        'rsa1024', 'rsa2048', 'rsa3072',
+        'aes128', 'aes256',
+        'ecc224', 'ecc256', 'ecc384', 'ecc521'
     ]
 
     TEMPLATES = {


### PR DESCRIPTION
Fix the C code that validates the RSA keysize. A TODO was left there to
fix that the code should query the TPM for rsa min and max keysizes.

Add --algorithm=rsa3072 to the addkey commandlet. This fixes #644. Also
implement the test, which closes #642.

Signed-off-by: William Roberts <william.c.roberts@intel.com>