### PR TITLE
test: do not skip SSH tests when RSA3072 is not supported

### DIFF
--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -97,46 +97,43 @@ else
 fi
 
 # verify that RSA3072 keys work if supported, turn off set -e so we can check the rc
-set +e
-tpm2_testparms rsa3072
-if [ $? -ne 0 ]; then
-	echo "TPM Does not support RSA3072, skipping"
-    exit 0
+
+if ! tpm2_testparms rsa3072 ; then
+    echo "TPM Does not support RSA3072, skipping"
+else
+    #
+    # pkcs11-tool is always fun, it seems to be ignoring --label, so things like --label="fake" will still work.
+    # set an id as it seems to respect that.
+    #
+    tpm2_ptool addkey --label="label" --id="myrsa3072key" --key-label="myrsa3072key" --userpin="myuserpin" --algorithm="rsa3072" --path="$TPM2_PKCS11_STORE"
+
+    # Since the PKCS11 Store gets automagically cleaned up, use that as our tempdir scratch space
+    tempdir=$TPM2_PKCS11_STORE
+
+    # pkcs11-tool --id is hex encoded input, so encode "myrsa3072key" as hex: 6d79727361333037326b6579
+    # python -c 'print("6d79727361333037326b6579".decode("hex"))'
+    # myrsa3072key
+    echo "testdata">${tempdir}/data
+    pkcs11_tool --sign --login --slot=1 --id="6d79727361333037326b6579" --pin="myuserpin" \
+                --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+                --mechanism SHA256-RSA-PKCS
+
+    size="$(stat --printf="%s" ${tempdir}/sig)"
+    test "$size" -eq "384"
+
+    # Test that we can generate a RSA3072 key via the CAPI
+    pkcs11_tool --slot=1 --login --pin=myuserpin --keypairgen --id="11223344556677889900" --label="myrsa3072CKey" --key-type rsa:3072
+
+    # validate key is 384 bytes and usable
+    rm ${tempdir}/sig
+    echo "testdata">${tempdir}/data
+    pkcs11_tool --sign --login --slot=1 --id="6d79727361333037326b6579" --pin="myuserpin" \
+                --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+                --mechanism SHA256-RSA-PKCS
+
+    size="$(stat --printf="%s" ${tempdir}/sig)"
+    test "$size" -eq "384"
 fi
-set -e
-
-#
-# pkcs11-tool is always fun, it seems to be ignoring --label, so things like --label="fake" will still work.
-# set an id as it seems to respect that.
-#
-tpm2_ptool addkey --label="label" --id="myrsa3072key" --key-label="myrsa3072key" --userpin="myuserpin" --algorithm="rsa3072" --path="$TPM2_PKCS11_STORE"
-
-# Since the PKCS11 Store gets automagically cleaned up, use that as our tempdir scratch space
-tempdir=$TPM2_PKCS11_STORE
-
-# pkcs11-tool --id is hex encoded input, so encode "myrsa3072key" as hex: 6d79727361333037326b6579
-# python -c 'print("6d79727361333037326b6579".decode("hex"))'
-# myrsa3072key
-echo "testdata">${tempdir}/data
-pkcs11_tool --sign --login --slot=1 --id="6d79727361333037326b6579" --pin="myuserpin" \
-            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
-            --mechanism SHA256-RSA-PKCS
-
-size="$(stat --printf="%s" ${tempdir}/sig)"
-test "$size" -eq "384"
-
-# Test that we can generate a RSA3072 key via the CAPI
-pkcs11_tool --slot=1 --login --pin=myuserpin --keypairgen --id="11223344556677889900" --label="myrsa3072CKey" --key-type rsa:3072
-
-# validate key is 384 bytes and usable
-rm ${tempdir}/sig
-echo "testdata">${tempdir}/data
-pkcs11_tool --sign --login --slot=1 --id="6d79727361333037326b6579" --pin="myuserpin" \
-            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
-            --mechanism SHA256-RSA-PKCS
-
-size="$(stat --printf="%s" ${tempdir}/sig)"
-test "$size" -eq "384"
 
 #
 # Test that the imported SSH keys are useable


### PR DESCRIPTION
In `test/integration/pkcs11-tool.sh`, when `tpm2_testparms rsa3072` returns a failure, the test cases with `--algorithm="rsa3072"` are skipped. But the tests which come after, like the ones related to SSH keys, are also skipped.

As this behaviour seems unexpected, encapsulate the RSA3072 tests inside an if block. Moreover using `if` makes using `set +e`/`set -e` no longer necessary.
