### PR TITLE
db: fix PKCS11_SQL_LOCK usage

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -2394,7 +2394,7 @@ DEBUG_VISIBILITY int get_lock_path(const char *path, char *lockpath) {
     size_t lenv_lock = 0;
     char *env_lock = getenv("PKCS11_SQL_LOCK");
 
-    if (env_lock && (lenv_lock = strlen(env_lock) > 0)) {
+    if (env_lock && ((lenv_lock = strlen(env_lock)) > 0)) {
         /*
          * lock file shall be "PKCS11_SQL_LOCK" + '/' + path + ".lock", but
          * path's '/' will be substituted by '_'.

--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -2387,7 +2387,7 @@ static CK_RV db_create(char *path, size_t len) {
     return db_for_path(path, len, db_create_handler);
 }
 
-DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
+DEBUG_VISIBILITY int get_lock_path(const char *path, char *lockpath) {
 
     unsigned l;
 
@@ -2405,7 +2405,7 @@ DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
         }
         if ((lenv_lock + 1 + strlen(path) + strlen(".lock")) >= PATH_MAX) {
             LOGE("Lock file path would be longer than PATH_MAX");
-            return NULL;
+            return SQLITE_ERROR;
         }
         strncpy(lockpath, env_lock, PATH_MAX-1);
         strcat(lockpath, "/");
@@ -2424,6 +2424,15 @@ DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
     }
     if (l >= PATH_MAX) {
         LOGE("Lock file path is longer than PATH_MAX");
+        return SQLITE_ERROR;
+    }
+
+    return SQLITE_OK;
+}
+
+DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
+
+    if (get_lock_path(path, lockpath) != SQLITE_OK) {
         return NULL;
     }
 

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -92,6 +92,7 @@ int init_pobject(unsigned pid, pobject *pobj, tpm_ctx *tpm);
 int __real_init_pobject(unsigned pid, pobject *pobj, tpm_ctx *tpm);
 int init_sealobjects(unsigned tokid, sealobject *sealobj);
 int __real_init_sealobjects(unsigned tokid, sealobject *sealobj);
+int get_lock_path(const char *path, char *lockpath);
 FILE *take_lock(const char *path, char *lockpath);
 #endif
 


### PR DESCRIPTION
Fix PKCS11_SQL_LOCK environent variable usage and add tests for lock file path creation.

Fixes: #820