### PR TITLE
utils: do not dereference newsalthex if it is NULL

### DIFF
--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -61,8 +61,10 @@ out:
 
     if (rv != CKR_OK) {
         twist_free(*newauthhex);
-        twist_free(*newsalthex);
-        *newsalthex = NULL;
+        if (newsalthex) {
+            twist_free(*newsalthex);
+            *newsalthex = NULL;
+        }
     }
 
     if (allocated_pin_to_use) {


### PR DESCRIPTION
clang's static analyzer reports a possible dereference of NULL pointer in `utils_setup_new_object_auth` when `newsalthex = NULL`, which is the case when this function is called from:

    static inline CK_RV utils_new_random_object_auth(twist *newauthhex) {
        return utils_setup_new_object_auth(NULL, newauthhex, NULL);
    }

Check that the pointer is not NULL before dereferencing it.