### PR TITLE
lib: ecdh1 derive: simple implementation for KDF null

### DIFF
--- a/Makefile-integration.am
+++ b/Makefile-integration.am
@@ -41,7 +41,8 @@ check_PROGRAMS += \
     test/integration/pkcs-crypt.int \
     test/integration/pkcs-keygen.int \
     test/integration/pkcs-session-state.int \
-    test/integration/pkcs-lockout.int
+    test/integration/pkcs-lockout.int \
+    test/integration/pkcs-ecdh.int
 
 # add test scripts
 check_SCRIPTS += $(integration_scripts)
@@ -96,6 +97,10 @@ test_integration_pkcs_crypt_int_SOURCES = test/integration/pkcs-crypt.int.c test
 test_integration_pkcs_keygen_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_keygen_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
 test_integration_pkcs_keygen_int_SOURCES = test/integration/pkcs-keygen.int.c test/integration/test.c
+
+test_integration_pkcs_ecdh_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+test_integration_pkcs_ecdh_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+test_integration_pkcs_ecdh_int_SOURCES = test/integration/pkcs-ecdh.int.c test/integration/test.c
 
 test_integration_pkcs_session_state_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
 test_integration_pkcs_session_state_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)

--- a/src/lib/attrs.c
+++ b/src/lib/attrs.c
@@ -979,6 +979,7 @@ static CK_RV ecc_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs) 
         CKM_ECDSA_SHA256,
         CKM_ECDSA_SHA384,
         CKM_ECDSA_SHA512,
