### PR TITLE
lib: ecdh1 derive: add support for CKD_SHA1_KDF key derivation function

### DIFF
--- a/src/lib/derive.c
+++ b/src/lib/derive.c
@@ -229,10 +229,10 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
 
     /* Get the shaed secret */
     CK_BYTE* shared_secret = NULL;
-    rv = tpm_ec_ecdh1_derive(tok->tctx, tobj, /* EC private */
-                             mecha_params->public_data, /* EC point */
-                             mecha_params->public_data_len,
-                             &shared_secret, &udata.len);
+    rv = tpm_ec_ecdh_zgen(tok->tctx, tobj, /* EC private */
+                          mecha_params->public_data, /* EC point */
+                          mecha_params->public_data_len,
+                          &shared_secret, &udata.len);
     if (rv != CKR_OK) {
          tobject_user_decrement(tobj);
          return rv;

--- a/src/lib/derive.c
+++ b/src/lib/derive.c
@@ -193,10 +193,6 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
     CK_ECDH1_DERIVE_PARAMS_PTR mecha_params;
     SAFE_CAST(mechanism, mecha_params);
 
-    if (mecha_params->kdf != CKD_NULL) {
-        return CKR_MECHANISM_PARAM_INVALID;
-    }
-
     /* 2. Uncompressed EC_POINT: is a DER OCTECT string of 04||x||y */
     if (!mecha_params->public_data_len ||
         (mecha_params->public_data_len - 1) != 2 * keysize) {
@@ -227,22 +223,44 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
         return rv;
     }
 
-    /* Get the shaed secret */
-    CK_BYTE* shared_secret = NULL;
+    /* Perform an Elliptic Curve Diffie Helman key exchange using the TPM resident
+     * private key and a supplied public key.
+     * This establishes a shared secret ECC point z_point between us and the owner
+     * of the private key belonging to the supplied public key.
+     *
+     * The result can either be used as a shared secret directly (CKD_NULL) or as
+     * the input to a key derivation function, to optain a shared secret of arbitrary
+     * length (i.e. CKD_SHA1_KDF). */
+    CK_BYTE* z_point = NULL;
+    size_t z_point_len = 0;
     rv = tpm_ec_ecdh_zgen(tok->tctx, tobj, /* EC private */
                           mecha_params->public_data, /* EC point */
                           mecha_params->public_data_len,
-                          &shared_secret, &udata.len);
+                          &z_point, &z_point_len);
     if (rv != CKR_OK) {
          tobject_user_decrement(tobj);
          return rv;
     }
 
     CK_ATTRIBUTE shared_secret_attr = {
-        .ulValueLen = udata.len,
-        .pValue = shared_secret,
+        .ulValueLen = 0,
+        .pValue = NULL,
         .type = CKA_VALUE,
     };
+
+    if (mecha_params->kdf == CKD_NULL) {
+        /* Use the shared z_point as is.
+         * Without a KDF the output length depends on the ECC algorithm used
+         * and the value in the supplied template is ignored. */
+        shared_secret_attr.ulValueLen = z_point_len;
+        shared_secret_attr.pValue = z_point;
+    }
+    else {
+        free(z_point);
+        tobject_user_decrement(tobj);
+
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
 
     /* Return the shared secret in a CKO_SECRET_KEY class object */
     rv = object_create(ctx, secret_template, secret_template_count, secret);
@@ -258,6 +276,6 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
     }
 
 out:
-    free(shared_secret);
+    free(shared_secret_attr.pValue);
     return rv;
 }

--- a/src/lib/derive.c
+++ b/src/lib/derive.c
@@ -8,6 +8,11 @@
 #include <openssl/ecdsa.h>
 #include <openssl/evp.h>
 
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+#include <openssl/kdf.h>
+#include <openssl/core_names.h>
+#endif
+
 #include "attrs.h"
 #include "backend.h"
 #include "checks.h"
