### PR TITLE
fix tpm2_ptool destroy command failures

### DIFF
--- a/tools/tpm2_pkcs11/commandlets_store.py
+++ b/tools/tpm2_pkcs11/commandlets_store.py
@@ -10,7 +10,7 @@ from .command import Command
 from .command import commandlet
 
 from .db import Db
-from .utils import bytes_to_file
+from .utils import get_pobject
 from .utils import TemporaryDirectory
 from .utils import query_yes_no
 from .utils import create_primary
@@ -153,7 +153,7 @@ class InitCommand(Command):
 
                 except Exception as e:
                     if shall_evict and pobj_ctx != None:
-                        tpm2.evictcontrol(hierarchyauth, pobj_ctx)
+                        tpm2.evictcontrol_remove(hierarchyauth, pobj_ctx)
 
                     traceback.print_exc(file=sys.stdout)
                     sys.exit(e)
@@ -173,7 +173,7 @@ class DestroyCommand(Command):
         group_parser.add_argument(
             '--hierarchy-auth',
             default="",
-            help="The primary object id to remove.\n")
+            help='The authorization password for adding a primary object to the hierarchy.\n')
 
     def __call__(self, args):
         path = args['path']
@@ -199,10 +199,10 @@ class DestroyCommand(Command):
             with TemporaryDirectory() as d:
                 tpm2 = Tpm2(d)
 
-                tr_file = bytes_to_file(pobj['handle'], d)
+                pobj_handle = get_pobject(pobj, tpm2, hierarchyauth, d)
 
                 db.rmprimary(pid)
-                tpm2.evictcontrol(hierarchyauth, tr_file)
+                tpm2.evictcontrol_remove(hierarchyauth, pobj_handle)
 
 @commandlet("dbup")
 class DbUp(Command):

--- a/tools/tpm2_pkcs11/tpm2.py
+++ b/tools/tpm2_pkcs11/tpm2.py
@@ -106,6 +106,25 @@ class Tpm2(object):
                                stderr)
         return tr_file
 
+    def evictcontrol_remove(self, hierarchyauth, ctx, handle=None):
+
+        # Only provide persistent handle when removing 
+        # persistent objects
+        cmd = ['tpm2_evictcontrol', '-c', str(ctx)]
+
+        if hierarchyauth and len(hierarchyauth) > 0:
+            cmd.extend(['-P', hierarchyauth])
+
+        if handle:
+            cmd.append(str(handle))
+
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
+        stdout, stderr = p.communicate()
+        if (p.wait()):
+            raise RuntimeError("Could not execute tpm2_evictcontrol: %s" %
+                               stderr)
+        return stdout
+
     def readpublic(self, handle, get_tr_file=True):
 
         tr_file = os.path.join(self._tmp, "primary.handle")


### PR DESCRIPTION
The current `tpm2_ptool destroy` command does not work as intended and does not remove the persistent object

**Current behavior**:
```
❯ sudo tpm2_ptool init
action: Created
id: 1

❯ sudo tpm2_ptool destroy --pid=1
This will delete the primary object of id "1" and all associated data from db under "/root/.tpm2_pkcs11" [y/N] y
Traceback (most recent call last):
  File "/usr/bin/tpm2_ptool", line 33, in <module>
    sys.exit(load_entry_point('tpm2-pkcs11-tools==1.33.7', 'console_scripts', 'tpm2_ptool')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/tpm2_pkcs11/tpm2_ptool.py", line 26, in main
    commandlet.init('A tool for manipulating the tpm2-pkcs11 database')
  File "/usr/lib/python3/dist-packages/tpm2_pkcs11/command.py", line 102, in init
    commandlet.get()[d['which']](d)
  File "/usr/lib/python3/dist-packages/tpm2_pkcs11/commandlets_store.py", line 202, in __call__
    tr_file = bytes_to_file(pobj['handle'], d)
                            ~~~~^^^^^^^^^^
IndexError: No item with that key
```

**Updated behavior with this PR**:
```
❯ sudo tpm2_ptool destroy --pid=1
This will delete the primary object of id "1" and all associated data from db under "/root/.tpm2_pkcs11" [y/N] y
❯ echo $?
0
```

This fixes two issues:
- bytes_to_file function is replaced by get_pobject
- and we introduce a new evictcontrol method to handle removing of the persistent object
   - With the current logic `tpm2_evictcontrol` was passed an object and a handle even for a remove action.
   - We introduce a new method evictcontrol_remove to handle just removing persistent objects
     - I am not too familiar with this code, and TPM2, just in the process of learning my way around, please let me know if there's a better approach.

Thank you!