### PR TITLE
Minor FAPI cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AS_IF([test "x$esapi_sf" = "xyes"],
 
 AC_ARG_ENABLE(
   [fapi],
-  [AS_HELP_STRING([--with-fapi],
+  [AS_HELP_STRING([--enable-fapi],
     [enable or disable the fapi backend. Default is "auto" to autodetect])],
     [enable_fapi=$enableval],
     [enable_fapi=auto])

--- a/docs/FAPI.md
+++ b/docs/FAPI.md
@@ -11,7 +11,7 @@ code was implemented using the Enhanced System API (ESAPI) and for on disk stora
 ## Build Time
 
 At the time the package is built, it will detect tss2-fapi library and automatically configure it's inclusion into the tpm2-pkcs11 library. One can *explicitly* configure this
-with `--with-fapi=yes|no`.
+with `--enable-fapi=yes|no`.
 
 ## Run Time
 
@@ -23,8 +23,8 @@ You can take a few actions if you run into this issue:
 1. Ignore them, and optionally disable FAPI error logging:
     - `export TSS2_LOG=fapi+NONE`
 
-2. Reconfigure the package with `--with-fapi=no`:
-    - `./configure --with-fapi=no`
+2. Reconfigure the package with `--enable-fapi=no`:
+    - `./configure --enable-fapi=no`
 
 3. Provision FAPI using `tss2_provision`. See the tpm2-tools project for more information:
     - <https://github.com/tpm2-software/tpm2-tools/blob/master/man/tss2_provision.1.md>

--- a/src/lib/backend.c
+++ b/src/lib/backend.c
@@ -53,7 +53,9 @@ CK_RV backend_init(void) {
             LOGE(msg);
             return rv;
         }
-        LOGW(msg);
+        if (rv != CKR_FUNCTION_NOT_SUPPORTED) {
+            LOGW(msg);
+        }
     } else {
         fapi_init = true;
     }

--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -977,7 +977,8 @@ out:
 
 CK_RV backend_fapi_init(void) {
 
-	return CKR_OK;
+	LOGV("FAPI not enabled, failing init");
+	return CKR_FUNCTION_NOT_SUPPORTED;
 }
 
 CK_RV backend_fapi_destroy(void) {


### PR DESCRIPTION
This PR contains 2 minor FAPI cleanups

- Fix the help text to show enable-fapi rather than with-fapi to enable/disable the support
- Don't spit out a warning message about not being able to fetch from FAPI when it's not compiled in and it's not the selected backend