### PR TITLE
src/lib/tpm: return NULL for twist on auth failure

### DIFF
--- a/src/lib/tpm.c
+++ b/src/lib/tpm.c
@@ -1037,7 +1037,7 @@ twist tpm_unseal(tpm_ctx *ctx, uint32_t handle, twist objauth) {
 
     bool result = set_esys_auth(ctx->esys_ctx, handle, objauth);
     if (!result) {
-        return false;
+        return NULL;
     }
 
     TPM2B_SENSITIVE_DATA *unsealed_data = NULL;


### PR DESCRIPTION
`tpm_unseal` returns `twist` (a const char pointer alias).
Returning `false` in the error path is a type mismatch that fails with stricter compiler settings.
Return `NULL` instead.