### PR TITLE
Fix memory leaks from Esys_CreatePrimary

### DIFF
--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -4408,6 +4408,11 @@ WEAK CK_RV tpm_create_transient_primary_from_template(tpm_ctx *tpm,
         return CKR_GENERAL_ERROR;
     }
 
+    Esys_Free(data);
+    Esys_Free(hash);
+    Esys_Free(ticket);
+    Esys_Free(out_pub);
+
     *primary_handle = handle;
 
     return CKR_OK;


### PR DESCRIPTION
Fixed a few apparent leaks that result from `Esys_CreatePrimary` allocating memory for its output arguments. These variables seem to freed in `tpm_create_persistent_primary` but not in `tpm_create_transient_primary_from_template` when the same function is called and it didn't seem like they were being used afterwards.

Noticed this leak while attempting to load this library multiple times in a long-running application.