### PR TITLE
tpm2_ptool: fix error message when the DB is too new

### DIFF
--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -576,7 +576,6 @@ class Db(object):
     def _do_create(self):
 
         # perform an update if we need to
-        dbbakpath = None
         try:
             old_version = self._get_version()
 
@@ -599,7 +598,7 @@ class Db(object):
                 return True
 
         except Exception as e:
-            sys.stderr.write('DB Upgrade failed: "{}", backup located in "{}"'.format(e, dbbakpath))
+            sys.stderr.write('DB Upgrade failed: "{}"\n'.format(e))
             raise e
 
     def _create(self):


### PR DESCRIPTION
While testing tpm2_ptool with the wrong version of the tool (compared to the database), I got:

    DB Upgrade failed: "DB Version exceeds library version: 5 > 4", backup located in "None"Traceback (most recent call last):
      File "/usr/sbin/tpm2_ptool", line 33, in <module>
        sys.exit(load_entry_point('tpm2-pkcs11-tools==1.33.7', 'console_scripts', 'tpm2_ptool')())
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/tpm2_ptool.py", line 26, in main
        commandlet.init('A tool for manipulating the tpm2-pkcs11 database')
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/command.py", line 102, in init
        commandlet.get()[d['which']](d)
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/commandlets_store.py", line 91, in __call__
        with Db(path) as db:
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/db.py", line 23, in __enter__
        self._create()
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/db.py", line 559, in _create
        self._do_create()
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/db.py", line 548, in _do_create
        raise e
      File "/usr/lib/python3.9/site-packages/tpm2_pkcs11/db.py", line 538, in _do_create
        raise RuntimeError("DB Version exceeds library version:"
    RuntimeError: DB Version exceeds library version: 5 > 4

The error is expected, but `backup located in "None"` is unexpected and a newline character was missing. Fix these issues.