### PR TITLE
docs/BUILDING: document how to run tests in a container

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -88,3 +88,32 @@ To enable testing, run `make check`.
 
 **Note:** If make check runs 0 tests, you likely need the configure options `--enable-unit` and `--enable-integration`. See [Configure Options](#configure-options)
 for more details.
+
+## Running tests in a container
+
+Sometimes it is useful to be able to run tests in a fresh environment where everything is configured by default.
+Using a container is a light way to ensure the environment of the test is quite clean.
+There are several containers provided in [tpm2-software-container](https://github.com/tpm2-software/tpm2-software-container) project.
+
+For example here is a command which builds tpm2-pkcs11 and runs continuous integration tests in a Fedora 32 container with [podman](https://podman.io/):
+
+```sh
+podman run --rm -v "$(pwd):/workspace/tpm2-pkcs11" --env-file .ci/docker.env \
+    --workdir /workspace/tpm2-pkcs11 -ti ghcr.io/tpm2-software/fedora-32 \
+    bash -c .ci/docker.run
+```
+
+Building the project and running tests can be also done with specific shell commands inside a container:
+
+```sh
+# Configure tpm2-pkcs11 to build unit and integration tests
+./bootstrap
+./configure --enable-esapi-session-manage-flags --enable-fapi --enable-unit --enable-integration
+
+# Build the project and run tests
+make -j $(nproc)
+make check
+
+# Run a single test, for example to debug a failure
+make check TESTS=test/integration/pkcs-get-mechanism.int
+```

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -95,9 +95,16 @@ Sometimes it is useful to be able to run tests in a fresh environment where ever
 Using a container is a light way to ensure the environment of the test is quite clean.
 There are several containers provided in [tpm2-software-container](https://github.com/tpm2-software/tpm2-software-container) project.
 
-For example here is a command which builds tpm2-pkcs11 and runs continuous integration tests in a Fedora 32 container with [podman](https://podman.io/):
+For example here is a command which builds tpm2-pkcs11 and runs continuous integration tests in a Fedora 32 container with [Docker](https://www.docker.com/) or [Podman](https://podman.io/):
 
 ```sh
+sudo docker run --rm -v "$(pwd):/workspace/tpm2-pkcs11" --env-file .ci/docker.env \
+    --workdir /workspace/tpm2-pkcs11 -ti ghcr.io/tpm2-software/fedora-32 \
+    bash -c .ci/docker.run
+# NB. sudo can be omitted if the user is added to the "docker" group, but this
+# configuration impacts security in your system, as documented in
+# https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
+
 podman run --rm -v "$(pwd):/workspace/tpm2-pkcs11" --env-file .ci/docker.env \
     --workdir /workspace/tpm2-pkcs11 -ti ghcr.io/tpm2-software/fedora-32 \
     bash -c .ci/docker.run

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -115,7 +115,7 @@ Building the project and running tests can be also done with specific shell comm
 ```sh
 # Configure tpm2-pkcs11 to build unit and integration tests
 ./bootstrap
-./configure --enable-esapi-session-manage-flags --enable-fapi --enable-unit --enable-integration
+./configure --enable-fapi --enable-unit --enable-integration
 
 # Build the project and run tests
 make -j $(nproc)


### PR DESCRIPTION
Hello,

Finding out all the dependencies which are required to run every integration test is quite painful. This PR documents how to use containers to launch tests, which helps maintaining the dependencies list.

Add a part to the `BUILDING` documentation which describes how to launch an Arch Linux and a Debian containers to install dependencies and run all tests. This also greatly helps setting up a development system for tpm2-pkcs11.

(This PR is a cleaned-up version of what I posted a few days ago when I tested another PR, https://github.com/tpm2-software/tpm2-pkcs11/pull/684#pullrequestreview-667972361)