### PR TITLE
Skip null attribute during DB update

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -2169,9 +2169,11 @@ static CK_RV dbup_handler_from_7_to_8(sqlite3 *updb) {
 
         /* for each tobject */
         CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_ALLOWED_MECHANISMS);
-        CK_BYTE type = type_from_ptr(a->pValue, a->ulValueLen);
-        if (type != TYPE_BYTE_INT_SEQ) {
-            rv = _db_update_tobject_attrs(updb, tobj->id, tobj->attrs);
+        if (a) {
+            CK_BYTE type = type_from_ptr(a->pValue, a->ulValueLen);
+            if (type != TYPE_BYTE_INT_SEQ) {
+                rv = _db_update_tobject_attrs(updb, tobj->id, tobj->attrs);
+            }
         }
 
         tobject_free(tobj);


### PR DESCRIPTION
This PR is based on a patch from https://github.com/tpm2-software/tpm2-pkcs11/issues/845 and fixes the issue when there is no CKA_ALLOWED_MECHANISMS attribute during DB migration