### PR TITLE
test/integration: define variable T in all scripts

### DIFF
--- a/test/integration/nss-tests.sh
+++ b/test/integration/nss-tests.sh
@@ -3,6 +3,10 @@
 
 set -xo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 EXT_FILE="$TEST_FIXTURES/smimeextensions"
 CLIENT_CNF="$TEST_FIXTURES/client.cnf"
 

--- a/test/integration/openssl.sh
+++ b/test/integration/openssl.sh
@@ -3,6 +3,10 @@
 
 set -exo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 PIN="myuserpin"

--- a/test/integration/p11-tool.sh.nosetup
+++ b/test/integration/p11-tool.sh.nosetup
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 #WARNING: If your system hangs on this test, then the reason is typically that
 #you are running clang on a fedora-30 or similar system that has a buggy combination
 #of p11-tool p11-kit and libasan (clang). Consider using gcc or exporting
@@ -70,7 +74,7 @@ p11tool --list-tokens
 if ! p11_tool --list-tokens | grep -q "Model: SW   TPM"; then
   echo "p11tool did not find this token."
   echo "If you are running a recent version of p11tool then you need to configure the module system-wide:"
-  echo "echo \"module: $TRAVIS_BUILD_DIR/build/src/.libs/libtpm2_pkcs11.so\" >/etc/pkcs11/modules/tpm2_pkcs11.module"
+  echo "echo \"module: $T/src/.libs/libtpm2_pkcs11.so\" >/etc/pkcs11/modules/tpm2_pkcs11.module"
 
   if [[ "${DOCKER_IMAGE:-nodocker}" = "fedora-30" || "${DOCKER_IMAGE:-nodocker}" = "ubuntu-20.04" ]]; then
     echo "p11-tool on fedora-30 or ubuntu-20.04 with clang is dysfunctional even without asan"

--- a/test/integration/pkcs11-dbup.sh.nosetup
+++ b/test/integration/pkcs11-dbup.sh.nosetup
@@ -3,6 +3,10 @@
 
 set -eo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 tempdir=$(mktemp -d)

--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -3,6 +3,10 @@
 
 set -x
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 tempdir=$(mktemp -d)

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -3,6 +3,10 @@
 
 set -eo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 setup_asan

--- a/test/integration/ptool-link.sh.nosetup
+++ b/test/integration/ptool-link.sh.nosetup
@@ -3,6 +3,10 @@
 
 set -xe
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 tempdir=$(mktemp -d)

--- a/test/integration/python-pkcs11.sh
+++ b/test/integration/python-pkcs11.sh
@@ -3,6 +3,10 @@
 
 set -exo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 setup_asan

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -2,7 +2,7 @@
 #!/usr/bin/env bash
 
 if [ -z "$T" ]; then
-    export T="$(pwd)"
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 fi
 
 if [ -z "$TEST_FIXTURES" ]; then

--- a/test/integration/tls-tests.sh
+++ b/test/integration/tls-tests.sh
@@ -3,6 +3,10 @@
 
 set -xo pipefail
 
+if [ -z "$T" ]; then
+    export T="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
 source "$T/test/integration/scripts/helpers.sh"
 
 EXT_FILE="$TEST_FIXTURES/xpextensions"


### PR DESCRIPTION
When `test/integration/p11-tool.sh.nosetup` is called directly (for example when debugging issues related to `p11tool`), `$T` is not defined. Define this variable to the top-level directory using `${BASH_SOURCE[0]}` to make `p11-tool.sh.nosetup` directly invokable.

Repeat this change in all files which use `$T` in order to make debugging issues easier, even though running `make check TESTS=...` also enables running each test directly.

While at it, use this variable in the error message in order to produce a line which directly contains the path to the tested library `libtpm2_pkcs11.so`.