### PR TITLE
db: fix C code check of backup failure

### DIFF
--- a/src/lib/db.c
+++ b/src/lib/db.c
@@ -2568,7 +2568,7 @@ CK_RV db_init_new(sqlite3 *db) {
 static CK_RV db_verify_update_ok(const char *dbpath) {
 
     char buf[PATH_MAX];
-    unsigned l = snprintf(buf, sizeof(buf), "%s.old", dbpath);
+    unsigned l = snprintf(buf, sizeof(buf), "%s.bak", dbpath);
     if (l >= sizeof(buf)) {
         LOGE("Backup DB path is longer than PATH_MAX");
         return CKR_GENERAL_ERROR;


### PR DESCRIPTION
The C code should be looking for .bak to indicate a failure, .old is just there as the last db so nothing is lost.

Partially Fixes: #826