### PR TITLE
test: update to cmocka version 2

### DIFF
--- a/test/fuzz/init-token-sopin.fuzz.c
+++ b/test/fuzz/init-token-sopin.fuzz.c
@@ -24,22 +24,22 @@ static void test(void **state) {
      */
     setenv("TPM2_PKCS11_STORE", ":memory:", 1);
 
-    will_return_always(__wrap_backend_fapi_init, CKR_GENERAL_ERROR);
-    will_return_always(__wrap_Esys_Initialize, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Tss2_TctiLdr_Initialize, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Tss2_TctiLdr_Finalize, TSS2_RC_SUCCESS);
-    //will_return_always(__wrap_Esys_GetCapability, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_Finalize, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_TR_FromTPMPublic, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_TR_Serialize, TSS2_RC_SUCCESS);
-    // will_return_always(__wrap_Esys_TR_Deserialize, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_TR_SetAuth, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_StartAuthSession, TSS2_RC_SUCCESS);
-    // will_return_always(__wrap_Esys_TRSess_GetAttributes, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_TRSess_SetAttributes, TSS2_RC_SUCCESS);
-    // will_return_always(__wrap_Esys_CreateLoaded, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_Create, TSS2_RC_SUCCESS);
-    will_return_always(__wrap_Esys_FlushContext, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_backend_fapi_init, CKR_GENERAL_ERROR);
+    will_return_uint_always(__wrap_Esys_Initialize, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Tss2_TctiLdr_Initialize, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Tss2_TctiLdr_Finalize, TSS2_RC_SUCCESS);
+    //will_return_uint_always(__wrap_Esys_GetCapability, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_Finalize, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_TR_FromTPMPublic, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_TR_Serialize, TSS2_RC_SUCCESS);
+    // will_return_uint_always(__wrap_Esys_TR_Deserialize, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_TR_SetAuth, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_StartAuthSession, TSS2_RC_SUCCESS);
+    // will_return_uint_always(__wrap_Esys_TRSess_GetAttributes, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_TRSess_SetAttributes, TSS2_RC_SUCCESS);
+    // will_return_uint_always(__wrap_Esys_CreateLoaded, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_Create, TSS2_RC_SUCCESS);
+    will_return_uint_always(__wrap_Esys_FlushContext, TSS2_RC_SUCCESS);
 
     CK_RV rv = C_Initialize(NULL);
     assert_int_equal(rv, CKR_OK);

--- a/test/integration/pkcs-find-objects.int.c
+++ b/test/integration/pkcs-find-objects.int.c
@@ -61,7 +61,7 @@ static int test_setup_by_label(void **state) {
         }
     }
 
-    assert_in_range(i, 0, count - 1);
+    assert_uint_in_range(i, 0, count - 1);
 
     /* open a session on found slot */
     CK_SESSION_HANDLE session;

