### PR TITLE
general: fix parse_lib_version

### DIFF
--- a/src/lib/general.c
+++ b/src/lib/general.c
@@ -59,7 +59,7 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
 
     endptr = NULL;
     val = strtoul(minor_str, &endptr, 10);
-    if (errno != 0 || endptr[0] || val > UINT8_MAX) {
+    if (errno != 0 || (endptr[0] != '\0' && endptr[0] != '.') || val > UINT8_MAX) {
         LOGW("Could not strtoul(%s): %s", minor_str, strerror(errno));
         *major = *minor = 0;
         return;

--- a/test/integration/pkcs-misc.int.c
+++ b/test/integration/pkcs-misc.int.c
@@ -144,7 +144,7 @@ static void parse_lib_version(CK_BYTE *major, CK_BYTE *minor) {
 
     endptr = NULL;
     val = strtoul(minor_str, &endptr, 10);
-    if (errno != 0 || endptr[0] || val > UINT8_MAX) {
+    if (errno != 0 || (endptr[0] != '\0' && endptr[0] != '.') || val > UINT8_MAX) {
         *major = *minor = 0;
         return;
     }
@@ -174,6 +174,7 @@ static void test_get_info(void **state) {
     CK_BYTE major;
     CK_BYTE minor;
     parse_lib_version(&major, &minor);
+    assert_int_not_equal(major | minor, 0);
     assert_int_equal(info.libraryVersion.major, major);
     assert_int_equal(info.libraryVersion.minor, minor);
 }

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -22,6 +22,19 @@ pkcs11_tool() {
   return $?
 }
 
+echo "Check library line from --show-info"
+pkcs11_info="$(pkcs11_tool --show-info)"
+if ! printf "%s" "$pkcs11_info" | grep -q "^Library\s\+TPM2.0 Cryptoki " ; then
+    echo "pkcs11-tool did not report using TPM2.0 Cryptoki library:"
+    printf "%s\n" "$pkcs11_info"
+    exit 1
+fi
+if ! printf "%s" "$pkcs11_info" | grep -q "^Library\s\+TPM2.0 Cryptoki (ver [^0][0-9]*\." ; then
+    echo "pkcs11-tool reported an erroneous library version:"
+    printf "%s\n" "$pkcs11_info"
+    exit 1
+fi
+
 echo "Finding cert"
 id=$(pkcs11_tool --label label --list-objects --type cert | grep 'ID:' | cut -d':' -f2- | sed s/' '//g)
 echo "Found cert: $id"


### PR DESCRIPTION
`parse_lib_version` only supports MAJOR.MINOR versions, not MAJOR.MINOR.PATCH ones. This leads `pkcs11-tool -I` to display a library version which is 0.0, when using tpm2-pkcs11 1.6.0:

    $ TPM2_PKCS11_LOG_LEVEL=1 pkcs11-tool --module /usr/lib64/pkcs11/libtpm2_pkcs11.so -I
    WARNING: Could not strtoul(6.0): Success
    Cryptoki version 2.40
    Manufacturer     tpm2-software.github.io
    Library          TPM2.0 Cryptoki (ver 0.0)
    Using slot 0 with a present token (0x1)

Note the warning about `strtoul(6.0)`: this is comes from `strtoul(minor_str, &endptr, 10)` where `minor_str` is the part after the major version number in `1.6.0`.

Fix this by allowing `endptr` to be `'.'` after this `strtoul`.

Add a regression tests which detects that a zero version was returned by `pkcs11-tool`. Before this commit, the new test failed with:

    Check library line from --show-info
    WARNING: Could not strtoul(6.0-37-g854f0cc): Success
    Using slot 0 with a present token (0x1)
    pkcs11-tool reported an erroneous library version:
    Cryptoki version 2.40
    Manufacturer     tpm2-software.github.io
    Library          TPM2.0 Cryptoki (ver 0.0)