### PR TITLE
use github_token for ghcr login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
           - docker_image: ubuntu-22.04
             compiler: clang
     steps:
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check out repository
         uses: actions/checkout@v2
         with:
@@ -31,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"
     steps:
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check out repository
         uses: actions/checkout@v2
         with:
@@ -50,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"
     steps:
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check out repository
         uses: actions/checkout@v2
         with:
@@ -69,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'coverity_scan')
     steps:
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check out repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fix the error:
  docker: Error response from daemon: Head "https://ghcr.io/v2/tpm2-software/fedora-30/manifests/latest": unauthorized.

Signed-off-by: Vincent Jardin <vjardin@free.fr>