### PR TITLE
Remove unsued function tpm2_error_get

### DIFF
--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -178,12 +178,6 @@ struct tpm_ctx {
 #define TPM2B_INIT(xsize) { .size = xsize, }
 #define TPM2B_EMPTY_INIT TPM2B_INIT(0)
 
-#define TPM2_ERROR_TSS2_RC_ERROR_MASK 0xFFFF
-
-static inline UINT16 tpm2_error_get(TSS2_RC rc) {
-    return ((rc & TPM2_ERROR_TSS2_RC_ERROR_MASK));
-}
-
 struct tpm_op_data {
 
     tpm_ctx *ctx;


### PR DESCRIPTION
The last use of this function was removed in
dc83d34291cda8ebd05ed9eca6573a2b8b32f93e.

This fixes the build when compiling with clang.