### PR TITLE
tpm2_ptool import: enable importing encrypted private keys and SSH private keys

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -647,7 +647,7 @@ class LinkCommand(NewKeyCommandBase):
         return (tertiarypriv, tertiarypub, tertiarypubdata)
 
     # Links a new key
-    def new_key_create(self, pobj, objauth, hierarchyauth, tpm2, alg, keypaths, d):
+    def new_key_create(self, pobj, objauth, hierarchyauth, tpm2, alg, keypaths, passin, d):
 
         if keypaths is None:
             sys.exit("Keypath must be specified")

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -215,7 +215,7 @@ class ImportCommand(NewKeyCommandBase):
             '--algorithm',
             help='The type of the key.\n',
             choices=['rsa', 'ecc'],
-            required=True)
+            required=False)
         group_parser.add_argument(
             '--passin',
             help='Password of the input private key file like OpenSSL (example: "pass:secret").\n',

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -264,7 +264,9 @@ class Tpm2(object):
         if privey_data.startswith(b'-----BEGIN OPENSSH PRIVATE KEY-----'):
             if passin:
                 # Parse passin to extract the password
-                if passin.startswith('file:'):
+                if passin.startswith('env:'):
+                    password_bytes = os.getenvb(passin[4:].encode())
+                elif passin.startswith('file:'):
                     with open(passin[5:], 'rb') as f:
                         password_bytes = f.read()
                 elif passin.startswith('pass:'):

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -239,7 +239,8 @@ class Tpm2(object):
                   privkey,
                   objattrs=None,
                   seal=None,
-                  alg=None):
+                  alg=None,
+                  passin=None):
 
         if privkey and len(privkey) > 0:
             exists = os.path.isfile(privkey)
@@ -272,6 +273,9 @@ class Tpm2(object):
 
         if alg != None:
             cmd.extend(['-G', alg])
+
+        if passin is not None:
+            cmd.extend(['--passin', passin])
 
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=os.environ)
         stdout, stderr = p.communicate(input=seal)

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -297,6 +297,16 @@ class Tpm2(object):
             os.write(pem_priv_fd, pem_key)
             os.close(pem_priv_fd)
             privkey = pem_priv_name
+        elif alg is None:
+            # Guess the key algorithm from the PEM header
+            if privey_data.startswith(b'-----BEGIN EC PARAMETERS-----'):
+                alg = 'ecc'
+            elif privey_data.startswith(b'-----BEGIN EC PRIVATE KEY-----'):
+                alg = 'ecc'
+            elif privey_data.startswith(b'-----BEGIN RSA PRIVATE KEY-----'):
+                alg = 'rsa'
+            else:
+                raise RuntimeError("Unable to detect key type, use --algorithm to specify it")
 
         parent_path = str(phandle)
         cmd = [


### PR DESCRIPTION
Hello,

This Pull Request implements what was discussed in https://github.com/tpm2-software/tpm2-pkcs11/issues/659 : being to able to use `tpm2_ptool import` with OpenSSH keys.

In order to support encrypted private keys, I added option `--passin` exactly like `tpm2_import`. This enables importing encrypted PEM and DER private keys with all supported `--passin` variants (cf. `man 1 openssl`: https://www.openssl.org/docs/man1.1.1/man1/openssl.html#Pass-Phrase-Options). This option is also parsed when importing encrypted OpenSSH keys.

While at it, this PR also makes `--algorithm` optional, as the type of the private key (`ecc` or `rsa`) can be guessed from the PEM file header. This argument is still required when importing DER keys.

I did not write tests as I do not know how `tpm2_ptool` is tested. Nevertheless I documented in the commit descriptions some commands which can be used in order to test this Pull Request. I ran these commands in a container which was using a software TPM (with `swtpm`).