### PR TITLE
lib: ecdh1 derive: register CKM_ECDH1_DERIVE as available mechanism

### DIFF
--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -4020,6 +4020,7 @@ CK_RV tpm2_getmechanisms(tpm_ctx *ctx, CK_MECHANISM_TYPE *mechanism_list, CK_ULO
         if_add_mech(algs, TPM2_ALG_ECDSA, CKM_ECDSA_SHA384);
         if_add_mech(algs, TPM2_ALG_ECDSA, CKM_ECDSA_SHA512);
 
+        if_add_mech(algs, TPM2_ALG_ECDH, CKM_ECDH1_DERIVE);
     }
 
     /* AES */


### PR DESCRIPTION
Commit cd7b486 ("lib: ecdh1 derive: simple implementation for KDF null") has laid all of the ground work to enable ECDH key exchange via tpm2-pkcs11 but did not advertise this change to users.

This prevents the feature from working with the i.e.  [pkcs11-provider](https://github.com/latchset/pkcs11-provider) in openssl, because it does not see the mechanism and will thus not try using it.

For practival use like e.g. decrypting files using `openssl cms` we will need other KDF mechanisms than null, but this should at least get us a step closer.

Fixes: cd7b486 ("lib: ecdh1 derive: simple implementation for KDF null")