### PR TITLE
dist: add fake-tpm to release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ include src_vars.mk
 EXTRA_DIST = \
     LICENSE \
     docs \
+    test/fake-tpm \
     test/integration/scripts \
     misc/p11-kit \
     tools \


### PR DESCRIPTION
The fuzz tests need fake-tpm so add it to the distribution tarball generated via make dist.

Fixes: #854