### PR TITLE
LGTM: clone tpm2-tss and tpm2-tools repositories to fix the build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -12,18 +12,16 @@ extraction:
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir
-    - wget https://github.com/tpm2-software/tpm2-tss/archive/master.tar.gz
-    - tar xf master.tar.gz && rm master.tar.gz
-    - cd tpm2-tss-master
+    - git clone https://github.com/tpm2-software/tpm2-tss.git
+    - cd tpm2-tss
     - ./bootstrap
     - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc
     - make install
     - export PKG_CONFIG_PATH="$LGTM_WORKSPACE/installdir/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
     - export LD_LIBRARY_PATH="$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"
     - cd "$LGTM_WORKSPACE"
-    - wget https://github.com/tpm2-software/tpm2-tools/archive/master.tar.gz
-    - tar -xavf master.tar.gz && rm master.tar.gz
-    - cd "tpm2-tools-master"
+    - git clone https://github.com/tpm2-software/tpm2-tools.git
+    - cd "tpm2-tools"
     - ./bootstrap
     - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr"
     - make install


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tss/pull/2069 installing tpm2-tss from a snapshot of the master branch no longer works fine: even if `./configure` and `make install` work, there is a failure in the configure phase of tpm2-tools. Here is the build log from https://lgtm.com/projects/g/tpm2-software/tpm2-pkcs11/logs/rev/pr-ae3094acd9630566fa4cbea107ba5592740be8f9/lang:cpp/stage:Build%20master_06ca8f4f0d7d11f877cfe08a0a6d1f95f52ebee4

    [2021-06-08 21:13:44] [build-stderr] ++ wget https://github.com/tpm2-software/tpm2-tss/archive/master.tar.gz
    ...
    [2021-06-08 21:13:45] [build-stderr] ++ tar xf master.tar.gz
    [2021-06-08 21:13:45] [build-stderr] ++ rm master.tar.gz
    [2021-06-08 21:13:45] [build-stderr] ++ cd tpm2-tss-master
    [2021-06-08 21:13:45] [build-stderr] ++ ./bootstrap
    [2021-06-08 21:13:45] [build-stdout] Generating file lists: src_vars.mk
    [2021-06-08 21:13:49] [build-stderr] fatal: not a git repository (or any of the parent directories): .git
    [2021-06-08 21:13:49] [build-stderr] fatal: not a git repository (or any of the parent directories): .git
    [2021-06-08 21:13:49] [build-stderr] fatal: not a git repository (or any of the parent directories): .git
    ...
    [2021-06-08 21:16:18] [build-stderr] ++ cd /opt/work/lgtm-workspace
    [2021-06-08 21:16:18] [build-stderr] ++ wget https://github.com/tpm2-software/tpm2-tools/archive/master.tar.gz
    ...
    [2021-06-08 21:16:37] [build-stderr] ++ ./configure --prefix=/opt/work/lgtm-workspace/installdir/usr
    ...
    [2021-06-08 21:16:40] [build-stdout] checking for TSS2_FAPI... yes
    [2021-06-08 21:16:40] [build-stdout] checking for TSS2_FAPI_3_0... no
    [2021-06-08 21:16:40] [build-stdout] checking for TSS2_ESYS_3_0... no
    [2021-06-08 21:16:40] [build-stdout] checking for TSS2_ESYS_2_3... no
    [2021-06-08 21:16:40] [build-stderr] configure: error: Package requirements (tss2-esys >= 2.4.0) were not met:
    [2021-06-08 21:16:40] [build-stderr] Package dependency requirement 'tss2-esys >= 2.4.0' could not be satisfied.
    [2021-06-08 21:16:40] [build-stderr] Package 'tss2-esys' has version '', required version is '>= 2.4.0'

Fix this by cloning tpm2-tss completely. This is similar to the fix https://github.com/tpm2-software/tpm2-tools/pull/2763 .

While at it, also clone tpm2-tools as it also requires a git repository to compute its version (since 2017, commit https://github.com/tpm2-software/tpm2-tools/commit/2e8a07bc5e4a9d93d814fb6d8ce0e9e6cf9278b7)

Fixes: https://github.com/tpm2-software/tpm2-pkcs11/issues/696