### PR TITLE
Remove deprecated tests_require

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -38,7 +38,6 @@ setup(
         'pyasn1_modules',
         'tpm2_pytss'
     ],
-    tests_require=[],
     entry_points={
         'console_scripts': ['tpm2_ptool = tpm2_pkcs11.tpm2_ptool:main'],
     }, )


### PR DESCRIPTION
Building with recent setuptools shows the following warning:

/usr/lib/python3.13/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'tests_require'

Given that the list is empty, I think removing it altogether is ok.