### PR TITLE
Relax tss2-esys versioned deps for non-FAPI builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,10 @@ AC_DEFUN([do_esapi_manage_flags], [
 # Check for ESYS version below 2.2.1 which requires us to manage ESYS session flags
 PKG_CHECK_EXISTS([tss2-esys < 2.2.1], [do_esapi_manage_flags])
 
+# ESYS >= 2.4 introduces additional functions that we use with certain optional features
+PKG_CHECK_EXISTS([tss2-esys >= 2.4],
+                 [AC_DEFINE([ESYS_2_4], [1], [New functions in ESAPI version 2.4])])
+
 # ESYS >= 3.0 uses a different ABI param hierarchy in Esys_LoadExternal()
 PKG_CHECK_EXISTS([tss2-esys >= 3.0],
                  [AC_DEFINE([ESYS_3], [1], [Esys3])])
@@ -81,8 +85,8 @@ AC_ARG_ENABLE(
 AC_DEFUN([do_fapi_configure], [
 
   AS_IF([test "x$enable_fapi" = "xauto"],
-      [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0], [have_fapi=1], [have_fapi=0]) ],
-	  [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0], [have_fapi=1]) ]
+      [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 tss2-esys >= 2.4], [have_fapi=1], [have_fapi=0]) ],
+	  [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 tss2-esys >= 2.4], [have_fapi=1]) ]
   )
 ])
 

--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -46,9 +46,19 @@ static CK_RV get_key(FAPI_CONTEXT *fapictx, tpm_ctx *tctx, const char *path, uin
         }
         return CKR_OK;
     case FAPI_ESYSBLOB_DESERIALIZE:
-        ret = tpm_deserialize_handle(tctx, twistdata, esysHandle, tpmHandle);
+        ret = tpm_deserialize_handle(tctx, twistdata, esysHandle);
         if (!ret) {
             LOGE("Error on deserialize");
+            return CKR_GENERAL_ERROR;
+        }
+        /* Esys_TR_GetTpmHandle() was added to tss2-esys in v2.4. The rest
+         * of the code works fine with older versions. Hence, we open-code
+         * the function call here to restrict the dependency on >= 2.4 to
+         * FAPI-enabled builds.
+         */
+        ret = tpm_get_tpmhandle(tctx, *esysHandle, tpmHandle);
+        if (!ret) {
+            LOGE("Error on get_tpmhandle");
             return CKR_GENERAL_ERROR;
         }
         return CKR_OK;

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -407,7 +407,7 @@ DEBUG_VISIBILITY int init_pobject_from_stmt(sqlite3_stmt *stmt, tpm_ctx *tpm, po
             LOGE("Expected persistent pobject config to have ESYS_TR blob");
             return SQLITE_ERROR;
         }
-        res = tpm_deserialize_handle(tpm, pobj->config.blob, &pobj->handle, NULL);
+        res = tpm_deserialize_handle(tpm, pobj->config.blob, &pobj->handle);
         if (!res) {
             /* just set a general error as rc could be success right now */
             return SQLITE_ERROR;

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <tss2/tss2_esys.h>
+
 #include "attrs.h"
 #include "debug.h"
 #include "object.h"
@@ -94,7 +96,14 @@ bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle);
 
 twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth);
 
-WEAK bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle, uint32_t *tpmHandle);
+#ifdef ESYS_2_4
+/* Any (optional) component using this function needs to add a dependency on
+ * tss2-esys >= 2.4 to its configure checks.
+ */
+WEAK bool tpm_get_tpmhandle(tpm_ctx *ctx, uint32_t handle, uint32_t *tpm_handle);
+#endif
+
+WEAK bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
 
 bool tpm_contextload_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
 

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -270,15 +270,23 @@ char *emit_pobject_to_conf_string(pobject_config *config) {
 }
 
 /* weak override */
+bool tpm_get_tpmhandle(tpm_ctx *ctx, uint32_t handle,
+                       uint32_t *tpm_handle) {
+    UNUSED(ctx);
+    UNUSED(handle);
+
+    if (tpm_handle)
+        *tpm_handle = 42;
+
+    return true;
+}
+
+/* weak override */
 bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob,
-        uint32_t *handle, uint32_t *tpm_handle) {
+        uint32_t *handle) {
     UNUSED(ctx);
     UNUSED(handle_blob);
     UNUSED(handle);
-
-    if (tpm_handle) {
-        *tpm_handle = 42;
-    }
 
     will_return_data *d = mock_type(will_return_data *);
     return d->rcb;


### PR DESCRIPTION
Commit 5b379c0d introduced a call to Esys_TR_GetTpmHandle() into a common code
path.  This function was only added to tss2-esys in version 2.4, and isn't
readily available in packaged distributions, yet. Only the FAPI backend
actually makes use of the function. Hence, splice out the call to a separate
function that can be conditionally included. (No matching stub is added for
tss2-esys < 2.4, so dependency errors can be caught already at compile time.)
This change restricts the versioned dependency on tss2-esys >= 2.4 to
FAPI-enabled builds, and thus facilitates standard builds of tpm2-pkcs11 on
current distributions.

Fixes: #632

Signed-off-by: Daniel Kobras <kobras@puzzle-itc.de>