### PR TITLE
test/integration/PKCS11JavaTests: fix version parsing with openjdk-17-jdk

### DIFF
--- a/test/integration/PKCS11JavaTests.java
+++ b/test/integration/PKCS11JavaTests.java
@@ -40,10 +40,11 @@ public class PKCS11JavaTests {
 		String cwd = System.getProperty("user.dir");
 		Path libPath = Paths.get(cwd, "src/.libs/libtpm2_pkcs11.so.0.0.0");
 
-                String version = System.getProperty("java.version");
-                String [] chunks = version.split("\\.");
-                int major = Integer.parseInt(chunks[0]);
-                if (major >= 9) {
+		String version = System.getProperty("java.version");
+		/* Parse for example "11.0.11" or "17-ea" */
+		String [] chunks = version.split("[\\.-]");
+		int major = Integer.parseInt(chunks[0]);
+		if (major >= 9) {
 			/* Java >= 9 */
 			Method configure = Provider.class.getMethod("configure", String.class);
 			String pkcs11Config = "--name = TPM2\nlibrary = " + libPath;


### PR DESCRIPTION
When using Debian 11 to run integration tests with openjdk-17-jdk, the integration checks fail:

    FAIL: test/integration/pkcs11-javarunner.sh.java

This is because `System.getProperty("java.version")` is `"17-ea"` and does not contain any dot, even though the test expects the version to be something such as `11.0.11`.

Parse Java versions which use a `-ea` suffix without including any dot.

While at it, uniformize the indentation in order to use tabs.