### PR TITLE
Fixes "Host memory error" when using tpm with wpa_supplicant

### DIFF
--- a/src/lib/ssl_util.c
+++ b/src/lib/ssl_util.c
@@ -125,25 +125,71 @@ static CK_RV get_RSA_evp_pubkey(CK_ATTRIBUTE_PTR e_attr, CK_ATTRIBUTE_PTR n_attr
 
     /* convert params to EVP key */
     evp_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
-    if (!evp_ctx) {
-        SSL_UTIL_LOGE("EVP_PKEY_CTX_new_id");
-        goto out;
+    if (evp_ctx) {
+        int rc = EVP_PKEY_fromdata_init(evp_ctx);
+        if (rc == 1) {
+            rc = EVP_PKEY_fromdata(evp_ctx, out_pkey, EVP_PKEY_PUBLIC_KEY, params);
+            if (rc == 1) {
+                rv = CKR_OK;
+                goto out;
+            }
+            SSL_UTIL_LOGE("EVP_PKEY_fromdata");
+        } else {
+            SSL_UTIL_LOGE("EVP_PKEY_fromdata_init");
+        }
+    } else {
+        SSL_UTIL_LOGE("EVP_PKEY_CTX_new_from_name");
     }
 
-    int rc = EVP_PKEY_fromdata_init(evp_ctx);
-    if (rc != 1) {
-        SSL_UTIL_LOGE("EVP_PKEY_fromdata_init");
-        goto out;
-    }
+    /*
+     * Fallback: EVP_PKEY_fromdata_init() requires ctx->keymgmt to be set,
+     * which OpenSSL populates via EVP_KEYMGMT_fetch() -- but that fetch is
+     * SKIPPED whenever some other component sharing this process (e.g. an
+     * ENGINE such as libp11's engine_pkcs11, loaded via "-engine pkcs11"
+     * for smartcard support) has registered itself as the process-wide
+     * default EVP_PKEY_METHOD provider for RSA via ENGINE_set_default().
+     * That is normal, expected ENGINE usage and not specific to this
+     * caller, but it leaves ctx->keymgmt NULL here, and
+     * EVP_PKEY_fromdata_init() (unlike OpenSSL releases before the
+     * "foreign key" fix was reverted in PR #23063) no longer falls back
+     * to a legacy pmeth-based path in that case, so it errors out even
+     * though nothing is actually wrong with these e/n values.
+     *
+     * Since this has nothing to do with providers/keymgmt at all, build
+     * the EVP_PKEY directly via the classic RSA_set0_key() +
+     * EVP_PKEY_assign_RSA() APIs instead (the same technique used by the
+     * pre-OpenSSL-3.0 code path below, and by libp11 itself for wrapping
+     * its own "foreign" keys), which sidesteps ENGINE/provider defaults
+     * entirely.
+     */
+    {
+        RSA *rsa = RSA_new();
+        if (!rsa) {
+            SSL_UTIL_LOGE("RSA_new");
+            goto out;
+        }
+        if (!RSA_set0_key(rsa, n, e, NULL)) {
+            SSL_UTIL_LOGE("RSA_set0_key");
+            RSA_free(rsa);
+            goto out;
+        }
+        /* ownership of n/e transferred to rsa; avoid double-free below */
+        n = e = NULL;
 
-    rc = EVP_PKEY_fromdata(evp_ctx, out_pkey, EVP_PKEY_PUBLIC_KEY, params);
-    if (rc != 1) {
-        SSL_UTIL_LOGE("EVP_PKEY_fromdata");
-        EVP_PKEY_CTX_free(evp_ctx);
-        goto out;
+        EVP_PKEY *pkey = EVP_PKEY_new();
+        if (!pkey) {
+            SSL_UTIL_LOGE("EVP_PKEY_new");
+            RSA_free(rsa);
+            goto out;
+        }
+        if (EVP_PKEY_assign_RSA(pkey, rsa) != 1) {
+            RSA_free(rsa);
+            EVP_PKEY_free(pkey);
+            goto out;
+        }
+        *out_pkey = pkey;
+        rv = CKR_OK;
     }
-
-    rv = CKR_OK;
 
 out:
 	EVP_PKEY_CTX_free(evp_ctx);


### PR DESCRIPTION
**Disclaimer**: I'm not an expert on this code so I generated this PR with help of AI including the text below. I have nevertheless tested the patch myself and it fixed the issue for me. I'll post the reproducer code later in the PR.

### Problem ###
On OpenSSL 3.0.14+ `ssl_util_attrs_to_evp() → get_RSA_evp_pubkey()`  fails during `C_SignInit / C_VerifyInit` on RSA objects whenever an OpenSSL ENGINE (e.g. libp11's engine_pkcs11, loaded via  `-engine pkcs11`) is registered as the process-wide default handler for RSA `EVP_PKEY_METHOD`. The observed error is:

```
EVP_PKEY_fromdata_init: error:03000096:digital envelope routines::operation not supported for this keytype
```

which propagates up through `EVP_DigestSignFinal() / EVP_DigestVerifyFinal()` and ultimately surfaces to callers as a fatal  `Host memory error / CKR_GENERAL_ERROR` from tpm2-pkcs11, breaking TLS client authentication (e.g. wpa_supplicant EAP-TLS/PEAP with a TPM2-backed smartcard, using `engine_pkcs11` in front of `libtpm2_pkcs11.so`). 

This regressed between OpenSSL 3.0.13 (working) and 3.0.14/3.5.5 (broken).

### Root cause ###
`get_RSA_evp_pubkey()` builds a plain, in-memory RSA public key from raw `CKA_MODULUS / CKA_PUBLIC_EXPONENT`  attributes via the provider-based API:

```
evp_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
EVP_PKEY_fromdata_init(evp_ctx);                               
EVP_PKEY_fromdata(evp_ctx, out_pkey, EVP_PKEY_PUBLIC_KEY, params);
```

`EVP_PKEY_fromdata_init()` requires `ctx->keymgmt` to be set, which OpenSSL populates via `EVP_KEYMGMT_fetch()`. However, OpenSSL's `int_ctx_new()` (`crypto/evp/pmeth_lib.c`) looks up a process-wide default ENGINE for the requested algorithm/NID before attempting the provider fetch. If any loaded component has registered itself as that default (which is normal, expected  ENGINE  usage — e.g.  `libp11's engine_pkcs11` does this via `ENGINE_set_default() / ENGINE_set_default_string()` when loaded with `-engine pkcs11`), the lookup is routed through the ENGINE's legacy `EVP_PKEY_METHOD` instead, and  `ctx->keymgmt` is left NULL . 

Critically, this affects all callers process-wide, including callers with no relation to that ENGINE — such as tpm2-pkcs11's own internal `get_RSA_evp_pubkey()` helper, which has nothing to do with libp11 or any specific ENGINE and simply wants a plain RSA key object.

Before OpenSSL 3.0.14, `EVP_PKEY_fromdata_init()` had a fallback path for exactly this "foreign"/engine-associated-key case (added by commit `2b74e75331a27fc89cad9c8ea6a26c70019300b5`, "Improved detection of engine-provided private classic keys"). That fallback was reverted in commit  `39ea78379826fa98e8dc8c0d2b07e2c17cd68380`  (PR  `openssl/openssl#23063`, merged 2024-01-31, backported to the 3.0/3.1/3.2 branches and present in 3.3+), per upstream's own reasoning:

>The commit was wrong. With 3.x versions the engines must be themselves responsible for creating their EVP_PKEYs in a way that they are treated as legacy ... The workaround has caused more problems than it solved.

So this is a genuine, intentional OpenSSL behavior change, not a bug in tpm2-pkcs11's inputs — but it means `EVP_PKEY_fromdata_init()` can no longer be relied upon to succeed whenever any ENGINE happens to be process-default for RSA, regardless of whether that ENGINE has anything to do with the key being constructed.
  
### Fix ###
`get_RSA_evp_pubkey()`  now falls back to the classic, ENGINE/provider-agnostic construction path — `RSA_new()  +  RSA_set0_key()  +  EVP_PKEY_new()  +  EVP_PKEY_assign_RSA()`  — whenever the provider-based
`EVP_PKEY_CTX_new_from_name() / EVP_PKEY_fromdata_init() / EVP_PKEY_fromdata()`  sequence fails. This is the same technique tpm2-pkcs11 already uses in its own pre-OpenSSL-3.0 code path (the  `#else`  branch  of this same function), and the same technique libp11 uses to wrap its own "foreign" keys — it doesn't touch  `ctx->keymgmt`  or any provider/ENGINE default at all, so it's unaffected by whatever else is    registered process-wide. The modern path is still attempted first and used whenever it succeeds; the fallback only kicks in on failure, so behavior is unchanged for callers/environments not hitting this condition.                                                                

### Testing ###                                                 
Verified with a synthetic reproducer: `swtpm + tpm2-abrmd + tpm2-pkcs11 + libp11's  engine_pkcs11` , performing a real TLS 1.2 mutual-auth handshake (client  `CertificateVerify`  signed via the TPM-backed key) with OpenSSL 3.5.5 and  -engine pkcs11  (mirroring wpa_supplicant's smartcard/EAP-TLS configuration):                                                                                                    
- Before the patch: handshake fails deterministically with  `EVP_PKEY_fromdata_init: ... operation not supported for this keytype`  during  C_SignInit .
- After the patch (rebuilt as a package and installed): handshake completes successfully ( Verify return code: 0 (ok) ), with the old error line only appearing as a benign, recovered-from diagnostic before the fallback succeeds.