### PR TITLE
VERSION: add version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ config.h.in
 test/unit/test_db
 
 *~
+
+#autogen VERSION file
+VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,8 @@ EXTRA_DIST = \
     docs \
     test/integration/scripts \
     misc/p11-kit \
-    tools
+    tools \
+    VERSION
 
 # Generate the AUTHORS file from git log
 AUTHORS :

--- a/bootstrap
+++ b/bootstrap
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 set -e
 
+# Generate a VERSION file that is included in the dist tarball to avoid needed git
+# when calling autoreconf in a release tarball.
+git describe --tags --always --dirty > VERSION
+
 # generate list of source files for use in Makefile.am
 # if you add new source files, you must run ./bootstrap again
 src_listvar () {

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 AC_INIT([tpm2-pkcs11],
-  [m4_esyscmd_s([git describe --tags --always --dirty])],
+  [m4_esyscmd_s([cat ./VERSION])],
   [https://github.com/tpm2-software/tpm2-pkcs11/issues],
   [],
   [https://github.com/tpm2-software/tpm2-pkcs11])


### PR DESCRIPTION
Generate the version file with bootstrap and include in the DIST tarball
so endusers can call autoreconf on a dist tarball which doesn't have
git. This alleviates git describe errors on release tarballs in the
autoreconf case

Signed-off-by: William Roberts <william.c.roberts@intel.com>