### PR TITLE
configure: update --with-fapi configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,11 +114,11 @@ AC_ARG_ENABLE(
 AS_IF([test "x$esapi_sf" = "xyes"],
        [do_esapi_manage_flags])
 
-AC_ARG_ENABLE(
+AC_ARG_WITH(
   [fapi],
   [AS_HELP_STRING([--with-fapi],
     [enable or disable the fapi backend. Default is "auto" to autodetect])],
-    [enable_fapi=$enableval],
+    [enable_fapi=$withval],
     [enable_fapi=auto])
 
 AC_DEFUN([do_fapi_configure], [

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -120,7 +120,7 @@ Building the project and running tests can be also done with specific shell comm
 ```sh
 # Configure tpm2-pkcs11 to build unit and integration tests
 ./bootstrap
-./configure --enable-fapi --enable-unit --enable-integration
+./configure --with-fapi --enable-unit --enable-integration
 
 # Build the project and run tests
 make -j $(nproc)

--- a/test/integration/scripts/create_pkcs_store.sh
+++ b/test/integration/scripts/create_pkcs_store.sh
@@ -181,21 +181,21 @@ if [ "$OSSL3_DETECTED" -eq "1" ]; then
     setup_asan
 
     TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
-        req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
+        req -provider tpm2 -provider default -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
             -key "$TPM2_PKCS11_STORE/14.pem" --passin "pass:$auth_14" -out "$cert.ec1"
 
     TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
-        req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
+        req -provider tpm2 -provider default -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
         -key "$TPM2_PKCS11_STORE/6.pem" --passin "pass:$auth_6" \
         -config "$TEST_FIXTURES/ossl-req-ca.cnf" -extensions ca_ext -out "$cert.rsa1"
 
 	# sign a certificate for rsa2 using the rsa1 key
 	TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
-	    req -provider tpm2 -provider base -new -subj '/CN=my sub key/' -sha256 \
+	    req -provider tpm2 -provider default -new -subj '/CN=my sub key/' -sha256 \
 	    -key "$TPM2_PKCS11_STORE/8.pem" --passin "pass:$auth_8" -out "$cert.csr.rsa2"
 
 	TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
-    	x509 -provider tpm2 -provider base -req -days 365 -sha256 -in "$cert.csr.rsa2" \
+        x509 -provider tpm2 -provider default -req -days 365 -sha256 -in "$cert.csr.rsa2" \
     	-CA "$cert.rsa1" -CAkey "$TPM2_PKCS11_STORE/6.pem" --passin "pass:$auth_6"\
     	-CAcreateserial -extfile "$TEST_FIXTURES/ossl-req-cert.cnf" -extensions cert_ext \
     	-out "$cert.rsa2"


### PR DESCRIPTION
Update configure.ac to use AC_ARG_WITH and update the docs to the proper argument. Keep the option the same for downstream packagers.

Fixes: #822