### PR TITLE
configure.ac: Add Wformat-security to Wformat check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -519,8 +519,7 @@ AS_IF([test x"$enable_hardening" != xno], [
   add_hardened_c_flag([-Wextra])
   AS_IF([test "x$ax_is_release" = "xno"], [add_hardened_c_flag([-Werror])])
 
-  add_hardened_c_flag([-Wformat])
-  add_hardened_c_flag([-Wformat-security])
+  add_hardened_c_flag([-Wformat -Wformat-security])
   add_hardened_c_flag([-Wstack-protector])
   add_hardened_c_flag([-fstack-protector-all])
   add_hardened_c_flag([-Wstrict-overflow=5])


### PR DESCRIPTION
Same change as https://github.com/tpm2-software/tpm2-tools/commit/52ac6afcbc6438fc549a43dba4087a438bdf379d

This became fatal with newer automake/autoconf

```
checking whether byte ordering is bigendian... no
checking whether the C compiler accepts -Wall... yes
checking whether the C compiler accepts -Wextra... yes
checking whether the C compiler accepts -Wformat... yes
checking whether the C compiler accepts -Wformat-security... no
configure: error: Cannot enable -Wformat-security, consider configuring with --disable-hardening
```