### PR TITLE
utils: pass char * to strchr to not discard const qualifier

### DIFF
--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -240,7 +240,7 @@ twist aes256_gcm_decrypt(const twist key, const twist objauth) {
 
     char *iv = (char *)objcopy;
 
-    char *tag = strchr(objcopy, ':');
+    char *tag = strchr(iv, ':');
     if (!tag) {
         LOGE("Could not find : to split tag");
         goto out;


### PR DESCRIPTION
The twist type is defined as `const char*`. This causes current versions of gcc (15.2.1 in my case) to generate the following warning:

    src/lib/utils.c: In function 'aes256_gcm_decrypt':
    src/lib/utils.c:243:17: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
      243 |     char *tag = strchr(objcopy, ':');
          |                 ^~~~~~
    cc1: all warnings being treated as errors

Most likely because gcc passes through the const qualifier to the strchr output and the subsequent assignment to `tag` would remove it.

Use `iv` instead of `objcopy`, which points to the same memory but is casted to remove the `const` qualifier.