### PR TITLE
build: only use -Werror for non-release builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -476,7 +476,7 @@ AS_IF([test x"$enable_hardening" != xno], [
 
   add_hardened_c_flag([-Wall])
   add_hardened_c_flag([-Wextra])
-  add_hardened_c_flag([-Werror])
+  AS_IF([test "x$ax_is_release" = "xno"], [add_hardened_c_flag([-Werror])])
 
   add_hardened_c_flag([-Wformat])
   add_hardened_c_flag([-Wformat-security])


### PR DESCRIPTION
In light of issues like #676 it is probably a good idea to disable `-Werror` for release builds, like e.g. [tpm2-tss does](https://github.com/tpm2-software/tpm2-tss/blob/2bae50a3551cd8b0123ef609ea973678339df5ae/configure.ac#L435-L436).