### PR TITLE
[FAPI] Fix appdata corruption caused by offset miscalculation

### DIFF
--- a/src/lib/backend_fapi.c
+++ b/src/lib/backend_fapi.c
@@ -666,7 +666,7 @@ CK_RV backend_fapi_update_tobject_attrs(token *t, tobject *tobj, attr_list *attr
     memcpy(&newappdata[0], &appdata[0], tobj_start);
     sprintf((char*)&newappdata[tobj_start], "%08x:%s", tobj->id, attrs);
     memcpy(&newappdata[tobj_start + 9 + strlen(attrs) + 1],
-           &appdata[tobj_start + tobj_len],
+           &appdata[tobj_start + tobj_len + 1],
            appdata_len - tobj_start - tobj_len - 1);
     newappdata[newappdata_len - 1] = '\0';
 


### PR DESCRIPTION
When the FAPI backend is used, the following steps occur whenever `C_SetAttributeValue()` is invoked to update attributes. The function `backend_fapi_update_tobject_attrs()` performs these actions:

1. Invoke `Fapi_GetAppData()` to retrieve the existing `appdata`.
2. Find the offset (`tobj_start`) of the `tobj` to be deleted in the `appdata`.
3. Allocate a new buffer `newappdata`.
4. Copy only the data before `tobj_start` from `appdata` to `newappdata`:
   ```
   memcpy(&newappdata[0], &appdata[0], tobj_start);
   ```
5. Append the new value (`attrs`) to `newappdata`:
   ```
   sprintf((char*)&newappdata[tobj_start], "%08x:%s", tobj->id, attrs);
   ```
6. Append the remaining data from `appdata`:
   ```
   memcpy(&newappdata[tobj_start + 9 + strlen(attrs) + 1],
          &appdata[tobj_start + tobj_len], <======================= [Issue]
          appdata_len - tobj_start - tobj_len - 1);
   ```
7. Call `Fapi_SetAppData(newappdata)` to update the data.

**[Issue]:** It does not account for the '\0' character. Essentially, the '\0' that marks the end of a tobj is copied over, resulting in the next tobj starting with a '\0' character, making subsequent tobjs unrecognizable.