### PR TITLE
tpm2_ptool: fix weird spaces in verify output

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_token.py
+++ b/tools/tpm2_pkcs11/commandlets_token.py
@@ -177,8 +177,8 @@ class VerifyCommand(Command):
                     tobjauth = wrapper.unwrap(encauth).decode()
 
                 verify_output['objects'].append({
-                    'id: ' : tobj['id'],
-                    'auth: ' : tobjauth,
+                    'id' : tobj['id'],
+                    'auth' : tobjauth,
                     'encauth' : encauth
                 })
 


### PR DESCRIPTION
The dict contained ': ' after the key, which isn't needed since YAML
will handle the conversion, drop it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>