### PR TITLE
Swap openssl base provider for default provider in integration tests

### DIFF
--- a/test/integration/p11-tool.sh.nosetup
+++ b/test/integration/p11-tool.sh.nosetup
@@ -222,7 +222,7 @@ auth_myrsakey=$(echo "$yaml_myrsakey" | grep "object-auth" | cut -d' ' -f2-)
 
 setup_asan
 
-openssl dgst -provider tpm2 -provider base \
+openssl dgst -provider tpm2 -provider default \
         -sha256 -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 \
         -sign "$TPM2_PKCS11_STORE/myrsakey.pem" -out ${tempdir}/sig -passin "pass:$auth_myrsakey" ${tempdir}/data
 
@@ -252,7 +252,7 @@ auth_myecckey=$(echo "$yaml_myecckey" | grep "object-auth" | cut -d' ' -f2-)
 
 setup_asan
 
-openssl dgst -provider tpm2 -provider base \
+openssl dgst -provider tpm2 -provider default \
   -sha1 -sign "$TPM2_PKCS11_STORE/myecckey.pem" -out ${tempdir}/sig -passin "pass:$auth_myecckey" ${tempdir}/data
 
 openssl dgst -sha1 -verify ${tempdir}/eccpubkey.pem -signature ${tempdir}/sig ${tempdir}/data


### PR DESCRIPTION
Integration tests are failing when built against openssl 3.3.1, e.g:

```
+ openssl req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 -key /tmp/tpm_simulator_Ulvzcd/14.pem --passin pass:756dc95213a46b4249b1d3def6187339 -out /tmp/tpm_simulator_Ulvzcd/cert.pem.ec1
req: Unknown option or message digest: sha256
req: Use -help for summary.
```

This appears to be because neither the `base` nor `tpm2` providers currently support the sha256 symmetric cipher algorithm, although it can be enabled in `tpm2-openssl` [at compile time](https://github.com/tpm2-software/tpm2-openssl/blob/master/docs/INSTALL.md#building-from-source).

Using the `default` provider instead of `base` fixes tests that are currently failing.

I've submitted this patch to the [Arch Linux package](https://gitlab.archlinux.org/archlinux/packaging/packages/tpm2-pkcs11/-/merge_requests/1) as well, where I later realised that it implements a commit already made here: https://github.com/tpm2-software/tpm2-pkcs11/commit/1b3aab90ee5f7debbce82c7e229aa2950a9e8f0d