### PR TITLE
Fix database upgrading

### DIFF
--- a/tools/tpm2_pkcs11/db.py
+++ b/tools/tpm2_pkcs11/db.py
@@ -394,7 +394,7 @@ class Db(object):
             hexblob = bytes.hex(blob)
 
             config = {
-                'persistent' : True,
+                'transient': False,
                 'esys-tr': hexblob
             }
 


### PR DESCRIPTION
There are two issues with database upgrading. 
During an upgrade of the database to version 4, the config key 'persistent' is added instead of 'transient', causing KeyError when using the upgraded database.
After upgrading, there is no way to revert the database. This is a problem when no error is raised during the upgrade, but the database is upgraded incorrectly, like in the previous issue. This also is a problem when an error is raised during the upgrade, and the original database file is overwritten with the new one anyway. 

This pull fixes both of those issues.

Fixes #793.