### PR TITLE
C_CreateObject should not return CKR_SESSION_READ_ONLY when a RW session is in use.

### DIFF
--- a/src/lib/object.c
+++ b/src/lib/object.c
@@ -1123,12 +1123,14 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
     /*
      * Currently we only support RW user session state objects.
      */
-    if (state != CKS_RW_USER_FUNCTIONS) {
-        if (state == CKS_RW_SO_FUNCTIONS) {
-            return CKR_USER_NOT_LOGGED_IN;
-        } else {
-            return CKR_SESSION_READ_ONLY;
-        }
+    switch(state) {
+    case CKS_RW_USER_FUNCTIONS:
+        break;
+    case CKS_RW_PUBLIC_SESSION:
+    case CKS_RW_SO_FUNCTIONS:
+        return CKR_USER_NOT_LOGGED_IN;
+    default:
+        return CKR_SESSION_READ_ONLY;
     }
 
     /*


### PR DESCRIPTION
The PKCS#11 specification states:
- CKR_SESSION_READ_ONLY: The specified session was unable to accomplish the desired action because it is a read-only session.

However, the current implementation erroneously returns CKR_SESSION_READ_ONLY when a CKS_RW_PUBLIC_SESSION is detected, which contradicts the specification. Consequently, this leads to issues when adding certificates with NSS tools `certutil`. Typically, `certutil` initiates a CKS_RW_PUBLIC_SESSION; it only attempts a user login if it encounters the CKR_USER_NOT_LOGGED_IN error.

Script to reproduce the issue:
```
export TPM2_PKCS11_BACKEND="esysdb"
export NSSDB_DIR=$(mktemp -d)

cd $NSSDB_DIR
rm ./*
tpm2_clear -c p
rm -rf $TPM2_PKCS11_STORE
export TPM2_PKCS11_STORE=$(mktemp -d)
tpm2_ptool init --path $TPM2_PKCS11_STORE
tpm2_ptool addtoken --pid 1 --sopin sopin --userpin userpin     --label tpm2-token --path $TPM2_PKCS11_STORE
pkcs11-tool-tpm2 --list-token-slots

certutil -N -d "sql:$NSSDB_DIR" --empty-password
ls -la $NSSDB_DIR
modutil -list -dbdir "sql:$NSSDB_DIR"
SLOT_INDEX=$(pkcs11-tool-tpm2 --list-token-slots | grep "): tpm2-token" | awk '{print $2}')
pkcs11-tool-tpm2 --slot-index $SLOT_INDEX --generate-random 32 --output-file noise.bin
echo -ne "y\ny" | certutil -S -s "CN=Local CA" -n "local-ca-crt" -x -t "C,C,C" -2 \
   --keyUsage certSigning,crlSigning,critical \
   --nsCertType objectSigningCA,critical \
   -d "sql:$NSSDB_DIR" -z noise.bin
certutil -L -d "sql:$NSSDB_DIR" | grep "local-ca-crt"
certutil -K -d "sql:$NSSDB_DIR" | grep "NSS Certificate DB:local-ca-crt"

echo "userpin" > userpin.txt
echo -ne "\n" | modutil -add "TPM2-based PKCS #11 Module" -libfile "${HOME}/tpm2-pkcs11/src/.libs/libtpm2_pkcs11.so" -dbdir "sql:$NSSDB_DIR"
modutil -list -dbdir "sql:$NSSDB_DIR"
certutil -R -k rsa -g 2048 -s "CN=Example2,O=Example2 Corp,C=DE" \
    -d "sql:$NSSDB_DIR" -h "tpm2-token" -f "userpin.txt" \
    -z noise.bin -a -o tpm2-client.csr.pem
certutil -K -d "sql:$NSSDB_DIR" -h "tpm2-token" -f "userpin.txt"
openssl req -in tpm2-client.csr.pem -outform DER -out tpm2-client.csr.der
sleep 1
certutil -C -c "local-ca-crt" -i tpm2-client.csr.der -o tpm2-client.crt.der \
   -v 12 -w 1 -d "sql:$NSSDB_DIR" \
   --keyUsage nonRepudiation,dataEncipherment \
   --nsCertType sslClient --extKeyUsage clientAuth \
   -7 tpm2-client@example.com

# Error message:
# certutil: could not add certificate to token or database: SEC_ERROR_ADDING_CERT: Error adding certificate to database.
certutil -A -n "tpm2-client-crt" -t "u,u,u" -d "sql:$NSSDB_DIR" -i tpm2-client.crt.der -h "tpm2-token" -f "userpin.txt" 
```