### PR TITLE
Update docs/RELEASE

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,7 +1,8 @@
 # Release Information
 
 Releases shall be tagged following semantic version guidelines found at:
-  - http://semver.org/
+
+- <http://semver.org/>
 
 The general release process will be one of two models:
 
@@ -111,41 +112,24 @@ The steps, in order, required to make a release.
 
 - Send announcement on [mailing list](https://lists.01.org/mailman/listinfo/tpm2).
 
-
-## Historical Version Information
-
-Versions after v1.1.0 will no longer have the "v" prefix. Autoconf now sets
-the VERSION #define based on the output of git describe. See commit 2e8a07bc
-for the details.
-
-Version tags after v1.1.0 shall be signed.
-
 ## Verifying git signature
 
-Valid known public keys can be reached by
-referencing the annotated tags listed below:
+Valid known public keys can be reached via a PGP public keyring server like:
 
-- william-roberts-pub
-- javier-martinez-pub
-- joshua-lock-pub
-- idesai-pub
+- <http://keyserver.pgp.com/vkd/GetWelcomeScreen.event>
+- <https://keyserver.ubuntu.com/>
 
-or via a PGP public keyring server like:
-  - http://keyserver.pgp.com/vkd/GetWelcomeScreen.event
+**Example** for William Roberts (key [`5B482B8E3E19DA7C978E1D016DE2E9078E1F50C1`](https://keyserver.ubuntu.com/pks/lookup?search=0x5B482B8E3E19DA7C978E1D016DE2E9078E1F50C1&fingerprint=on&op=index):
 
-Import the key into your keyring:
-```
-$ git show [annotated-tag-name] | gpg --import
-```
-
-**Example**:
-```
-$ git show william-roberts-pub | gpg --import
+```bash
+curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x5b482b8e3e19da7c978e1d016de2e9078e1f50c1' | \
+  gpg --import
 ```
 
 Verify the release tag:
-```
-$ git tag --verify [signed-tag-name]
+
+```bash
+git tag --verify [signed-tag-name]
 ```
 
 # Local Release Configuration
@@ -157,18 +141,18 @@ Below you will find information how to configure your machine locally to conduct
 Signing keys should have these four properties going forward:
   - belong to a project maintainer.
   - be discoverable using a public GPG key server.
-  - be [associated]((https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/))
+  - be [associated](https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/)
     with the maintainers GitHub account.
   - be discoverable via an annotated tag within the repository itself.
 
 Ensure you have a key set up:
-```
-$ gpg --list-keys
+```bash
+gpg --list-keys
 ```
 
 If you don't generate one:
-```
-$ gpg --gen-key
+```bash
+gpg --gen-key
 ```
 
 Add that key to the gitconfig:
@@ -188,7 +172,7 @@ git push origin [your-name-here]-pub
 ```
 
 Make sure you publish your key by doing:
-  - http://keyserver.pgp.com/vkd/GetWelcomeScreen.event
+  - <http://keyserver.pgp.com/vkd/GetWelcomeScreen.event>
     - Select "Publish your key".
     - Select "Key block"
     - Copy and paste the output of `gpg --armor --export <key-id>`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,11 +50,11 @@ For a final release, change the version to the final release version (i.e: 3.0.5
 update the date. The commit for this change will be tagged as $version.
 
 ## Testing
-The tools code **MUST** pass the Travis CI testing and have a clean
+
+The tools code **MUST** pass the Github Actions testing and have a clean
 Coverity scan result performed on every release. The CI testing not
 only tests for valid outputs, but also runs tests uses clang's ASAN
 feature to detect memory corruption issues.
-  - BUG: Reconfigure Coverity: https://github.com/tpm2-software/tpm2-tools/issues/1727
 
 ## Release Checklist
 
@@ -62,8 +62,8 @@ The steps, in order, required to make a release.
 
 - Ensure current HEAD is pointing to the last commit in the release branch.
 
-- Ensure [Travis](https://travis-ci.org/tpm2-software/tpm2-tools) has conducted a passing build of
-  HEAD.
+- Ensure [GitHub Actions](https://github.com/tpm2-software/tpm2-pkcs11/actions)
+  has conducted a passing build of HEAD.
 
 - Update version and date information in [CHANGELOG.md](CHANGELOG.md) **and** commit.
 
@@ -90,10 +90,11 @@ The steps, in order, required to make a release.
   git push origin <tag-name>
   ```
 
-- Verify that the Travis CI build passes. **Note**: Travis will have two builds, one for the
-  push to master and one for the tag push. Both should succeed.
+- Verify that the GitHub Actions build passes.
+  **Note**: GitHub Actions will have two builds, one for the push to master and one for the tag push.
+  Both should succeed.
 
-- Create a release on [Github](https://github.com/tpm2-software/tpm2-tools/releases),
+- Create a release on [Github](https://github.com/tpm2-software/tpm2-pkcs11/releases),
   using the `<release-tag>` uploaded. If it is a release candidate, ensure you check the "pre-release"
   box on the GitHub UI. Use the [CHANGELOG.md](CHANGELOG.md) contents for
   that release as the message for the GitHub release. **Add the dist tarball and signature file


### PR DESCRIPTION
* Replace references to Travis CI with Github Actions
* Update instructions to verify git signature (following https://github.com/tpm2-software/tpm2-pkcs11/issues/722)
* and some other fixes to the Markdown syntax