### PR TITLE
sign: skip ssl_util_attrs_to_evp when signing

### DIFF
--- a/src/lib/sign.c
+++ b/src/lib/sign.c
@@ -36,7 +36,7 @@ struct sign_opdata {
     const EVP_MD *md;
 };
 
-static sign_opdata *sign_opdata_new(mdetail *mdtl, CK_MECHANISM_PTR mechanism, tobject *tobj) {
+static sign_opdata *sign_opdata_new(operation op, mdetail *mdtl, CK_MECHANISM_PTR mechanism, tobject *tobj) {
 
     int padding = 0;
     CK_RV rv = mech_get_padding(mdtl,
@@ -74,9 +74,11 @@ static sign_opdata *sign_opdata_new(mdetail *mdtl, CK_MECHANISM_PTR mechanism, t
     }
 
     EVP_PKEY *pkey = NULL;
-    rv = ssl_util_attrs_to_evp(tobj->attrs, &pkey);
-    if (rv != CKR_OK) {
-        return NULL;
+    if (op != operation_sign) {
+        rv = ssl_util_attrs_to_evp(tobj->attrs, &pkey);
+        if (rv != CKR_OK) {
+            return NULL;
+        }
     }
 
     sign_opdata *opdata = calloc(1, sizeof(sign_opdata));
@@ -226,7 +228,7 @@ static CK_RV common_init(operation op, session_ctx *ctx, CK_MECHANISM_PTR mechan
         }
     }
 
-    sign_opdata *opdata = sign_opdata_new(tok->mdtl,
+    sign_opdata *opdata = sign_opdata_new(op, tok->mdtl,
             mechanism, tobj);
     if (!opdata) {
         tpm_opdata_free(&tpm_opdata);


### PR DESCRIPTION
Starting with this libp11 commit [1] (release 0.4.18), tpm2-pkcs + opennsl is broken. Any attempt to sign result in the following error:

```
$ openssl dgst -engine pkcs11 -keyform engine -sign "pkcs11:object=key-label;type=private" -sha256 -out /tmp/example.bin /dev/null
Engine "pkcs11" set.
WARNING:fapi:src/tss2-fapi/api/Fapi_List.c:228:Fapi_List_Finish() Profile of path not provisioned: /HS/SRK
ERROR:fapi:src/tss2-fapi/api/Fapi_List.c:81:Fapi_List() ErrorCode (0x00060034) Entities_List
WARNING: Listing FAPI token objects failed: "fapi:Provisioning was not executed."
Please see https://github.com/tpm2-software/tpm2-pkcs11/blob/1.10.0/docs/FAPI.md for more details
WARNING: Getting tokens from fapi backend failed.
Enter PKCS#11 token PIN for tpm-token:
ERROR: EVP_PKEY_fromdata_init: error:03000096:digital envelope routines::operation not supported for this keytype
Error signing data
```

This also breaks EAP_TLS auth in wpa_supplicant.

A suggested fix from issue [2] solves this problem. Specifically, we skip generation of pkey in sign_opdata_new for signing operations, since it is not actually needed in that case.

[1] https://github.com/OpenSC/libp11/commit/60329e0502f751705bb939ad06574e36e4a42bc2
[2] https://github.com/tpm2-software/tpm2-pkcs11/issues/830