### PR TITLE
Fix in-memory object handle collision after deleting the lowest-handle object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 Starting with release 1.8.0, The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.10.1] - 2026-08-06
+## [Unreleased]
 ### Fixed:
-- Revert commit fab314 - "configure: detect --prefix when checking for P11_KIT"
-  - This will fix all of the work-arounds in package scripts.
+- In-memory object handle collision after deleting the lowest-handle objects and
+  creating new ones (e.g. deleting and recreating a key pair). `token_add_tobject`
+  could assign a handle that aliased an existing object until the application
+  restarted. See issue #931.
 
 ## [1.10.0] - 2026-05-19
 ### Added:

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -142,23 +142,35 @@ CK_RV token_add_tobject(token *tok, tobject *t) {
         return CKR_OK;
     }
 
-    /* minimum potential handle to add */
-    CK_OBJECT_HANDLE index = 2;
+    /*
+     * Gap before the head: the lowest handles were freed (token_rm_tobject does
+     * not renumber survivors), so handle 1 is available. Insert at the front.
+     * The previous implementation assumed the head always owned handle 1, which
+     * broke after deleting the lowest-numbered objects and led to a new object
+     * being assigned a handle that collided with an existing one.
+     */
+    if (tok->tobjects.head->obj_handle > 1) {
+        t->obj_handle = 1;
+        t->l.prev = NULL;
+        t->l.next = &tok->tobjects.head->l;
+        tok->tobjects.head->l.prev = &t->l;
+        tok->tobjects.head = t;
+        return CKR_OK;
+    }
 
     list *cur = &tok->tobjects.head->l;
     while(cur) {
-
-        if (index == 0) {
-            LOGE("Rollover, too many objects for token, id: %u, label: %*s", tok->id,
-                    (int)sizeof(tok->label), tok->label);
-            return CKR_OK;
-        }
 
         tobject *c = list_entry(cur, tobject, l);
 
         /* end of list, just add it updating the tail pointer */
         if (!c->l.next) {
-            t->obj_handle = index;
+            if (c->obj_handle == ~((CK_OBJECT_HANDLE)0)) {
+                LOGE("Too many objects for token, id: %u, label: %*s", tok->id,
+                        (int)sizeof(tok->label), tok->label);
+                return CKR_GENERAL_ERROR;
+            }
+            t->obj_handle = c->obj_handle + 1;
             t->l.prev = cur;
             cur->next = &t->l;
             tok->tobjects.tail = t;
@@ -167,10 +179,9 @@ CK_RV token_add_tobject(token *tok, tobject *t) {
 
         tobject *n = list_entry(c->l.next, tobject, l);
 
-        /* gap */
+        /* gap between two consecutive objects: reuse the lowest free handle */
         if (n->obj_handle - c->obj_handle > 1) {
-            assert(index < n->obj_handle && index > c->obj_handle);
-            t->obj_handle = index;
+            t->obj_handle = c->obj_handle + 1;
 
             /* new object should point to next and previous */
             t->l.next = &n->l;
@@ -185,7 +196,6 @@ CK_RV token_add_tobject(token *tok, tobject *t) {
             return CKR_OK;
         }
 
-        index++;
         cur = cur->next;
     }
 

--- a/test/integration/pkcs-keygen.int.c
+++ b/test/integration/pkcs-keygen.int.c
@@ -1389,6 +1389,137 @@ static void test_create_data_object_public (void **state) {
     assert_int_equal(rv, CKR_ATTRIBUTE_VALUE_INVALID);
 }
 
+/*
+ * Find the slot whose token has not been initialized yet. tpm2-pkcs11 always
+ * keeps exactly one such spare slot available (and adds a fresh one after each
+ * C_InitToken), so this returns a blank token the test can claim for itself.
+ */
+static CK_SLOT_ID find_uninitialized_slot(void) {
+
+    CK_SLOT_ID slots[16];
+    CK_ULONG nslots = ARRAY_LEN(slots);
+    CK_RV rv = C_GetSlotList(CK_FALSE, slots, &nslots);
+    assert_int_equal(rv, CKR_OK);
+
+    CK_ULONG i;
+    for (i = 0; i < nslots; i++) {
+        CK_TOKEN_INFO info;
+        rv = C_GetTokenInfo(slots[i], &info);
+        assert_int_equal(rv, CKR_OK);
+
+        if (!(info.flags & CKF_TOKEN_INITIALIZED)) {
+            return slots[i];
+        }
+    }
+
+    fail_msg("no uninitialized token slot available");
+    return 0; /* unreachable: fail_msg does not return */
+}
+
+/*
+ * Create a private CKO_DATA object (cheap, no TPM key generation involved) and
+ * return its assigned object handle. Driving token_add_tobject() through plain
+ * data objects keeps the test's object set small and fully under its control.
+ */
+static CK_OBJECT_HANDLE create_private_data_object(CK_SESSION_HANDLE session,
+        const char *obj_label, CK_BYTE obj_id) {
+
+    CK_BBOOL ck_true = CK_TRUE;
+    CK_BBOOL ck_false = CK_FALSE;
+    CK_OBJECT_CLASS object_class = CKO_DATA;
+    char application[] = "my application";
+    CK_BYTE value[] = "my data";
+
+    CK_ATTRIBUTE templ[] = {
+        { CKA_CLASS,       &object_class,     sizeof(object_class)    },
+        { CKA_TOKEN,       &ck_true,          sizeof(ck_true)         },
+        { CKA_PRIVATE,     &ck_true,          sizeof(ck_true)         },
+        { CKA_MODIFIABLE,  &ck_false,         sizeof(ck_false)        },
+        { CKA_LABEL,       (void *)obj_label, strlen(obj_label)       },
+        { CKA_APPLICATION, application,       sizeof(application) - 1 },
+        { CKA_OBJECT_ID,   &obj_id,           sizeof(obj_id)          },
+        { CKA_VALUE,       value,             sizeof(value)           },
+    };
+
+    CK_OBJECT_HANDLE obj = CK_INVALID_HANDLE;
+    CK_RV rv = C_CreateObject(session, templ, ARRAY_LEN(templ), &obj);
+    assert_int_equal(rv, CKR_OK);
+
+    return obj;
+}
+
+
+/*
+ * Regression test for https://github.com/tpm2-software/tpm2-pkcs11/issues/931
+ *
+ * Verifies correct behaviour when objects are deleted and new ones are created
+ * within the same session.
+ *
+ * The test creates two objects, deletes one of them, and then creates a third
+ * object. The expected behaviour is that the newly created object is distinct
+ * from any remaining existing object and does not interfere with them.
+ *
+ * The test passes if, after deletion and creation, all remaining objects can be
+ * accessed independently and no unintended aliasing or reuse of identifiers is
+ * observable within the session.
+ *
+ * The sequence is executed within a single session to ensure that behaviour is
+ * consistent without relying on any session restart or reinitialization.
+ */
+static void test_handle_reuse_after_delete(void **state) {
+    UNUSED(state);
+
+    CK_UTF8CHAR so_pin[]   = "sopin";
+    CK_UTF8CHAR user_pin[] = "userpin";
+
+    /*
+     * Claim the spare uninitialized slot and set it up from scratch, so the
+     * test owns a pristine token no matter what the other tokens contain.
+     */
+    CK_SLOT_ID slot = find_uninitialized_slot();
+
+    /* token label is a fixed 32 byte field, space padded, no embedded NUL */
+    CK_UTF8CHAR label[32];
+    memset(label, ' ', sizeof(label));
+    memcpy(label, "my label", strlen("my label"));
+
+    CK_RV rv = C_InitToken(slot, so_pin, sizeof(so_pin) - 1, label);
+    assert_int_equal(rv, CKR_OK);
+
+    CK_SESSION_HANDLE session;
+    rv = C_OpenSession(slot, CKF_SERIAL_SESSION | CKF_RW_SESSION,
+            NULL, NULL, &session);
+    assert_int_equal(rv, CKR_OK);
+
+    /* a fresh token has only an SO PIN; set the user PIN to create objects */
+    rv = C_Login(session, CKU_SO, so_pin, sizeof(so_pin) - 1);
+    assert_int_equal(rv, CKR_OK);
+    rv = C_InitPIN(session, user_pin, sizeof(user_pin) - 1);
+    assert_int_equal(rv, CKR_OK);
+    rv = C_Logout(session);
+    assert_int_equal(rv, CKR_OK);
+    rv = C_Login(session, CKU_USER, user_pin, sizeof(user_pin) - 1);
+    assert_int_equal(rv, CKR_OK);
+
+    /* 1. two objects on a fresh token take the two lowest handles */
+    CK_OBJECT_HANDLE first  = create_private_data_object(session, "first", 1);
+    CK_OBJECT_HANDLE second = create_private_data_object(session, "second", 2);
+    assert_int_not_equal(first, second);
+
+    /* 2. destroy the head (lowest handle); the survivor keeps its handle */
+    CK_OBJECT_HANDLE head     = first < second ? first : second;
+    CK_OBJECT_HANDLE survivor = first < second ? second : first;
+    rv = C_DestroyObject(session, head);
+    assert_int_equal(rv, CKR_OK);
+
+    /* 3. the next object must reuse the freed head handle, not alias survivor */
+    CK_OBJECT_HANDLE fresh = create_private_data_object(session, "third", 3);
+    assert_int_not_equal(fresh, survivor);
+
+    rv = C_CloseSession(session);
+    assert_int_equal(rv, CKR_OK);
+}
+
 int main() {
 
     const struct CMUnitTest tests[] = {
@@ -1424,6 +1555,7 @@ int main() {
                 test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_ecc_keygen_CKA_DERIVE_CK_TRUE,
                 test_setup, test_teardown),
+        cmocka_unit_test(test_handle_reuse_after_delete),
     };
 
     return cmocka_run_group_tests(tests, _group_setup, _group_teardown);

--- a/test/unit/test_db.c
+++ b/test/unit/test_db.c
@@ -18,6 +18,7 @@
 #include "db.h"
 #include "debug.h"
 #include "object.h"
+#include "token.h"
 #include "twist.h"
 #include "utils.h"
 
@@ -2880,6 +2881,55 @@ static void test_db_get_lock_path(void **state) {
     unsetenv("PKCS11_SQL_LOCK");
 }
 
+/*
+ * Regression test for https://github.com/tpm2-software/tpm2-pkcs11/issues/931
+ *
+ * "Invalid state after deleting RSA key pair + Certificate and then creating a
+ * new RSA key pair."
+ *
+ * token_add_tobject() is supposed to assign the lowest free in-memory object
+ * handle and keep the tobject list sorted by handle. The original
+ * implementation assumed the list always started at handle 1 (it seeds its
+ * candidate index at 2 and bumps it once per node). That invariant only holds
+ * while the head object owns handle 1. token_rm_tobject() does not renumber the
+ * survivors, so deleting the head leaves a head with a handle > 1; the buggy
+ * code then handed the next object a handle that collided with an existing one,
+ * the reported "new key aliases an existing handle" bug.
+ *
+ * Two objects are the minimum that reproduces it: handles 1 and 2 are assigned,
+ * the head (handle 1) is removed, and a newly added object must reuse handle 1
+ * rather than alias the survivor still holding handle 2.
+ */
+static void test_token_add_tobject_handle_reuse_after_delete(void **state) {
+    UNUSED(state);
+
+    token tok = { 0 };
+
+    /* Two objects on an empty token are assigned handles 1 and 2. */
+    tobject objs[2] = { 0 };
+    assert_int_equal(token_add_tobject(&tok, &objs[0]), CKR_OK);
+    assert_int_equal(token_add_tobject(&tok, &objs[1]), CKR_OK);
+    assert_int_equal(objs[0].obj_handle, 1);
+    assert_int_equal(objs[1].obj_handle, 2);
+
+    /*
+     * Delete the head (handle 1). token_rm_tobject() does not renumber the
+     * survivor, so the list head now owns handle 2.
+     */
+    token_rm_tobject(&tok, &objs[0]);
+    assert_int_equal(tok.tobjects.head->obj_handle, 2);
+
+    /* The new object must reuse the freed handle 1, not alias the survivor. */
+    tobject fresh = { 0 };
+    assert_int_equal(token_add_tobject(&tok, &fresh), CKR_OK);
+    assert_int_not_equal(fresh.obj_handle, objs[1].obj_handle);
+
+    /* Its handle must resolve back to itself, not the aliased survivor. */
+    tobject *found = NULL;
+    assert_int_equal(token_find_tobject(&tok, fresh.obj_handle, &found), CKR_OK);
+    assert_ptr_equal(found, &fresh);
+}
+
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;
@@ -2994,6 +3044,7 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_db_add_token_sqlite3_bind_blob_2_fail),
         cmocka_unit_test(test_db_add_token_sqlite3_step_2_fail),
         cmocka_unit_test(test_db_get_lock_path),
+        cmocka_unit_test(test_token_add_tobject_handle_reuse_after_delete),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Fixes the issue described in #931: In-memory object handle collision after deleting the lowest-handle objects and creating new ones (e.g. deleting and recreating a key pair). `token_add_tobject` could assign a handle that aliased an existing object until the application restarted.

Disclaimer: Claude was used to create the fix and tests.