### PR TITLE
Fix C_Encrypt() and C_Decrypt() when using CKM_AES_CBC_PAD

### DIFF
--- a/src/lib/encrypt.c
+++ b/src/lib/encrypt.c
@@ -365,8 +365,20 @@ CK_RV decrypt_oneshot_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, CK
 
     bool is_buffer_too_small = false;
     CK_ULONG tmp_len = *data_len;
+    CK_RV rv = CKR_GENERAL_ERROR;
 
-    CK_RV rv = decrypt_update_op(ctx, supplied_opdata, encrypted_data, encrypted_data_len,
+    if (!supplied_opdata) {
+        encrypt_op_data *opdata = NULL;
+        rv = session_ctx_opdata_get(ctx, operation_decrypt, &opdata);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+        if (!opdata->use_sw) {
+            tpm_opdata_reset(opdata->cryptopdata.tpm_opdata);
+        }
+    }
+
+    rv = decrypt_update_op(ctx, supplied_opdata, encrypted_data, encrypted_data_len,
             data, &tmp_len);
     if (rv != CKR_OK && rv != CKR_BUFFER_TOO_SMALL) {
         return rv;
@@ -395,8 +407,20 @@ CK_RV encrypt_oneshot_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, CK
 
     bool is_buffer_too_small = false;
     CK_ULONG tmp_len = *encrypted_data_len;
+    CK_RV rv = CKR_GENERAL_ERROR;
 
-    CK_RV rv = encrypt_update_op (ctx, supplied_opdata, data, data_len, encrypted_data, &tmp_len);
+    if (!supplied_opdata) {
+        encrypt_op_data *opdata = NULL;
+        rv = session_ctx_opdata_get(ctx, operation_encrypt, &opdata);
+        if (rv != CKR_OK) {
+            return rv;
+        }
+        if (!opdata->use_sw) {
+            tpm_opdata_reset(opdata->cryptopdata.tpm_opdata);
+        }
+    }
+
+    rv = encrypt_update_op (ctx, supplied_opdata, data, data_len, encrypted_data, &tmp_len);
     if (rv != CKR_OK && rv != CKR_BUFFER_TOO_SMALL) {
         return rv;
     }

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -2159,6 +2159,10 @@ CK_RV tpm_hmac_sha512_get_opdata(mdetail *mdtl,
     return CKR_OK;
 }
 
+void tpm_opdata_reset(tpm_op_data *tpm_enc_data) {
+    tpm_enc_data->sym.prev.len = 0;
+}
+
 void tpm_opdata_free(tpm_op_data **opdata) {
 
     if (opdata) {

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -133,6 +133,7 @@ CK_RV tpm_hmac_sha256_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR 
 CK_RV tpm_hmac_sha384_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata);
 CK_RV tpm_hmac_sha512_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata);
 
+void tpm_opdata_reset(tpm_op_data *opdata);
 void tpm_opdata_free(tpm_op_data **opdata);
 
 CK_RV tpm_encrypt(crypto_op_data *opdata, CK_BYTE_PTR ptext, CK_ULONG ptextlen, CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen);


### PR DESCRIPTION
When using pkcs11 it is a common pattern to encrypt data like this:

  CK_ULONG_PTR out_len;
  // find the output length
  C_Encrypt(h, in, in_len, NULL, out_len);
  // allocate buffer with out_len bytes and do the encryption

The actual encryption is done by either a single call to C_Encrypt() or
multiple calls to C_EncryptUpdate(). In both cases we use common
functions which keep internal state needed for CKM_AES_CBC_PAD.
The problem is that C_Encrypt() modifies the state even in the case when
it is used for finding the output length. This causes a subsequent call
to C_Encrypt() for the actual encryption to fail.

The same problem exist for C_Decrypt().

This patch fixes the above problems by clearing the internal state at
the beginning of C_Encrypt/C_Decrypt.

Fixes: #730