### PR TITLE
C_FindObjects: init list to reload new objects

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -637,11 +637,6 @@ CK_RV db_get_tokens(token *tok, size_t *len) {
             goto error;
         }
 
-        rc = init_tobjects(t);
-        if (rc != SQLITE_OK) {
-            goto error;
-        }
-
         /* token initialized, bump cnt */
         cnt++;
     }

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -72,6 +72,8 @@ CK_RV db_update_token_config(token *tok);
 
 CK_RV db_update_tobject_attrs(unsigned id, attr_list *attrs);
 
+WEAK int init_tobjects(token *tok);
+
 /* Debug testing */
 #ifdef TESTING
 #include <stdio.h>
@@ -83,7 +85,6 @@ int get_blob(sqlite3_stmt *stmt, int i, twist *blob);
 tobject *db_tobject_new(sqlite3_stmt *stmt);
 tobject *__real_db_tobject_new(sqlite3_stmt *stmt);
 int init_pobject_v3_from_stmt(sqlite3_stmt *stmt, pobject_v3 *old_pobj);
-int init_tobjects(token *tok);
 int __real_init_tobjects(token *tok);
 CK_RV convert_pobject_v3_to_v4(pobject_v3 *old_pobj, pobject_v4 *new_pobj);
 CK_RV db_add_pobject_v4(sqlite3 *updb, pobject_v4 *new_pobj);

--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -335,6 +335,13 @@ CK_RV object_find_init(session_ctx *ctx, CK_ATTRIBUTE_PTR templ, CK_ULONG count)
     token *tok = session_ctx_get_token(ctx);
     assert(tok);
 
+    session_ctx_delete_tobject_list(ctx);
+
+    int rc = init_tobjects(tok);
+    if (rc != SQLITE_OK) {
+       goto out;
+    }
+
     if (!tok->tobjects.head) {
         LOGV("Token %i contains no objects.", tok->id);
         goto empty;

--- a/src/lib/session_ctx.c
+++ b/src/lib/session_ctx.c
@@ -175,6 +175,11 @@ void session_ctx_opdata_clear(session_ctx *ctx) {
     session_ctx_opdata_set(ctx, operation_none, NULL, NULL, NULL);
 }
 
+void session_ctx_delete_tobject_list(session_ctx *ctx)
+{
+   token_delete_tobject_list(ctx->tok);
+}
+
 static bool is_user(CK_USER_TYPE user) {
     return user == CKU_USER || user == CKU_CONTEXT_SPECIFIC;
 }

--- a/src/lib/session_ctx.h
+++ b/src/lib/session_ctx.h
@@ -220,4 +220,6 @@ CK_RV session_ctx_get_info(session_ctx *ctx, CK_SESSION_INFO *info);
  */
 CK_RV session_ctx_tobject_authenticated(session_ctx *ctx);
 
+void session_ctx_delete_tobject_list(session_ctx *ctx);
+
 #endif /* SRC_PKCS11_SESSION_CTX_H_ */

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -109,6 +109,26 @@ void token_free_list(token **tok_ptr, size_t *ptr_len) {
     free(t);
 }
 
+void token_delete_tobject_list(token *tok)
+{
+   if (tok->tobjects.head) {
+      list *cur = &tok->tobjects.head->l;
+      while(cur) {
+         tobject *tobj = list_entry(cur, tobject, l);
+         cur = cur->next;
+         if (tobj->tpm_handle) {
+             bool result = tpm_flushcontext(tok->tctx, tobj->tpm_handle);
+             assert(result);
+             UNUSED(result);
+             tobj->tpm_handle = 0;
+         }
+
+         tobject_free(tobj);
+      }
+      tok->tobjects.head = tok->tobjects.tail = NULL;
+   }
+}
+
 WEAK CK_RV token_add_tobject_last(token *tok, tobject *t) {
 
     if (!tok->tobjects.tail) {

--- a/src/lib/token.h
+++ b/src/lib/token.h
@@ -226,4 +226,6 @@ CK_RV token_init(token *t, CK_BYTE_PTR pin, CK_ULONG pin_len, CK_BYTE_PTR label)
 
 void pobject_config_free(pobject_config *c);
 
+void token_delete_tobject_list(token *tok);
+
 #endif /* SRC_TOKEN_H_ */


### PR DESCRIPTION
If the db is modified externally while an application has the db store open, new objects are not seen by the application becuase it occurs after the application has loaded the list of tobjects. To correct this, reload the list on every C_FindObjectsInit call.

Signed-off-by: jupana, Juan Narino <juanpablo.narino@ekinops.com>
Signed-off-by: William Roberts <william.c.roberts@intel.com>