### PR TITLE
ci: fix perms between clone and docker

### DIFF
--- a/.ci/docker-prelude.sh
+++ b/.ci/docker-prelude.sh
@@ -27,3 +27,5 @@ fi
 echo "echo changing to $DOCKER_BUILD_DIR"
 # Change to the docker build dir
 cd $DOCKER_BUILD_DIR
+
+git config --global --add safe.directory "$DOCKER_BUILD_DIR"


### PR DESCRIPTION
Docker runs in a root user container and the source code checkout is
done with some other UID. This causes git to complain its not a safe
directory so we need to mark it safe.

See the below link for details:
  - https://github.blog/2022-04-12-git-security-vulnerability-announced/

This issue is not relevant for our disposable containers so we can
safely ignore this.

Signed-off-by: William Roberts <william.c.roberts@intel.com>