### PR TITLE
backed/fapi: drop Esys_TR_GetTpmHandle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,10 +48,6 @@ AC_DEFUN([do_esapi_manage_flags], [
 # Check for ESYS version below 2.2.1 which requires us to manage ESYS session flags
 PKG_CHECK_EXISTS([tss2-esys < 2.2.1], [do_esapi_manage_flags])
 
-# ESYS >= 2.4 introduces additional functions that we use with certain optional features
-PKG_CHECK_EXISTS([tss2-esys >= 2.4],
-                 [AC_DEFINE([ESYS_2_4], [1], [New functions in ESAPI version 2.4])])
-
 # ESYS >= 3.0 uses a different ABI param hierarchy in Esys_LoadExternal()
 PKG_CHECK_EXISTS([tss2-esys >= 3.0],
                  [AC_DEFINE([ESYS_3], [1], [Esys3])])
@@ -85,8 +81,8 @@ AC_ARG_ENABLE(
 AC_DEFUN([do_fapi_configure], [
 
   AS_IF([test "x$enable_fapi" = "xauto"],
-      [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 tss2-esys >= 2.4], [have_fapi=1], [have_fapi=0]) ],
-	  [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 tss2-esys >= 2.4], [have_fapi=1]) ]
+      [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 ], [have_fapi=1], [have_fapi=0]) ],
+	  [ PKG_CHECK_MODULES([TSS2_FAPI], [tss2-fapi >= 3.0 ], [have_fapi=1]) ]
   )
 ])
 

--- a/src/lib/config.h.in~
+++ b/src/lib/config.h.in~
@@ -1,0 +1,121 @@
+/* src/lib/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
+/* Define to disable built in overflow math */
+#undef DISABLE_OVERFLOW_BUILTINS
+
+/* ESAPI versions below 2.2.1 are known to require manual session flag
+   management. */
+#undef ESAPI_MANAGE_FLAGS
+
+/* New functions in ESAPI version 2.4 */
+#undef ESYS_2_4
+
+/* Esys3 */
+#undef ESYS_3
+
+/* Defined when building fuzzing tests */
+#undef FUZZING
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Enabled if FAPI >= 3.0 is found */
+#undef HAVE_FAPI
+
+/* Define to 1 if the system has the `weak' function attribute */
+#undef HAVE_FUNC_ATTRIBUTE_WEAK
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define if you have POSIX threads libraries and header files. */
+#undef HAVE_PTHREAD
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#undef HAVE_PTHREAD_PRIO_INHERIT
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#undef LT_OBJDIR
+
+/* Define if debugging is disabled */
+#undef NDEBUG
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to enable 1 byte structure packing. Default for Windows builds. */
+#undef PKCS11_PACK
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+#undef PTHREAD_CREATE_JOINABLE
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Changes the store directory to search. Defaults to /etc/tpm2_pkcs11 */
+#undef TPM2_PKCS11_STORE_DIR
+
+/* Define when unit testing. libtwist uses this to define a debug interface
+   for alloc failures */
+#undef UNIT_TESTING
+
+/* Version number of package */
+#undef VERSION
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -26,6 +26,7 @@ typedef union crypto_op_data crypto_op_data;
 typedef struct mdetail mdetail;
 typedef struct pobject pobject;
 
+
 /**
  * Destroys the system API context, and when the refcnt
  * hits 0 for the tcti context, destroys it as well.
@@ -95,13 +96,6 @@ CK_RV tpm_loadobj(tpm_ctx *ctx, uint32_t phandle, twist auth,
 bool tpm_flushcontext(tpm_ctx *ctx, uint32_t handle);
 
 twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth);
-
-#ifdef ESYS_2_4
-/* Any (optional) component using this function needs to add a dependency on
- * tss2-esys >= 2.4 to its configure checks.
- */
-WEAK bool tpm_get_tpmhandle(tpm_ctx *ctx, uint32_t handle, uint32_t *tpm_handle);
-#endif
 
 WEAK bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob, uint32_t *handle);
 
@@ -193,6 +187,8 @@ CK_RV tpm_create_transient_primary_from_template(tpm_ctx *tpm,
         uint32_t *primary_handle);
 
 CK_RV tpm_get_pss_sig_state(tpm_ctx *tctx, tobject *tobj, bool *pss_sigs_good);
+
+bool tpm_get_name(tpm_ctx *ctx, uint32_t handle, twist *name);
 
 void tpm_init(void);
 

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -270,18 +270,6 @@ char *emit_pobject_to_conf_string(pobject_config *config) {
 }
 
 /* weak override */
-bool tpm_get_tpmhandle(tpm_ctx *ctx, uint32_t handle,
-                       uint32_t *tpm_handle) {
-    UNUSED(ctx);
-    UNUSED(handle);
-
-    if (tpm_handle)
-        *tpm_handle = 42;
-
-    return true;
-}
-
-/* weak override */
 bool tpm_deserialize_handle(tpm_ctx *ctx, twist handle_blob,
         uint32_t *handle) {
     UNUSED(ctx);


### PR DESCRIPTION
Since the internals of the code were changed to use ESYS_TRs fully for primary
objects, to get name checking, thier was no longer a need for calls to
convert ESYS_TR's to TPM2_HANDLE's. Thus we can drop
Esys_TR_GetTpmHandle. However, the pid value is now currently unused by
the FAPI backend, so perhaps some population values should go there?
Perhaps just the ESYS_TR?

Signed-off-by: William Roberts <william.c.roberts@intel.com>