### PR TITLE
Fix detection of libasan location in CI tests

### DIFF
--- a/test/integration/scripts/helpers.sh
+++ b/test/integration/scripts/helpers.sh
@@ -31,6 +31,9 @@ setup_asan() {
   if [ ! -f "$p" ]; then
     p="/usr/lib64/clang/$clang_version/lib/linux/libclang_rt.asan-$(arch).so"
   fi
+  if [ ! -f "$p" ]; then
+    p="/usr/lib64/clang/$maj/lib/linux/libclang_rt.asan-$(arch).so"
+  fi
 
   if [ ! -f "$p" ]; then
     echo "Couldn't find libasan.so"


### PR DESCRIPTION
The latest update of the opensuse-leap container uses a new path schema:
/usr/lib64/clang/17/lib/linux/libclang_rt.asan-x86_64.so