### PR TITLE
test: add test for C_InitToken SRK with owner password

### DIFF
--- a/test/integration/pkcs11-tool-init.sh.nosetup
+++ b/test/integration/pkcs11-tool-init.sh.nosetup
@@ -48,6 +48,11 @@ echo "Found uninitialized token"
 pkcs11_tool -I
 pkcs11_tool -T
 
+# Their is no SRK so it should attempt to make an SRK, so lets test it with an owner
+# hierarchy password set to make sure that works.
+tpm2_changeauth -cowner mynewpass
+export TPM2_PKCS11_OWNER_AUTH=mynewpass
+
 echo "Initializing token"
 pkcs11_tool --slot-index=0 --init-token --label=mynewtoken --so-pin=mynewsopin
 echo "Token initialized"


### PR DESCRIPTION
Add a test to ensure that an SRK created with C_InitToken with an Owner
Hierarchy password set works.

Related-to: #777

Signed-off-by: William Roberts <william.c.roberts@intel.com>