### PR TITLE
tpm2_ptools: do not re-encode the signed data when importing a certificate

### DIFF
--- a/test/integration/fixtures/ossl-req-ca.cnf
+++ b/test/integration/fixtures/ossl-req-ca.cnf
@@ -1,0 +1,13 @@
+# OpenSSL configuration for generating CA certificates
+[req]
+default_bits = 2048
+req_extensions = ca_ext
+distinguished_name = ca_dn
+
+[ca_dn]
+commonName = "Test CA"
+
+[ca_ext]
+keyUsage = critical,keyCertSign,cRLSign
+basicConstraints = critical,CA:true
+subjectKeyIdentifier = hash

--- a/test/integration/fixtures/ossl-req-cert.cnf
+++ b/test/integration/fixtures/ossl-req-cert.cnf
@@ -1,0 +1,13 @@
+# OpenSSL configuration for generating a certificate signed by a CA
+[req]
+default_bits = 2048
+req_extensions = cert_ext
+distinguished_name = dn
+
+[dn]
+commonName = "Test Certificate"
+
+[cert_ext]
+keyUsage = critical,digitalSignature
+basicConstraints = critical,CA:false
+subjectKeyIdentifier = hash

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -23,7 +23,7 @@ pkcs11_tool() {
 }
 
 echo "Finding cert"
-id=$(pkcs11_tool --label label --list-objects --type cert | grep 'ID:' | cut -d':' -f2- | sed s/' '//g)
+id=$(pkcs11_tool --label label --list-objects --type cert | grep 'ID:' | head -n 1 | cut -d':' -f2- | sed s/' '//g)
 echo "Found cert: $id"
 
 # a public key with a cert label should exist

--- a/tools/tpm2_pkcs11/utils.py
+++ b/tools/tpm2_pkcs11/utils.py
@@ -253,8 +253,6 @@ def pemcert_to_attrs(certpath):
     cert = derdecoder.decode(bercert, asn1Spec=rfc2459.Certificate())[0]
     c = cert['tbsCertificate']
 
-    # print(cert.prettyPrint())
-
     h = binascii.hexlify
     d = derencoder.encode
 


### PR DESCRIPTION
When using `tpm2_ptool addcert`, several users experienced issues because the signed data of the certificate was re-encoded when being added to the database. More precisely, the encoded certificate data is encoded using a BER encoder which encodes booleans using 1 of True (cf. https://github.com/etingof/pyasn1/blob/v0.4.8/pyasn1/codec/ber/encoder.py#L164). But in DER, the encoding of "True" is 0xff, and changing the signed data made the signature of the certificate no longer valid.
    
To fix this issue:
    
- Directly use the result of `pem.readPemFromFile(f)` in attribute `CKA_VALUE`: this is directly the encoded form of the certificate.
- Remove `pyasn1.codec.ber`, as this encoder is no longer used.
- Rename the DER decoder from `decoder` to `derdecoder` and the encoder from `derenc` to `derencoder`, to make the code easier to read.

Also add a test which imports a certificate with boolean values and ensure that the signature is still valid after the import.

While at it, a few other things were modified, which are described in the commit descriptions.

This should fix https://github.com/tpm2-software/tpm2-pkcs11/issues/700 and probably also https://github.com/tpm2-software/tpm2-pkcs11/issues/631