### PR TITLE
configure: find the version number from the CHANGELOG if there is no tag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 AC_INIT([tpm2-pkcs11],
-  [m4_esyscmd_s([git describe --tags --always --dirty])],
+  m4_esyscmd_s([
+    (git describe --tags --always --dirty ; sed -n 's/^### \([0-9.]\+\) - .*/\1/p;' < CHANGELOG.md) | grep '\.' |head -n1
+  ]),
   [https://github.com/tpm2-software/tpm2-pkcs11/issues],
   [],
   [https://github.com/tpm2-software/tpm2-pkcs11])


### PR DESCRIPTION
When using git shallow clones (`git clone --depth=1`) or tarball downloads, `git describe --tags --always --dirty` does not give a proper version: it is either a git hash or an empty string.

When such cases occur, fallback to the version which is given in titles of `CHANGELOG.md`.

This fixes an issue discovered as part of https://github.com/tpm2-software/tpm2-pkcs11/pull/693