### PR TITLE
configure: add -Wformat to CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -520,7 +520,7 @@ AS_IF([test x"$enable_hardening" != xno], [
   AS_IF([test "x$ax_is_release" = "xno"], [add_hardened_c_flag([-Werror])])
 
   add_hardened_c_flag([-Wformat])
-  add_hardened_c_flag([-Wformat-security])
+  add_hardened_c_flag([-Wformat -Wformat-security])
   add_hardened_c_flag([-Wstack-protector])
   add_hardened_c_flag([-fstack-protector-all])
   add_hardened_c_flag([-Wstrict-overflow=5])


### PR DESCRIPTION
Without -Wformat for -Wformat-security, gcc will complain:

checking whether the C compiler accepts -Wformat-security... no configure: error: Cannot enable -Wformat-security, consider configuring with --disable-hardening

Related to: https://github.com/tpm2-software/tpm2-pkcs11/pull/899