### PR TITLE
Do not use sequence to calculate expected ECDSA signature length

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -127,13 +127,8 @@ CK_RV tobject_get_min_buf_size(tobject *tobj, CK_MECHANISM_PTR mech, size_t *max
         }
 
         /*
-         * Math below is based off of ECDSA signature:
-         * SEQUENCE (2 elem)
-         *  INTEGER R
-         *  INTEGER S
-         *
-         *  Integers R and S are bounded by keysize in bytes, followed by their
-         *  respective headers(2bytes) followed by the SEQUENCE header(2 bytes)
+         * The signature output from a PKCS#11 ECDSA operation is the raw R,S output
+         * which is twice the size of the keysize
          */
         unsigned keysize;
 
@@ -158,21 +153,7 @@ CK_RV tobject_get_min_buf_size(tobject *tobj, CK_MECHANISM_PTR mech, size_t *max
             return CKR_CURVE_NOT_SUPPORTED;
         }
 
-        /* R and S are INTEGER objects with a header and len byte */
-        static const unsigned INT_HDR = 2U;
-        /* R and S are combined in a SEQUENCE object with a header and len byte */
-        static const unsigned SEQ_HDR = 2U;
-        /* an R or S with a high bit set needs an extra nul byte so it's not negative (twos comp)*/
-        static const unsigned EXTRA = 1U;
-
-        unsigned tmp = 0;
-        safe_add(tmp, keysize, INT_HDR);
-        safe_adde(tmp, EXTRA);
-        safe_mule(tmp, 2);
-
-        tmp += SEQ_HDR;
-
-        *maxsize = tmp;
+        *maxsize = keysize * 2;
 
         return CKR_OK;
     }

--- a/test/integration/pkcs-sign-verify.int.c
+++ b/test/integration/pkcs-sign-verify.int.c
@@ -423,16 +423,10 @@ static void test_sign_verify_CKM_ECDSA(void **state) {
     rv = C_Sign(session, sha256_msg_hash, sizeof(sha256_msg_hash), NULL,
             &siglen);
     assert_int_equal(rv, CKR_OK);
-    /* The signature comes back as DER encoded R + S parts of the signature.
-     * R + S is 2 times the curve size in bytes (so 64 for P256) but we're not
-     * returning that, but the DER encoded format that tools expect.
-     * Since the length of DER encoding is dependent on the encoded value
-     * (e.g. leading zero if negative), the output size is not stable.
-     * Thus calling C_Sign for size must return the maximum length of the DER
-     * encoded value, which is (2+1+keylength) * 2 + 2. So for P256 = 72
-     * the actual signature size may be smaller.
+    /* The signature comes back as R + S parts of the signature.
+     * R + S is 2 times the curve size in bytes (so 64 for P256)
      */
-    assert_int_equal(siglen, 72);
+    assert_int_equal(siglen, 64);
     CK_ULONG tmp_len = siglen;
 
     rv = C_Sign(session, sha256_msg_hash, sizeof(sha256_msg_hash), sig,


### PR DESCRIPTION
This should fix #741.