### PR TITLE
Modifications for not reading objects into token at C_Initialize, but everytime C_FindObjectInit is called

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -27,3 +27,5 @@ fi
 echo "echo changing to $DOCKER_BUILD_DIR"
 # Change to the docker build dir
 cd $DOCKER_BUILD_DIR
+
+git config --global --add safe.directory "$DOCKER_BUILD_DIR"

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -225,7 +225,7 @@ error:
     return rc;
 }
 
-int init_tobjects(token *tok) {
+WEAK DEBUG_VISIBILITY int init_tobjects(token *tok) {
     return __real_init_tobjects(tok);
 }
 

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -225,7 +225,7 @@ error:
     return rc;
 }
 
-WEAK DEBUG_VISIBILITY int init_tobjects(token *tok) {
+int init_tobjects(token *tok) {
     return __real_init_tobjects(tok);
 }
 
@@ -633,11 +633,6 @@ CK_RV db_get_tokens(token *tok, size_t *len) {
         }
 
         rc = init_sealobjects(t->id, &t->esysdb.sealobject);
-        if (rc != SQLITE_OK) {
-            goto error;
-        }
-
-        rc = init_tobjects(t);
         if (rc != SQLITE_OK) {
             goto error;
         }

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -72,7 +72,7 @@ CK_RV db_update_token_config(token *tok);
 
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
-int init_tobjects(token *tok);
+WEAK DEBUG_VISIBILITY int init_tobjects(token *tok);
 
 /* Debug testing */
 #ifdef TESTING

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -72,7 +72,7 @@ CK_RV db_update_token_config(token *tok);
 
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
-WEAK DEBUG_VISIBILITY int init_tobjects(token *tok);
+WEAK int init_tobjects(token *tok);
 
 /* Debug testing */
 #ifdef TESTING

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -85,7 +85,6 @@ int get_blob(sqlite3_stmt *stmt, int i, twist *blob);
 tobject *db_tobject_new(sqlite3_stmt *stmt);
 tobject *__real_db_tobject_new(sqlite3_stmt *stmt);
 int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj);
-int init_tobjects(token *tok);
 int __real_init_tobjects(token *tok);
 CK_RV convert_pobject_v3_to_v4(pobject_v3 *old_pobj, pobject_v4 *new_pobj);
 CK_RV db_add_pobject_v4(sqlite3 *updb, pobject_v4 *new_pobj);

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -72,6 +72,8 @@ CK_RV db_update_token_config(token *tok);
 
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
+int init_tobjects(token *tok);
+
 /* Debug testing */
 #ifdef TESTING
 #include <stdio.h>

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -310,8 +310,7 @@ static CK_RV do_match_set(tobject_match_list *match_cur, tobject *tobj) {
 }
 
 CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count) {
-    int rc;
-
+  
     // if count is 0 template is not used and all objects are requested so templ can be NULL.
     if (count > 0) {
         check_pointer(templ);
@@ -338,7 +337,7 @@ CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count)
 
     session_ctx_delete_tobject_list(ctx);
 
-    rc = init_tobjects(tok);
+    int rc = init_tobjects(tok);
     if (rc != SQLITE_OK) {
        goto out;
     }

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -310,6 +310,7 @@ static CK_RV do_match_set(tobject_match_list *match_cur, tobject *tobj) {
 }
 
 CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count) {
+    int rc;
 
     // if count is 0 template is not used and all objects are requested so templ can be NULL.
     if (count > 0) {
@@ -334,6 +335,13 @@ CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count)
 
     token *tok = session_ctx_get_token(ctx);
     assert(tok);
+
+    session_ctx_delete_tobject_list(ctx);
+
+    rc = init_tobjects(tok);
+    if (rc != SQLITE_OK) {
+       goto out;
+    }
 
     if (!tok->tobjects.head) {
         LOGV("Token %i contains no objects.", tok->id);

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -175,6 +175,11 @@ void session_ctx_opdata_clear(session_ctx *ctx) {
     session_ctx_opdata_set(ctx, operation_none, NULL, NULL, NULL);
 }
 
+void session_ctx_delete_tobject_list(session_ctx *ctx)
+{
+   token_delete_tobject_list(ctx->tok);
+}
+
 static bool is_user(CK_USER_TYPE user) {
     return user == CKU_USER || user == CKU_CONTEXT_SPECIFIC;
 }

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -220,4 +220,6 @@ CK_RV session_ctx_get_info(session_ctx *ctx, CK_SESSION_INFO *info);
  */
 CK_RV session_ctx_tobject_authenticated(session_ctx *ctx);
 
+void session_ctx_delete_tobject_list(session_ctx *ctx);
+
 #endif /* SRC_PKCS11_SESSION_CTX_H_ */

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -109,6 +109,19 @@ void token_free_list(token **tok_ptr, size_t *ptr_len) {
     free(t);
 }
 
+void token_delete_tobject_list(token *tok)
+{
+   if (tok->tobjects.head) {
+      list *cur = &tok->tobjects.head->l;
+      while(cur) {
+         tobject *tobj = list_entry(cur, tobject, l);
+         cur = cur->next;
+         tobject_free(tobj);
+      }
+      tok->tobjects.head = tok->tobjects.tail = NULL;
+   }
+}
+
 WEAK CK_RV token_add_tobject_last(token *tok, tobject *t) {
 
     if (!tok->tobjects.tail) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -226,4 +226,6 @@ CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label)
 
 void pobject_config_free(pobject_config *c);
 
+void token_delete_tobject_list(token *tok);
+
 #endif /* SRC_TOKEN_H_ */


### PR DESCRIPTION
In order to keep the list in C_FindObjects up to date in case the DB has been updated externally (by tpm2_ptool), we now delete unconditionally the list of objects and read from the database everytime C_FindObjectInit is called.