### PR TITLE
object: properly reject importing RSA key

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -1178,8 +1178,7 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
     assert(tok);
     attr_list *new_attrs = NULL;
 
-    if (key_type == CKK_RSA ||
-            clazz == CKO_PUBLIC_KEY) {
+    if (key_type == CKK_RSA && clazz == CKO_PUBLIC_KEY) {
         rv = handle_rsa_public(templ, count, &new_attrs);
     } else if (clazz == CKO_DATA) {
         rv = handle_data_object(tok, templ, count, &new_attrs);

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -82,6 +82,19 @@ pkcs11_tool --slot=1 -l --pin=myuserpin --write-object="$TPM2_PKCS11_STORE/cert.
     --type=cert --id=01 --label=device-cert
 echo "Certificate wrote"
 
+echo "Importing RSA pubkey"
+openssl genrsa -out "$TPM2_PKCS11_STORE/key-rsa-priv.pem" 2048
+openssl rsa -in "$TPM2_PKCS11_STORE/key-rsa-priv.pem" -pubout -out "$TPM2_PKCS11_STORE/key-rsa-pub.pem"
+pkcs11_tool --slot=1 -l --pin=myuserpin --write-object="$TPM2_PKCS11_STORE/key-rsa-pub.pem" --type=pubkey
+echo "RSA pubkey imported"
+
+echo "Trying to import RSA privkey (should fail)"
+if pkcs11_tool --slot=1 -l --pin=myuserpin --write-object="$TPM2_PKCS11_STORE/key-rsa-priv.pem" --type=privkey ; then
+    echo >&2 "Error: pkcs11_tool unexpectedly succeeded in importing a RSA private key"
+    exit 1
+fi
+echo "RSA privkey not imported"
+
 # Run the --test and ensure nothing breaks
 # Note that pkcs11-tools 0.15 have invalid OAEP params size of things like
 # mechanism->ulParameterLen: 4225.


### PR DESCRIPTION
A friend tried to import a private RSA key using pkcs11-tool and got a strange state where the key seemed to be incorrectly imported.

The following commands can be used to reproduce this use-case:

    openssl genrsa -out key-rsa.pem 2048
    pkcs11-tool --module src/.libs/libtpm2_pkcs11.so --login --pin=XXXX \
        --write-object key-rsa.pem --type privkey

The last command displays several warning messages but does not fail:

    WARNING: Using default attribute handler for 291, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x123
    WARNING: Using default attribute handler for 292, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x124
    WARNING: Using default attribute handler for 293, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x125
    WARNING: Using default attribute handler for 294, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x126
    WARNING: Using default attribute handler for 295, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x127
    WARNING: Using default attribute handler for 296, consider registering a handler
    WARNING: Guessing type for attribute, consider adding type info: 0x128
    Created private key:
    Private Key Object; RSA
    ...

In fact, a Public RSA key was just created in tpm2-pkcs11 store, and its attributes contain the private key (for example attribute `0x123` is `CKA_PRIVATE_EXPONENT`). This is unexpected.

Currently, importing private keys into a TPM using the PKCS#11 interface is not supported. This is supposed to be prevented by a check in `src/lib/object.c`:

    if (key_type == CKK_RSA ||
        clazz == CKO_PUBLIC_KEY) {
        rv = handle_rsa_public(templ, count, &new_attrs);
    } else if (clazz == CKO_DATA) {
        rv = handle_data_object(tok, templ, count, &new_attrs);
    } else if (clazz == CKO_CERTIFICATE) {
        rv = handle_cert_object(templ, count, &new_attrs);
    } else {
        LOGE("Can only create RSA Public key objects or"
                " data objects, CKA_CLASS(%lu), CKA_KEY_TYPE(%lu)",
                clazz, key_type);
        return CKR_ATTRIBUTE_VALUE_INVALID;
    }

... but the check was wrong. `key_type == CKK_RSA || clazz == CKO_PUBLIC_KEY` is true when the object is an RSA key OR it is a public key. So `handle_rsa_public` was called on the private key which was imported.

Fix this by checking `key_type == CKK_RSA && clazz == CKO_PUBLIC_KEY`.