--- a/test/integration/pkcs-get-attribute-value.int.c
+++ b/test/integration/pkcs-get-attribute-value.int.c
@@ -209,7 +209,7 @@ static void test_get_attribute_value_multiple_fail(void **state) {
 
     rv = C_GetAttributeValue(ti->hSession, ti->hObject, template, 3);
     // Return should be CKR_ATTRIBUTE_TYPE_INVALID or CKR_BUFFER_TOO_SMALL
-    assert_in_set(rv, expected_returns, 2);
+    assert_uint_in_set(rv, expected_returns, 2);
     assert_int_equal(template[0].ulValueLen, CK_UNAVAILABLE_INFORMATION);
     assert_string_equal(template[1].pValue, "mykeylabel");
     assert_int_equal(template[2].ulValueLen, CK_UNAVAILABLE_INFORMATION);

--- a/test/integration/pkcs-get-mechanism.int.c
+++ b/test/integration/pkcs-get-mechanism.int.c
@@ -61,7 +61,7 @@ void test_get_mechanism_list_good(void **state) {
     // Only return the number of mechanisms
     CK_RV rv = C_GetMechanismList(slot_id, NULL, &mech_cnt);
     assert_int_equal(rv, CKR_OK);
-    assert_in_range(mech_cnt, 1, ARRAY_LEN(mechs));
+    assert_uint_in_range(mech_cnt, 1, ARRAY_LEN(mechs));
 
     // Return List of mechanisms
     rv = C_GetMechanismList(slot_id, mechs, &mech_cnt);
@@ -150,7 +150,7 @@ void test_get_mechanism_info_good(void **state) {
         assert_int_equal(rv, CKR_OK);
 
         assert_int_equal(mech_info.ulMinKeySize, 1024);
-        assert_in_range(mech_info.ulMaxKeySize, 2048, 3072);
+        assert_uint_in_range(mech_info.ulMaxKeySize, 2048, 3072);
         assert_int_equal(mech_info.flags, rsa_mechs[i].flags);
     }
 
@@ -167,8 +167,8 @@ void test_get_mechanism_info_good(void **state) {
         rv = C_GetMechanismInfo(slot_id, ecc_mechs[i].mech, &mech_info);
         assert_int_equal(rv, CKR_OK);
 
-        assert_in_range(mech_info.ulMinKeySize, 192, 256);
-        assert_in_range(mech_info.ulMaxKeySize, 384, 638);
+        assert_uint_in_range(mech_info.ulMinKeySize, 192, 256);
+        assert_uint_in_range(mech_info.ulMaxKeySize, 384, 638);
         assert_int_equal(mech_info.flags, ecc_mechs[i].flags);
     }
 

--- a/test/integration/pkcs-sign-verify.int.c
+++ b/test/integration/pkcs-sign-verify.int.c
@@ -433,7 +433,7 @@ static void test_sign_verify_CKM_ECDSA(void **state) {
             &siglen);
     assert_int_equal(rv, CKR_OK);
     /* the actual siglength may be smaller than the previously reported siglen */
-    assert_in_range(siglen, 1, tmp_len);
+    assert_uint_in_range(siglen, 1, tmp_len);
 
     /* try the public key verification */
     rv = C_VerifyInit(session, &mech, pubkey);
@@ -490,7 +490,7 @@ static void test_sign_verify_CKM_ECDSA_SHA1(void **state) {
             ckm_ecdsa_sha1_sig, &ckm_ecdsa_sha1_siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(ckm_ecdsa_sha1_siglen, 1, tmp_len);
+    assert_uint_in_range(ckm_ecdsa_sha1_siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, objhandles[0]);
     assert_int_equal(rv, CKR_OK);
@@ -546,7 +546,7 @@ static void test_sign_verify_CKM_ECDSA_SHA256(void **state) {
             ckm_ecdsa_sha256_sig, &ckm_ecdsa_sha256_siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(ckm_ecdsa_sha256_siglen, 1, tmp_len);
+    assert_uint_in_range(ckm_ecdsa_sha256_siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, objhandles[0]);
     assert_int_equal(rv, CKR_OK);
@@ -602,7 +602,7 @@ static void test_sign_verify_CKM_ECDSA_SHA384(void **state) {
             ckm_ecdsa_sha384_sig, &ckm_ecdsa_sha384_siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(ckm_ecdsa_sha384_siglen, 1, tmp_len);
+    assert_uint_in_range(ckm_ecdsa_sha384_siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, objhandles[0]);
     assert_int_equal(rv, CKR_OK);
@@ -658,7 +658,7 @@ static void test_sign_verify_CKM_ECDSA_SHA512(void **state) {
             ckm_ecdsa_sha512_sig, &ckm_ecdsa_sha512_siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(ckm_ecdsa_sha512_siglen, 1, tmp_len);
+    assert_uint_in_range(ckm_ecdsa_sha512_siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, objhandles[0]);
     assert_int_equal(rv, CKR_OK);
@@ -722,7 +722,7 @@ static void test_pss(CK_SESSION_HANDLE session,
             sig, &siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(siglen, 1, tmp_len);
+    assert_uint_in_range(siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, key[1]);
     assert_int_equal(rv, CKR_OK);
@@ -776,7 +776,7 @@ static void test_pss2(CK_SESSION_HANDLE session,
             sig, &siglen);
     assert_int_equal(rv, CKR_OK);
     /* actual size must not be larger than previously indicated */
-    assert_in_range(siglen, 1, tmp_len);
+    assert_uint_in_range(siglen, 1, tmp_len);
 
     rv = C_VerifyInit(session, &mech, key[1]);
     assert_int_equal(rv, CKR_OK);

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -918,7 +918,7 @@ static void test_init_pobject_from_stmt_tpm_create_transient_primary_from_templa
         { .rv = CKR_GENERAL_ERROR     }, /* tpm_create_transient_primary_from_template */
     };
 
-    will_return_always(__wrap_strdup,                       &d[0]);
+    will_return_ptr_always(__wrap_strdup,                   &d[0]);
     will_return(__wrap_sqlite3_column_bytes,                &d[1]);
     will_return(__wrap_sqlite3_column_text,                 &d[2]);
     will_return(__wrap_sqlite3_column_text,                 &d[3]);
@@ -1190,12 +1190,12 @@ static void test_db_get_tokens_token_overcount_fail(void **state) {
         { .rc = SQLITE_OK             }, /* sqlite3_finalize */
     };
 
-    will_return_always(__wrap_sqlite3_prepare_v2,  &d[0]);
-    will_return_always(__wrap_sqlite3_step,        &d[1]);
-    will_return_always(__wrap_sqlite3_data_count,  &d[2]);
-    will_return_always(token_min_init,             &d[3]);
-    will_return_always(init_pobject,               &d[4]);
-    will_return(__wrap_sqlite3_finalize,           &d[5]);
+    will_return_ptr_always(__wrap_sqlite3_prepare_v2,  &d[0]);
+    will_return_ptr_always(__wrap_sqlite3_step,        &d[1]);
+    will_return_ptr_always(__wrap_sqlite3_data_count,  &d[2]);
+    will_return_ptr_always(token_min_init,             &d[3]);
+    will_return_ptr_always(init_pobject,               &d[4]);
+    will_return(__wrap_sqlite3_finalize,               &d[5]);
 
     CK_RV rv = db_get_tokens(tok, &len);
     assert_int_equal(rv, CKR_GENERAL_ERROR);


### PR DESCRIPTION
The tests generate warnings / fail to build with `-Werror` on systems that ship with cmocka version 2.0 and newer because a couple of non-typesafe macros have been replaced by typesafe alternatives and the previous versions have been deprecated.

Sadly it looks like they decided against having both the new and old API in parallel (in a non-deprecation-warning-generating way) for a couple of releases and instead added and deprecated them in 2.0.

We will likely want to delay merging this PR until all relevant distributions contain cmocka 2.0 or newer.