### PR TITLE
Enable using objects with no user PIN

### DIFF
--- a/src/lib/emitter.c
+++ b/src/lib/emitter.c
@@ -328,6 +328,26 @@ WEAK char *emit_config_to_string(token *t) {
         }
     }
 
+    /* add config value empty user PIN, if set */
+    if (t->config.empty_user_pin) {
+        key = yaml_document_add_scalar(&doc, (yaml_char_t *)YAML_STR_TAG,
+             (yaml_char_t *)"empty-user-pin", -1, YAML_ANY_SCALAR_STYLE);
+        if (!key) {
+            LOGE("yaml_document_add_scalar for key failed");
+            goto doc_delete;
+        }
+
+        int node = yaml_document_add_scalar(&doc, (yaml_char_t *)YAML_BOOL_TAG,
+             (yaml_char_t *)"true", -1, YAML_ANY_SCALAR_STYLE);
+
+        rc = yaml_document_append_mapping_pair(&doc,
+                root, key, node);
+        if (!rc) {
+            LOGE("yaml_document_append_mapping_pair failed");
+            goto doc_delete;
+        }
+    }
+
     yaml_emitter_t emitter = { 0 };
 
     /* dummy dump the yaml to get size */

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -393,8 +393,8 @@ CK_RV object_find(session_ctx *ctx, CK_OBJECT_HANDLE *object, CK_ULONG max_objec
         // Get the current object, and grab it's id for the object handle
         CK_OBJECT_HANDLE handle = opdata->cur->tobj_handle;
 
-        // filter out CKA_PRIVATE set to CK_TRUE if not logged in
-        if (opdata->cur->cka_private && !token_is_user_logged_in(tok)) {
+        // filter out CKA_PRIVATE set to CK_TRUE if not logged in and PIN is needed
+        if (opdata->cur->cka_private && !token_is_user_logged_in(tok) && !tok->config.empty_user_pin) {
             opdata->cur = opdata->cur->next;
             continue;
         }

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -436,6 +436,9 @@ bool handle_token_config_event(yaml_event_t *e,
             } else if(!strcmp(state->key, "pss-sigs-good")) {
                 config->pss_sigs_good = !strcmp((const char *)e->data.scalar.value, "true")
                         ? pss_config_state_good : pss_config_state_bad;
+            } else if(!strcmp(state->key, "empty-user-pin")) {
+                config->empty_user_pin = !strcmp((const char *)e->data.scalar.value, "true")
+                        ? true : false;
             } else {
                 LOGE("Unknown key, got: \"%s\"\n",
                         state->key);

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -22,6 +22,7 @@ struct token_config {
     bool is_initialized;  /* token initialization state */
     char *tcti;           /* token specific tcti config */
     pss_config_state pss_sigs_good;
+    bool empty_user_pin;  /* user PIN of the token is empty */
 };
 
 typedef struct session_table session_table;

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -272,6 +272,12 @@ static inline CK_RV auth_min_ro_user(session_ctx *ctx) {
         /* no default */
     }
 
+    /* If the token does not require a PIN, allow calling the function */
+    token *t = session_ctx_get_token(ctx);
+    if (t && t->config.empty_user_pin) {
+        LOGV("No user PIN is needed for token %u\n", t->id);
+        return CKR_OK;
+    }
     return CKR_USER_NOT_LOGGED_IN;
 }
 

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -160,4 +160,27 @@ pkcs11_tool --sign --login --token-label="import-keys" --id="696d706f727465645f7
 size="$(stat --printf="%s" ${tempdir}/sig)"
 test "$size" -eq "64"
 
+#
+# Test that the keys with empty PIN are useable
+#
+pkcs11_tool --token-label="empty-pin" --list-objects
+# The Private Key Objects are enumerated without login
+pkcs11_tool --token-label="empty-pin" --list-objects | grep 'Private Key Object'
+
+echo "testdata">${tempdir}/data
+pkcs11_tool --sign --token-label="empty-pin" --id="7273615f6b6579" \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism SHA256-RSA-PKCS
+
+size="$(stat --printf="%s" ${tempdir}/sig)"
+test "$size" -eq "256"
+
+echo "testdata">${tempdir}/data
+pkcs11_tool --sign --token-label="empty-pin" --id="6563635f6b6579" \
+            --input-file ${tempdir}/data --output-file ${tempdir}/sig \
+            --mechanism ECDSA-SHA1
+
+size="$(stat --printf="%s" ${tempdir}/sig)"
+test "$size" -eq "64"
+
 exit 0

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -21,8 +21,8 @@
 #include "ssl_util.h"
 #include "utils.h"
 
-/* 3 in db tokens + 1 uninitialized token */
-#define TOKEN_COUNT (3 + 1)
+/* 4 in db tokens + 1 uninitialized token */
+#define TOKEN_COUNT (4 + 1)
 
 #define GOOD_USERPIN "myuserpin"
 #define GOOD_SOPIN   "mysopin"

--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -54,7 +54,7 @@ class NewKeyCommandBase(Command):
             '--hierarchy-auth',
             help='The hierarchyauth, required for transient pobjects.\n',
             default='')
-        pinopts = group_parser.add_mutually_exclusive_group(required=True)
+        pinopts = group_parser.add_mutually_exclusive_group()
         pinopts.add_argument('--sopin', help='The Administrator pin.\n'),
         pinopts.add_argument('--userpin', help='The User pin.\n'),
 
@@ -178,6 +178,14 @@ class NewKeyCommandBase(Command):
                 token = db.gettoken(label)
                 pobjectid = token['pid']
                 pobj = db.getprimary(pobjectid)
+
+                if userpin is None and sopin is None:
+                    # Use empty PIN if the token has an empty user PIN
+                    token_config = yaml.safe_load(io.StringIO(token['config']))
+                    if token_config.get('empty-user-pin'):
+                        userpin = ''
+                    else:
+                        sys.exit('error: at least one of the arguments --sopin --userpin is required')
 
                 sealobjects = db.getsealobject(token['id'])
 


### PR DESCRIPTION
Using password-less SSH keys is a nice feature, which can be achieved in PKCS#11 by not setting `CKF_LOGIN_REQUIRED` in token information.

The information whether a PIN is empty or not is stored in a new attribute of the token configuration, named `empty-user-pin`. This attribute is set when `tpm2_ptool addtoken` is used with `--userpin=""` and it is updated when users change their PIN using `tpm2_ptool changepin` or `tpm2_ptool initpin`.

In `src/pkcs11.c`, update `auth_min_ro_user` in order to accept using functions such as `C_SignInit` without the user being logged in, when the user PIN is empty.

Regarding operations related to the TPM, using no user PIN is implemented as using an empty PIN. So table `sealobjects` is still used to unseal the wrapping key. The main difference between "no PIN" and "a usual PIN" is that an empty string is combined with `userauthsalt` instead of a user PIN.

With this change, using OpenSSH client does not prompt for a PIN code,
when using a key stored in a token with an empty PIN.

Fixes: https://github.com/tpm2-software/tpm2-pkcs11/issues/629