### PR TITLE
When using pkcs11 it is a common pattern to encrypt data like this:

### DIFF
--- a/src/lib/encrypt.h
+++ b/src/lib/encrypt.h
@@ -49,9 +49,10 @@ static inline CK_RV encrypt_update (session_ctx *ctx, unsigned char *part, unsig
     return encrypt_update_op (ctx, NULL, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV encrypt_final_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len);
+CK_RV encrypt_final_ex (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len, bool is_oneshot);
+
 static inline CK_RV encrypt_final (session_ctx *ctx, unsigned char *last_encrypted_part, unsigned long *last_encrypted_part_len) {
-    return encrypt_final_op (ctx, NULL, last_encrypted_part, last_encrypted_part_len);
+    return encrypt_final_ex (ctx, NULL, last_encrypted_part, last_encrypted_part_len, false);
 }
 
 CK_RV decrypt_init_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE key);
@@ -64,9 +65,10 @@ static inline CK_RV decrypt_update (session_ctx *ctx, unsigned char *part, unsig
         return decrypt_update_op (ctx, NULL, part, part_len, encrypted_part, encrypted_part_len);
 }
 
-CK_RV decrypt_final_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_part, unsigned long *last_part_len);
+CK_RV decrypt_final_ex(session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *last_part, unsigned long *last_part_len, bool is_oneshot);
+
 static inline CK_RV decrypt_final (session_ctx *ctx,  unsigned char *last_part, unsigned long *last_part_len) {
-    return decrypt_final_op (ctx, NULL, last_part, last_part_len);
+    return decrypt_final_ex (ctx, NULL, last_part, last_part_len, false);
 }
 
 CK_RV decrypt_oneshot_op (session_ctx *ctx, encrypt_op_data *supplied_opdata, unsigned char *encrypted_data, unsigned long encrypted_data_len, unsigned char *data, unsigned long *data_len);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -2159,6 +2159,12 @@ CK_RV tpm_hmac_sha512_get_opdata(mdetail *mdtl,
     return CKR_OK;
 }
 
+void tpm_opdata_reset(tpm_op_data *opdata) {
+    if (opdata) {
+        opdata->sym.prev.len = 0;
+    }
+}
+
 void tpm_opdata_free(tpm_op_data **opdata) {
 
     if (opdata) {

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -133,6 +133,7 @@ CK_RV tpm_hmac_sha256_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR 
 CK_RV tpm_hmac_sha384_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata);
 CK_RV tpm_hmac_sha512_get_opdata(mdetail *mdtl, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **outdata);
 
+void tpm_opdata_reset(tpm_op_data *opdata);
 void tpm_opdata_free(tpm_op_data **opdata);
 
 CK_RV tpm_encrypt(crypto_op_data *opdata, CK_BYTE_PTR ptext, CK_ULONG ptextlen, CK_BYTE_PTR ctext, CK_ULONG_PTR ctextlen);


### PR DESCRIPTION
CK_ULONG_PTR out_len;
// find the output length
C_Encrypt(h, in, in_len, NULL, out_len);
// allocate buffer with out_len bytes and do the encryption

The actual encryption is done by either a single call to C_Encrypt() or
multiple calls to C_EncryptUpdate(). In both cases we use common
functions which keep internal state needed for CKM_AES_CBC_PAD.
The problem is that C_Encrypt() modifies the state even in the case when
it is used for finding the output length. This causes a subsequent call
to C_Encrypt() for the actual encryption to fail.

The same problem exist for C_Decrypt().

This patch fixes the above problems by clearing the internal state at
the beginning of C_Encrypt/C_Decrypt.

Fixes: #730

Started-by: Radoslav Gerganov <rgerganov@vmware.com>
Modified-by: William Roberts <william.c.roberts@intel.com>
Signed-off-by: William Roberts <william.c.roberts@intel.com>