@@ -255,6 +260,47 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
         shared_secret_attr.ulValueLen = z_point_len;
         shared_secret_attr.pValue = z_point;
     }
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+    else if (mecha_params->kdf == CKD_SHA1_KDF) {
+        /* Use a KDF to generate a shared secret of arbitrary length.
+         * The length is taken from the supplied template. */
+
+        shared_secret_attr.ulValueLen = udata.len;
+        shared_secret_attr.pValue = calloc(shared_secret_attr.ulValueLen,
+                                           sizeof(CK_BYTE));
+
+        EVP_KDF *kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_X963KDF, NULL);
+        EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+
+        OSSL_PARAM params[4], *p = params;
+
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+            "SHA1", 0);
+        *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+            (void *)z_point, z_point_len);
+
+        if (mecha_params->shared_data && mecha_params->shared_data_len) {
+            *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                (void *)mecha_params->shared_data, mecha_params->shared_data_len);
+        }
+
+        *p = OSSL_PARAM_construct_end();
+
+        if (EVP_KDF_derive(kctx, shared_secret_attr.pValue,
+                           shared_secret_attr.ulValueLen, params) != 1) {
+            rv = CKR_GENERAL_ERROR;
+        }
+
+        free(z_point);
+        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free(kdf);
+
+        if (rv != CKR_OK) {
+            tobject_user_decrement(tobj);
+            goto out;
+        }
+    }
+#endif
     else {
         free(z_point);
         tobject_user_decrement(tobj);

--- a/src/lib/derive.c
+++ b/src/lib/derive.c
@@ -8,6 +8,11 @@
 #include <openssl/ecdsa.h>
 #include <openssl/evp.h>
 
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+#include <openssl/kdf.h>
+#include <openssl/core_names.h>
+#endif
+
 #include "attrs.h"
 #include "backend.h"
 #include "checks.h"
@@ -255,6 +260,66 @@ CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point *
         shared_secret_attr.ulValueLen = z_point_len;
         shared_secret_attr.pValue = z_point;
     }
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+    else if (mecha_params->kdf == CKD_SHA1_KDF) {
+        /* Use a KDF to generate a shared secret of arbitrary length.
+         * The length is taken from the supplied template. */
+
+        shared_secret_attr.ulValueLen = udata.len;
+        shared_secret_attr.pValue = calloc(shared_secret_attr.ulValueLen,
+                                           sizeof(CK_BYTE));
+
+        EVP_KDF *kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_X963KDF, NULL);
+
+        if (!kdf) {
+            free(z_point);
+            tobject_user_decrement(tobj);
+            rv = CKR_GENERAL_ERROR;
+            goto out;
+        }
+
+        EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+
+        if (!kctx) {
+            free(z_point);
+            EVP_KDF_free(kdf);
+            tobject_user_decrement(tobj);
+
+            rv = CKR_HOST_MEMORY;
+            goto out;
+        }
+
+        OSSL_PARAM params[4];
+
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+            "SHA1", 0);
+        params[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+            (void *)z_point, z_point_len);
+
+        if (mecha_params->shared_data && mecha_params->shared_data_len) {
+            params[2] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                (void *)mecha_params->shared_data, mecha_params->shared_data_len);
+            params[3] = OSSL_PARAM_construct_end();
+        }
+        else {
+            params[2] = OSSL_PARAM_construct_end();
+        }
+
+        if (EVP_KDF_derive(kctx, shared_secret_attr.pValue,
+                           shared_secret_attr.ulValueLen, params) != 1) {
+            rv = CKR_GENERAL_ERROR;
+        }
+
+        free(z_point);
+        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free(kdf);
+
+        if (rv != CKR_OK) {
+            tobject_user_decrement(tobj);
+            goto out;
+        }
+    }
+#endif
     else {
         free(z_point);
         tobject_user_decrement(tobj);

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -4681,9 +4681,9 @@ out:
     return rv;
 }
 
-CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, uint8_t *ecc_point,
-                          size_t ecc_point_len, uint8_t **secret,
-                          size_t *secret_len)
+CK_RV tpm_ec_ecdh_zgen(tpm_ctx *tctx, tobject *tobj, uint8_t *ecc_point,
+                       size_t ecc_point_len, uint8_t **secret,
+                       size_t *secret_len)
 {
     TPM2B_ECC_POINT *out_point = NULL;
     TPM2B_ECC_POINT in_point = { };

--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -4682,9 +4682,9 @@ out:
     return rv;
 }
 
-CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, uint8_t *ecc_point,
-                          size_t ecc_point_len, uint8_t **secret,
-                          size_t *secret_len)
+CK_RV tpm_ec_ecdh_zgen(tpm_ctx *tctx, tobject *tobj, uint8_t *ecc_point,
+                       size_t ecc_point_len, uint8_t **secret,
+                       size_t *secret_len)
 {
     TPM2B_ECC_POINT *out_point = NULL;
     TPM2B_ECC_POINT in_point = { };

--- a/src/lib/tpm.h
+++ b/src/lib/tpm.h
@@ -122,7 +122,8 @@ CK_RV tpm_ec_ecdsa_sha1_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR m
 CK_RV tpm_ec_ecdsa_sha256_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_ec_ecdsa_sha384_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_ec_ecdsa_sha512_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
-CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, unsigned char *pubkey, size_t pubkey_len, unsigned char **psec, size_t *pseclen);
+
+CK_RV tpm_ec_ecdh_zgen(tpm_ctx *tctx, tobject *tobj, unsigned char *pubkey, size_t pubkey_len, unsigned char **psec, size_t *pseclen);
 
 CK_RV tpm_aes_cbc_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
 CK_RV tpm_aes_cfb_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);

--- a/test/integration/pkcs-ecdh.int.c
+++ b/test/integration/pkcs-ecdh.int.c
@@ -226,11 +226,25 @@ static void test_ecc_derive_nist_p256_templ_none(void **state) {
     test_ecc_derive_nist_p256_templ(state, 0, CKD_NULL, 32);
 }
 
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+static void test_ecc_derive_nist_p256_templ_sha1(void **state) {
+    /* The KDF can generate shared secrets of arbitrary length.
+     * Demonstrate that by generating 50 bytes, which is not divisble
+     * by the 32 bytes a P-256 point provides or the 20 byte output
+     * of SHA1 */
+    test_ecc_derive_nist_p256_templ(state, 2, CKD_SHA1_KDF, 50);
+}
+#endif
+
 int main() {
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ_none,
                                         test_setup, test_teardown),
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000)
+        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ_sha1,
+                                        test_setup, test_teardown),
+#endif
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/test/integration/pkcs-ecdh.int.c
+++ b/test/integration/pkcs-ecdh.int.c
@@ -115,7 +115,8 @@ static void gen_nistp256(CK_SESSION_HANDLE session, CK_BYTE id,
 
 static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
                          uint8_t *pubkey, size_t pubkey_len,
-                         uint8_t *secret, size_t secret_len) {
+                         uint8_t *secret, size_t secret_len,
+                         ck_ec_kdf_t kdf) {
 
     CK_MECHANISM mechanism = { CKM_ECDH1_DERIVE, NULL, 0 };
     CK_ATTRIBUTE secret_template[] = {
@@ -142,7 +143,7 @@ static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
         ATTR_VAR(CKA_VALUE, secret, secret_len),
     };
     CK_ECDH1_DERIVE_PARAMS params = {
-        .kdf = CKD_NULL,
+        .kdf = kdf,
         .ulSharedDataLen = 0,
         .pSharedData = secret,
         .ulPublicDataLen = 0,
@@ -184,37 +185,51 @@ static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
     assert_int_equal(rv, CKR_OK);
 }
 
-static void test_ecc_derive_nist_p256_templ(void **state) {
+static void test_ecc_derive_nist_p256_templ(void **state, CK_BYTE id_base, ck_ec_kdf_t kdf, size_t shr_len) {
 
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE session = ti->handle;
 
     /* NIST P-256: 32 bytes */
     struct {
-        CK_BYTE shr[32];    /* Shared secret is the length of the key */
+        CK_BYTE *shr;       /* Shared secret */
         CK_BYTE pub[70];    /* Allocate extra space for encoding      */
         size_t plen;
         CK_BYTE id;
     } key[] = {
-        [0] = { .id = 0x00, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
-        [1] = { .id = 0x01, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
+        [0] = { .id = id_base, .shr = NULL, .pub = { 0 }, .plen = 70 },
+        [1] = { .id = id_base + 1, .shr = NULL, .pub = { 1 }, .plen = 70 },
     };
+
+    key[0].shr = malloc(shr_len);
+    key[1].shr = malloc(shr_len);
+    memset(key[0].shr, 0, shr_len);
+    memset(key[0].shr, 1, shr_len);
 
     user_login(session);
 
     gen_nistp256(session, key[0].id, key[0].pub, &key[0].plen);
     gen_nistp256(session, key[1].id, key[1].pub, &key[1].plen);
 
-    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32);
-    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32);
+    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, shr_len, kdf);
+    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, shr_len, kdf);
 
-    assert(memcmp(key[0].shr, key[1].shr, 32) == 0);
+    assert(memcmp(key[0].shr, key[1].shr, shr_len) == 0);
+
+    free(key[0].shr);
+    free(key[1].shr);
+}
+
+static void test_ecc_derive_nist_p256_templ_none(void **state) {
+    /* The CKD_NONE generates a shared secrets of 32 bytes when using
+     * a P-256 curve. */
+    test_ecc_derive_nist_p256_templ(state, 0, CKD_NULL, 32);
 }
 
 int main() {
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ,
+        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ_none,
                                         test_setup, test_teardown),
     };
 

