### PR TITLE
ci: Add nixos-26.05-pkcs11 to the workflow matrix

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -27,8 +27,9 @@ if [[ "$CC" == clang* ]]; then
   echo "Detecting clang, enable asan"
   config_flags="--enable-asan"
   export ASAN_ENABLED=true
-  if [[ "${DOCKER_IMAGE:-}" == "ubuntu-26.04-pkcs11" ]] ||
-    [[ "${DOCKER_IMAGE:-}" == "fedora-44-pkcs11" ]]; then
+  if [[ "${DOCKER_IMAGE:-}" == "nixos-26.05-pkcs11" ]] ||
+     [[ "${DOCKER_IMAGE:-}" == "ubuntu-26.04-pkcs11" ]] ||
+     [[ "${DOCKER_IMAGE:-}" == "fedora-44-pkcs11" ]]; then
     echo "${DOCKER_IMAGE} ships pkcs11-tool with RTLD_DEEPBIND and is incompatible with asan"
     config_flags=""
     export ASAN_ENABLED=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.ref, 'coverity_scan')"
     strategy:
       matrix:
-        docker_image: [ ubuntu-26.04-pkcs11, fedora-44-pkcs11, opensuse-leap-pkcs11 ]
+        docker_image: [ ubuntu-26.04-pkcs11, fedora-44-pkcs11, opensuse-leap-pkcs11, nixos-26.05-pkcs11 ]
         compiler: [gcc, clang]
         exclude:
           - docker_image: ubuntu-26.04-pkcs11

--- a/Makefile.am
+++ b/Makefile.am
@@ -119,7 +119,7 @@ AM_TESTS_ENVIRONMENT = \
     TPM2_PKCS11_MODULE=$(abs_builddir)/src/.libs/libtpm2_pkcs11.so \
     TEST_JAVA_ROOT=$(JAVAROOT) \
     PACKAGE_URL=$(PACKAGE_URL) \
-    CC=$(CC) \
+    CC='$(CC)' \
     dbus-run-session
 
 TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES) $(p11lib_LTLIBRARIES) $(AM_LDFLAGS) $(CMOCKA_LIBS) $(CRYPTO_LIBS)


### PR DESCRIPTION
This PR adds NixOS 26.05 to the tpm2-pkcs11 CI workflow matrix and includes two fixes uncovered by the new CI environment:

* Quote `CC` in `AM_TESTS_ENVIRONMENT` so compiler commands containing additional flags, such as `clang -std=gnu23`, are passed correctly to the integration tests.
* Disable ASan for the NixOS PKCS#11 job because the OpenSC `pkcs11-tool` uses `RTLD_DEEPBIND`, which is incompatible with the sanitizer runtime.

With these changes, the existing build and integration tests can run successfully using the new `nixos-26.05-pkcs11` container.
