### PR TITLE
configure: Change mistaken $(prefix) to ${prefix}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -487,7 +487,7 @@ AM_CONDITIONAL([HAVE_P11KIT], [test "x$have_p11kit" = "xyes"])
 
 # check for --prefix and set flag HAVE_PREFIX if found
 #   do not change install location if --prefix is given and with P11_KIT found
-AM_CONDITIONAL([HAVE_PREFIX], [test ! -z "$(prefix)"])
+AM_CONDITIONAL([HAVE_PREFIX], [test ! -z "${prefix}"])
 
 # END P11 CONFIG
 


### PR DESCRIPTION
./configure whines with the prefix executable cannot be found, which is probably not what was intended.