### PR TITLE
tools: fix try/finally scope around os.write

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_keys.py
+++ b/tools/tpm2_pkcs11/commandlets_keys.py
@@ -640,14 +640,16 @@ class LinkCommand(NewKeyCommandBase):
         ctx = tpm2.load(pobj_handle, pobjauth, privbytes, pubbytes)
         tertiarypubdata, _ = tpm2.readpublic(ctx, False)
 
+        privfd, tertiarypriv = mkstemp(prefix='', suffix='.priv', dir=d)
         try:
-            privfd, tertiarypriv = mkstemp(prefix='', suffix='.priv', dir=d)
-            pubfd, tertiarypub = mkstemp(prefix='', suffix='.pub', dir=d)
-
             os.write(privfd, privbytes)
-            os.write(pubfd, pubbytes)
         finally:
             os.close(privfd)
+
+        pubfd, tertiarypub = mkstemp(prefix='', suffix='.pub', dir=d)
+        try:
+            os.write(pubfd, pubbytes)
+        finally:
             os.close(pubfd)
 
         return (tertiarypriv, tertiarypub, tertiarypubdata)

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -301,8 +301,10 @@ class Tpm2(object):
                 encryption_algorithm=enc_alg)
 
             pem_priv_fd, pem_priv_name = mkstemp(prefix='', suffix='.privpem', dir=self._tmp)
-            os.write(pem_priv_fd, pem_key)
-            os.close(pem_priv_fd)
+            try:
+                os.write(pem_priv_fd, pem_key)
+            finally:
+                os.close(pem_priv_fd)
             privkey = pem_priv_name
         elif alg is None:
             # Guess the key algorithm from the PEM header


### PR DESCRIPTION
Doing:

    try:
        privfd, tertiarypriv = mkstemp(prefix='', suffix='.priv', dir=d)
        # ...
    finally:
        os.close(privfd)

can lead to issues when the call to `mkstemp` raises an exception, as `privfd` does not exist yet. Fix this issue by moving `mkstemp` out of the `try`/`finally` block.

When writing both the private and public files, in class `LinkCommand`, this change leads to intricated (and hard-to-understand) `try`/`finally` blocks. Reduce the complexity of the code by writing the files one after another.

Finally, introduce a `try`/`finally` block around an `os.write` call in function `importkey`, as it makes sense if the operating system raises an exception while writing the file (for example when the storage is full).