+        CKM_ECDH1_DERIVE,
     };
 
     bool r = attr_list_add_int_seq(new_pub_attrs, CKA_ALLOWED_MECHANISMS,

--- a/src/lib/derive.c
+++ b/src/lib/derive.c
@@ -1,0 +1,263 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include "config.h"
+#include <assert.h>
+#include <stdlib.h>
+
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+
+#include "attrs.h"
+#include "backend.h"
+#include "checks.h"
+#include "derive.h"
+#include "digest.h"
+#include "encrypt.h"
+#include "log.h"
+#include "mech.h"
+#include "ssl_util.h"
+#include "session.h"
+#include "session_ctx.h"
+#include "token.h"
+#include "tpm.h"
+
+typedef struct sanity_check_data sanity_check_data;
+struct sanity_check_data {
+    size_t len;
+};
+
+CK_RV handle_token(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_BBOOL value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_BBOOL(attr, &value);
+
+    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV handle_class(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_OBJECT_CLASS value = 0;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_OBJECT_CLASS(attr, &value);
+
+    if (value != CKO_SECRET_KEY)
+        rv = CKR_ARGUMENTS_BAD;
+
+    LOGV("attr: name %s, \t\t val = %s", attr_get_name(attr->type), "CKO_SECRET_KEY");
+    return rv;
+}
+
+CK_RV handle_key_type(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_KEY_TYPE value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_KEY_TYPE(attr, &value);
+
+    if (value != CKK_GENERIC_SECRET)
+        rv = CKR_ARGUMENTS_BAD;
+
+    LOGV("attr: name %s,\t val = %s", attr_get_name(attr->type), "CKK_GENERIC_SECRET");
+    return rv;
+}
+
+CK_RV handle_sensitive(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    UNUSED(userdat);
+
+    LOGV("attr: name %s", attr_get_name(attr->type));
+    return CKR_OK;
+}
+
+CK_RV handle_extractable(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    UNUSED(userdat);
+
+    LOGV("attr: name %s", attr_get_name(attr->type));
+    return CKR_OK;
+}
+
+CK_RV handle_encrypt(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_BBOOL value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_BBOOL(attr, &value);
+
+    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV handle_decrypt(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_BBOOL value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_BBOOL(attr, &value);
+
+    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV handle_wrap(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_BBOOL value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_BBOOL(attr, &value);
+
+    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV handle_unwrap(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_BBOOL value;
+    UNUSED(userdat);
+    CK_RV rv = attr_CK_BBOOL(attr, &value);
+
+    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV handle_value_len(const CK_ATTRIBUTE_PTR attr, void* userdat) {
+    CK_ULONG value;
+    CK_RV rv = attr_CK_ULONG(attr, &value);
+
+    if (rv == CKR_OK) {
+        ((sanity_check_data*)userdat)->len = value;
+    }
+
+    LOGV("attr: name %s,\t val = 0x%lx", attr_get_name(attr->type), value);
+    return rv;
+}
+
+CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point */
+             CK_OBJECT_HANDLE tpm_key,   /* private key */
+             CK_ATTRIBUTE_PTR secret_template, CK_ULONG secret_template_count,
+             CK_OBJECT_HANDLE_PTR secret) { /* secret buffer in CKA_VALUE */
+    CK_RV rv = CKR_GENERAL_ERROR;
+
+    check_pointer(mechanism);
+
+    LOGV("mechanism: 0x%lx\n\thas_params: %s\n\tlen: %lu",
+         mechanism->mechanism,
+         mechanism->pParameter ? "yes" : "no", mechanism->ulParameterLen);
+
+    if (mechanism->mechanism != CKM_ECDH1_DERIVE)
+        return CKR_MECHANISM_INVALID;
+
+    if (session_ctx_opdata_is_active(ctx))
+        return CKR_OPERATION_ACTIVE;
+
+    token* tok = session_ctx_get_token(ctx);
+    assert(tok);
+
+    tobject* tobj = NULL;
+    rv = token_load_object(tok, tpm_key, &tobj);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    rv = object_mech_is_supported(tobj, mechanism);
+    if (rv != CKR_OK) {
+        tobject_user_decrement(tobj);
+        return rv;
+    }
+
+    /*  Validate the keysize against the one provided by the mechanism */
+    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_EC_PARAMS);
+    if (!a) {
+        LOGE("Expected tobject to have attribute CKA_EC_PARAMS");
+        return CKR_GENERAL_ERROR;
+    }
+
+    int nid = 0;
+    rv = ssl_util_params_to_nid(a, &nid);
+    if (rv != CKR_OK) {
+        return rv;
+    }
+
+    unsigned keysize;
+    switch (nid) {
+        case NID_X9_62_prime192v1:
+            keysize = 24;
+            break;
+        case NID_secp224r1:
+            keysize = 28;
+            break;
+        case NID_X9_62_prime256v1:
+            keysize = 32;
+            break;
+        case NID_secp384r1:
+            keysize = 48;
+            break;
+        case NID_secp521r1:
+            keysize = 66;
+            break;
+        default:
+            return CKR_CURVE_NOT_SUPPORTED;
+    }
+
+    /* 1. Get the public EC point to use in the derivation from the mechanism */
+    CK_ECDH1_DERIVE_PARAMS_PTR mecha_params;
+    SAFE_CAST(mechanism, mecha_params);
+
+    if (mecha_params->kdf != CKD_NULL) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /* 2. Uncompressed EC_POINT: is a DER OCTECT string of 04||x||y */
+    if (!mecha_params->public_data_len ||
+        (mecha_params->public_data_len - 1) != 2 * keysize) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    /* Validate the shared secret attributes */
+    static const attr_handler secret_check_handlers[] = {
+        { CKA_TOKEN, handle_token },
+        { CKA_CLASS, handle_class },
+        { CKA_KEY_TYPE, handle_key_type },
+        { CKA_SENSITIVE, handle_sensitive },
+        { CKA_EXTRACTABLE, handle_extractable },
+        { CKA_ENCRYPT, handle_encrypt },
+        { CKA_DECRYPT, handle_decrypt },
+        { CKA_WRAP, handle_wrap },
+        { CKA_UNWRAP, handle_unwrap },
+        { CKA_VALUE_LEN, handle_value_len },
+    };
+    sanity_check_data udata = { 0 };
+
+    rv = attr_list_raw_invoke_handlers(secret_template, secret_template_count,
+                                       secret_check_handlers,
+                                       ARRAY_LEN(secret_check_handlers),
+                                       &udata);
+    if (rv != CKR_OK) {
+        tobject_user_decrement(tobj);
+        return rv;
+    }
+
+    /* Get the shaed secret */
+    CK_BYTE* shared_secret = NULL;
+    rv = tpm_ec_ecdh1_derive(tok->tctx, tobj, /* EC private */
+                             mecha_params->public_data, /* EC point */
+                             mecha_params->public_data_len,
+                             &shared_secret, &udata.len);
+    if (rv != CKR_OK) {
+         tobject_user_decrement(tobj);
+         return rv;
+    }
+
+    CK_ATTRIBUTE shared_secret_attr = {
+        .ulValueLen = udata.len,
+        .pValue = shared_secret,
+        .type = CKA_VALUE,
+    };
+
+    /* Return the shared secret in a CKO_SECRET_KEY class object */
+    rv = object_create(ctx, secret_template, secret_template_count, secret);
+    if (rv != CKR_OK) {
+        tobject_user_decrement(tobj);
+        goto out;
+    }
+
+    rv = object_set_attributes(ctx, *secret, &shared_secret_attr, 1);
+    if (rv != CKR_OK) {
+        tobject_user_decrement(tobj);
+        goto out;
+    }
+
+out:
+    free(shared_secret);
+    return rv;
+}

--- a/src/lib/derive.h
+++ b/src/lib/derive.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifndef _SRC_LIB_DERIVE_H_
+#define _SRC_LIB_DERIVE_H_
+
+#include "pkcs11.h"
+#include "session_ctx.h"
+
+CK_RV derive(session_ctx *ctx,
+	     CK_MECHANISM *mechanism,
+	     CK_OBJECT_HANDLE tpm_key,
+	     CK_ATTRIBUTE_PTR secret_template,
+	     CK_ULONG secret_template_count,
+	     CK_OBJECT_HANDLE_PTR secret);
+#endif

--- a/src/lib/mech.c
+++ b/src/lib/mech.c
@@ -36,6 +36,7 @@ enum mechanism_flags {
     mf_aes           = 1 << 11,
     mf_force_synthetic = 1 << 12,
     mf_hmac          = 1 << 13,
+    mf_derive        = 1 << 14,
 };
 
 typedef struct mdetail_entry mdetail_entry;
@@ -106,6 +107,7 @@ static CK_RV rsa_pkcs_hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_lis
 static CK_RV rsa_pss_hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
 static CK_RV ecc_keygen_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
 static CK_RV ecdsa_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+static CK_RV ecdh1_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
 static CK_RV hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
 static CK_RV hmac_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
 static CK_RV rsa_pkcs_synthesizer(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs,
@@ -174,6 +176,8 @@ static const mdetail_entry _g_mechs_templ[] = {
     { .type = CKM_ECDSA_SHA256,    .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha256_get_halg, .get_digester = sha256_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha256_get_opdata },
     { .type = CKM_ECDSA_SHA384,    .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha384_get_halg, .get_digester = sha384_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha384_get_opdata },
     { .type = CKM_ECDSA_SHA512,    .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha512_get_halg, .get_digester = sha512_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha512_get_opdata },
+
+    { .type = CKM_ECDH1_DERIVE,    .flags = mf_derive | mf_ecc, .validator = ecdh1_validator },
 
     /* AES */
     { .type = CKM_AES_KEY_GEN, .flags = mf_is_keygen|mf_aes },
@@ -717,6 +721,20 @@ CK_RV ecdsa_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs) {
 
     /* this does not require an argument */
     if (mech->pParameter || mech->ulParameterLen) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    return CKR_OK;
+}
+
+CK_RV ecdh1_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs)
+{
+    UNUSED(attrs);
+    UNUSED(m);
+
+    CK_ECDH1_DERIVE_PARAMS *params = mech->pParameter;
+
+    if (!params || !mech->ulParameterLen) {
         return CKR_MECHANISM_PARAM_INVALID;
     }
 

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -122,6 +122,7 @@ CK_RV tpm_ec_ecdsa_sha1_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR m
 CK_RV tpm_ec_ecdsa_sha256_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_ec_ecdsa_sha384_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_ec_ecdsa_sha512_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, unsigned char *pubkey, size_t pubkey_len, unsigned char **psec, size_t *pseclen);
 
 CK_RV tpm_aes_cbc_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_aes_cfb_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <tss2/tss2_tpm2_types.h>
+
 #include "config.h"
 #include "log.h"
 #include "pkcs11.h"
@@ -127,6 +129,21 @@ CK_RV apply_pkcs7_pad(const CK_BYTE_PTR in, CK_ULONG inlen,
  *  The minor version of the library.
  */
 void parse_lib_version(const char *buf, CK_BYTE *major, CK_BYTE *minor);
+
+/**
+*
+* Given an uncompressed ECC point in DER (0x04||x||y) populate a TPM2B_ECC_POINT
+* @param from
+*  ECC point in uncompressed DER format (0x04||x||y)
+* @param to
+*  Pointer to the TPM2B_ECC_POINT to populate
+* @param len
+*  Length of the ECC point in uncompressed DER format
+* @return CK_RV
+*   CKR_ARGUMENTS_BAD if the uncompressed ECC point is invalid
+*   CKR_OK on success
+*/
+CK_RV utils_uncompressed_ecpoint_to_tpm2b(uint8_t* from, TPM2B_ECC_POINT* to, size_t len);
 
 /*
  * Work around bugs in clang not including the builtins, and when asan is enabled

--- a/src/pkcs11.c
+++ b/src/pkcs11.c
@@ -7,6 +7,7 @@
 
 #include "pkcs11.h"
 
+#include "derive.h"
 #include "digest.h"
 #include "encrypt.h"
 #include "key.h"
@@ -630,7 +631,7 @@ CK_RV C_UnwrapKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT
 }
 
 CK_RV C_DeriveKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE base_key, CK_ATTRIBUTE *templ, CK_ULONG attribute_count, CK_OBJECT_HANDLE *key) {
-    TOKEN_UNSUPPORTED;
+    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(derive, session, mechanism, base_key, templ, attribute_count, key);
 }
 
 CK_RV C_SeedRandom (CK_SESSION_HANDLE session, CK_BYTE_PTR seed, CK_ULONG seed_len) {

--- a/test/integration/pkcs-ecdh.int.c
+++ b/test/integration/pkcs-ecdh.int.c
@@ -1,0 +1,222 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/err.h>
+#include <assert.h>
+
+#include "test.h"
+
+#define ATTR(a, v, t) { a, &(t){v}, sizeof(t) }
+#define ATTR_VAR(a, v, len) { a, v, len }
+
+struct test_info {
+    CK_SESSION_HANDLE handle;
+    CK_SLOT_ID slot_id;
+};
+
+static test_info *test_info_new(void) {
+
+    test_info *ti = calloc(1, sizeof(*ti));
+    assert_non_null(ti);
+
+    /* Get the slots */
+    CK_SLOT_ID slots[6];
+    CK_ULONG count = ARRAY_LEN(slots);
+    CK_RV rv = C_GetSlotList(true, slots, &count);
+    assert_int_equal(rv, CKR_OK);
+
+    ti->slot_id = slots[0];
+
+    return ti;
+}
+
+static int test_setup(void **state) {
+
+    test_info *ti = test_info_new();
+
+    CK_RV rv = C_OpenSession(ti->slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION,
+            NULL, NULL, &ti->handle);
+    assert_int_equal(rv, CKR_OK);
+
+    *state = ti;
+
+    return 0;
+}
+
+static int test_teardown(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+
+    CK_RV rv = C_CloseAllSessions(ti->slot_id);
+    assert_int_equal(rv, CKR_OK);
+
+    free(ti);
+
+    return 0;
+}
+
+static void gen_ecc_keypair(CK_SESSION_HANDLE session, CK_BYTE id,
+                            CK_BYTE *curve, size_t curve_size,
+                            uint8_t *pubkey, size_t *pubkey_len) {
+
+    CK_MECHANISM mechanism = { CKM_EC_KEY_PAIR_GEN, NULL, 0 };
+    CK_ATTRIBUTE pub_template[] = {
+        ATTR(CKA_CLASS, CKO_PUBLIC_KEY, CK_OBJECT_CLASS),
+        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
+        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
+        /* */
+        ATTR_VAR(CKA_EC_PARAMS, curve, curve_size),
+    };
+    CK_ATTRIBUTE priv_template[] = {
+        ATTR(CKA_CLASS, CKO_PRIVATE_KEY, CK_OBJECT_CLASS),
+        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
+        ATTR(CKA_PRIVATE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_SENSITIVE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_DECRYPT, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
+        /* */
+        ATTR(CKA_ID, id, CK_BYTE),
+    };
+    CK_ATTRIBUTE ec_point = { CKA_EC_POINT, NULL, 0 };
+    CK_OBJECT_HANDLE private = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE public = CK_INVALID_HANDLE;
+    CK_RV rv = CKR_GENERAL_ERROR;
+
+    rv = C_GenerateKeyPair(session, & mechanism,
+                           pub_template, ARRAY_LEN(pub_template),
+                           priv_template, ARRAY_LEN(priv_template),
+                           &public, &private);
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_GetAttributeValue(session, public, &ec_point, 1);
+    assert_int_equal(rv, CKR_OK);
+
+    assert(*pubkey_len >= ec_point.ulValueLen);
+    ec_point.pValue = pubkey;
+
+    rv = C_GetAttributeValue(session, public, &ec_point, 1);
+    assert_int_equal(rv, CKR_OK);
+
+    *pubkey_len = ec_point.ulValueLen;
+}
+
+static void gen_nistp256(CK_SESSION_HANDLE session, CK_BYTE id,
+                         uint8_t* pubkey, size_t *pubkey_len) {
+    CK_BYTE curve[] = {
+        0x06, 0x08, 0x2a, 0x86, 0x48,
+        0xce, 0x3d, 0x03, 0x01, 0x07
+    };
+
+    gen_ecc_keypair(session, id, curve, sizeof(curve), pubkey, pubkey_len);
+}
+
+static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
+                         uint8_t *pubkey, size_t pubkey_len,
+                         uint8_t *secret, size_t secret_len) {
+
+    CK_MECHANISM mechanism = { CKM_ECDH1_DERIVE, NULL, 0 };
+    CK_ATTRIBUTE secret_template[] = {
+        ATTR(CKA_KEY_TYPE, CKK_GENERIC_SECRET, CK_KEY_TYPE),
+        ATTR(CKA_CLASS, CKO_SECRET_KEY, CK_OBJECT_CLASS),
+        ATTR(CKA_EXTRACTABLE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_TOKEN, CK_FALSE, CK_BBOOL),
+        ATTR(CKA_SENSITIVE, CK_FALSE, CK_BBOOL),
+        /* */
+        ATTR(CKA_VALUE_LEN, secret_len, CK_ULONG),
+    };
+    CK_ATTRIBUTE priv_template[] = {
+        ATTR(CKA_CLASS, CKO_PRIVATE_KEY, CK_OBJECT_CLASS),
+        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
+        ATTR(CKA_PRIVATE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_SENSITIVE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_DECRYPT, CK_TRUE, CK_BBOOL),
+        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
+        /* */
+        ATTR(CKA_ID, id, CK_BYTE),
+    };
+    CK_ATTRIBUTE derived_template[] = {
+        ATTR_VAR(CKA_VALUE, secret, secret_len),
+    };
+    CK_ECDH1_DERIVE_PARAMS params = {
+        .kdf = CKD_NULL,
+        .ulSharedDataLen = 0,
+        .pSharedData = secret,
+        .ulPublicDataLen = 0,
+        .pPublicData = NULL,
+    };
+    CK_OBJECT_HANDLE private = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE derived = CK_INVALID_HANDLE;
+    CK_RV rv = CKR_GENERAL_ERROR;
+    CK_ULONG count = 0;
+
+    /* Populate the mechanism, skip the DER header */
+    mechanism.ulParameterLen = sizeof(params);
+    mechanism.mechanism = CKM_ECDH1_DERIVE;
+    mechanism.pParameter = &params;
+    params.ulPublicDataLen = pubkey_len - 2;
+    pubkey++;
+    pubkey++;
+    params.pPublicData = pubkey;
+
+    /* Retrieve the private key */
+    rv = C_FindObjectsInit(session, priv_template, ARRAY_LEN(priv_template));
+    assert_int_equal(rv, CKR_OK);
+
+    rv = C_FindObjects(session, &private, 2, &count);
+    assert_int_equal(rv, CKR_OK);
+    assert_int_equal(count, 1);
+
+    rv = C_FindObjectsFinal(session);
+    assert_int_equal(rv, CKR_OK);
+
+    /* Derive */
+    rv = C_DeriveKey(session, &mechanism, private, secret_template,
+                     ARRAY_LEN(secret_template), &derived);
+    assert_int_equal(rv, CKR_OK);
+
+    /* Get the secret */
+    rv = C_GetAttributeValue(session, derived, derived_template,
+                             ARRAY_LEN(derived_template));
+    assert_int_equal(rv, CKR_OK);
+}
+
+static void test_ecc_derive_nist_p256_templ(void **state) {
+
+    test_info *ti = test_info_from_state(state);
+    CK_SESSION_HANDLE session = ti->handle;
+
+    /* NIST P-256: 32 bytes */
+    struct {
+        CK_BYTE shr[32];    /* Shared secret is the length of the key */
+        CK_BYTE pub[70];    /* Allocate extra space for encoding      */
+        size_t plen;
+        CK_BYTE id;
+    } key[] = {
+        [0] = { .id = 0x00, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
+        [1] = { .id = 0x01, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
+    };
+
+    user_login(session);
+
+    gen_nistp256(session, key[0].id, key[0].pub, &key[0].plen);
+    gen_nistp256(session, key[1].id, key[1].pub, &key[1].plen);
+
+    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32);
+    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32);
+
+    assert(memcmp(key[0].shr, key[1].shr, 32) == 0);
+}
+
+int main() {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ,
+                                        test_setup, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}

--- a/test/integration/pkcs11-tool.sh
+++ b/test/integration/pkcs11-tool.sh
@@ -38,7 +38,7 @@ echo "Found privkey"
 
 # test pin change
 echo "Attempting pin change"
-pkcs11-tool --module "$modpath" --slot=1 --login --pin myuserpin --change-pin --new-pin mynewpin
+pkcs11_tool --slot=1 --login --pin myuserpin --change-pin --new-pin mynewpin
 echo "Pin changed"
 
 # change userpin from sopin


### PR DESCRIPTION
Use TPM2_ECDH_ZGen as provided by tss2-esys (Esys_ECDH_ZGen()).

Test:
1) create two EC:prime256v1 keypairs (01, 02)
2) read 02 pubkey to pub2.der
3) --derive -m ECDH1-DERIVE --id 01 --input-file pub2.der --output-file /tmp/bytes1 
4)  read 01 pubkey to pub1.der
5) --derive -m ECDH1-DERIVE --id 02 --input-file pub1.der --output-file /tmp/bytes2 
6)  diff bytes1 bytes2

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>