--- a/test/integration/pkcs-ecdh.int.c
+++ b/test/integration/pkcs-ecdh.int.c
@@ -115,7 +115,8 @@ static void gen_nistp256(CK_SESSION_HANDLE session, CK_BYTE id,
 
 static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
                          uint8_t *pubkey, size_t pubkey_len,
-                         uint8_t *secret, size_t secret_len) {
+                         uint8_t *secret, size_t secret_len,
+                         ck_ec_kdf_t kdf) {
 
     CK_MECHANISM mechanism = { CKM_ECDH1_DERIVE, NULL, 0 };
     CK_ATTRIBUTE secret_template[] = {
@@ -142,7 +143,7 @@ static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
         ATTR_VAR(CKA_VALUE, secret, secret_len),
     };
     CK_ECDH1_DERIVE_PARAMS params = {
-        .kdf = CKD_NULL,
+        .kdf = kdf,
         .ulSharedDataLen = 0,
         .pSharedData = secret,
         .ulPublicDataLen = 0,
@@ -184,7 +185,7 @@ static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
     assert_int_equal(rv, CKR_OK);
 }
 
-static void test_ecc_derive_nist_p256_templ(void **state) {
+static void test_ecc_derive_nist_p256_templ(void **state, CK_BYTE id_base, ck_ec_kdf_t kdf) {
 
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE session = ti->handle;
@@ -196,8 +197,8 @@ static void test_ecc_derive_nist_p256_templ(void **state) {
         size_t plen;
         CK_BYTE id;
     } key[] = {
-        [0] = { .id = 0x00, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
-        [1] = { .id = 0x01, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
+        [0] = { .id = id_base, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
+        [1] = { .id = id_base + 1, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
     };
 
     user_login(session);
@@ -205,16 +206,22 @@ static void test_ecc_derive_nist_p256_templ(void **state) {
     gen_nistp256(session, key[0].id, key[0].pub, &key[0].plen);
     gen_nistp256(session, key[1].id, key[1].pub, &key[1].plen);
 
-    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32);
-    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32);
+    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32, kdf);
+    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32, kdf);
 
     assert(memcmp(key[0].shr, key[1].shr, 32) == 0);
+}
+
+static void test_ecc_derive_nist_p256_templ_none(void **state) {
+    /* The CKD_NONE generates a shared secrets of 32 bytes when using
+     * a P-256 curve. */
+    test_ecc_derive_nist_p256_templ(state, 0, CKD_NULL);
 }
 
 int main() {
 
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ,
+        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ_none,
                                         test_setup, test_teardown),
     };
 

--- a/test/integration/pkcs-ecdh.int.c
+++ b/test/integration/pkcs-ecdh.int.c
@@ -185,37 +185,45 @@ static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
     assert_int_equal(rv, CKR_OK);
 }
 
-static void test_ecc_derive_nist_p256_templ(void **state, CK_BYTE id_base, ck_ec_kdf_t kdf) {
+static void test_ecc_derive_nist_p256_templ(void **state, CK_BYTE id_base, ck_ec_kdf_t kdf, size_t shr_len) {
 
     test_info *ti = test_info_from_state(state);
     CK_SESSION_HANDLE session = ti->handle;
 
     /* NIST P-256: 32 bytes */
     struct {
-        CK_BYTE shr[32];    /* Shared secret is the length of the key */
+        CK_BYTE *shr;       /* Shared secret */
         CK_BYTE pub[70];    /* Allocate extra space for encoding      */
         size_t plen;
         CK_BYTE id;
     } key[] = {
-        [0] = { .id = id_base, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
-        [1] = { .id = id_base + 1, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
+        [0] = { .id = id_base, .shr = NULL, .pub = { 0 }, .plen = 70 },
+        [1] = { .id = id_base + 1, .shr = NULL, .pub = { 1 }, .plen = 70 },
     };
 
     user_login(session);
 
-    gen_nistp256(session, key[0].id, key[0].pub, &key[0].plen);
-    gen_nistp256(session, key[1].id, key[1].pub, &key[1].plen);
+    for (size_t i=0; i <= 1; i++) {
+        key[i].shr = malloc(shr_len);
+        assert_non_null(key[i].shr);
+        memset(key[i].shr, i, shr_len);
 
-    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32, kdf);
-    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32, kdf);
+        gen_nistp256(session, key[i].id, key[i].pub, &key[i].plen);
+    }
 
-    assert(memcmp(key[0].shr, key[1].shr, 32) == 0);
+    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, shr_len, kdf);
+    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, shr_len, kdf);
+
+    assert(memcmp(key[0].shr, key[1].shr, shr_len) == 0);
+
+    free(key[0].shr);
+    free(key[1].shr);
 }
 
 static void test_ecc_derive_nist_p256_templ_none(void **state) {
     /* The CKD_NONE generates a shared secrets of 32 bytes when using
      * a P-256 curve. */
-    test_ecc_derive_nist_p256_templ(state, 0, CKD_NULL);
+    test_ecc_derive_nist_p256_templ(state, 0, CKD_NULL, 32);
 }
 
 int main() {


### PR DESCRIPTION
This PR adds support for the `CKD_SHA1_KDF` key derivation function to the Elliptic Curve Diffie Helman functionality in tpm2-pkcs11.

This Fixes https://github.com/tpm2-software/tpm2-pkcs11/issues/914 (at least partially).

Some more work is required to get it fully working:

- https://github.com/tpm2-software/tpm2-pkcs11/pull/913 should be merged as well.
- `openssl` with the `pkcs11-provider` uses a `CKS_RO_USER_FUNCTIONS` session state when calling derive. This makes `object_create()` in `src/lib/object.c` fail, because it assumes that all objects are token objects, when in fact a session object should be created here.

  See https://github.com/tpm2-software/tpm2-pkcs11/pull/921 for more information.